### PR TITLE
feat(cli): implement account subcommands

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,7 @@
+# Loaded by direnv when entering this directory. Run `direnv allow` once
+# after cloning. Requires `brew install direnv` and `eval "$(direnv hook zsh)"`
+# in ~/.zshrc.
+
+# Prepend Homebrew GNU Make (4.x) so `make` is GNU Make, not Apple's 3.81.
+# Required for this project's Makefile (.ONESHELL, modern PATH semantics).
+PATH_add /opt/homebrew/opt/make/libexec/gnubin

--- a/.envrc
+++ b/.envrc
@@ -2,6 +2,13 @@
 # after cloning. Requires `brew install direnv` and `eval "$(direnv hook zsh)"`
 # in ~/.zshrc.
 
-# Prepend Homebrew GNU Make (4.x) so `make` is GNU Make, not Apple's 3.81.
-# Required for this project's Makefile (.ONESHELL, modern PATH semantics).
+# GNU Make 4.x (not Apple's 3.81) — required for .ONESHELL, modern PATH semantics.
 PATH_add /opt/homebrew/opt/make/libexec/gnubin
+
+# PostgreSQL 18 client tools (psql, dropdb, createdb) — used by `make clean`
+# and for ad-hoc queries against the mailpilot database.
+PATH_add /opt/homebrew/opt/postgresql@18/bin
+
+# Project venv — exposes `mailpilot`, `pytest`, `ruff`, `basedpyright` without
+# the `uv run` prefix. Harmless when .venv doesn't exist yet.
+PATH_add .venv/bin

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,17 @@ uv run ruff check --fix # lint (without make)
 uv run basedpyright     # type check (without make)
 ```
 
+## GitHub
+
+Use the `/github-*` skills for all GitHub operations -- never drive `gh` or `git push`-to-PR flows by hand. The skills encode project conventions (Conventional Commits, PR-to-issue linking via `Resolves #N`, squash-merge defaults, release-note-ready merge messages).
+
+- `/github-issue-create` -- file an issue
+- `/github-pr-create` -- open a PR from an issue number or objective
+- `/github-pr-merge` -- merge a PR with a release-note-ready commit message
+- `/github-commit-staged` -- commit staged changes with a descriptive message
+
+If a GitHub operation isn't covered by a skill (e.g. reviewing comments, closing an issue manually), fall back to `gh`.
+
 ## TDD Process
 
 1. Write failing test first

--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@
 SHELL := /bin/bash
 .SHELLFLAGS := -euo pipefail -c
 MAKEFLAGS += --no-builtin-rules --no-builtin-variables
-PATH := $(abspath .venv)/bin:$(PATH)
+export PATH := $(abspath .venv)/bin:/opt/homebrew/opt/postgresql@18/bin:$(PATH)
 DATA_DIR := $(HOME)/.mailpilot
 
 default: .venv help
@@ -29,13 +29,14 @@ py-lint:
 	$(call header,Running Ruff lint)
 	uv run ruff check --fix
 
-clean: ## Export data, reset DB schema
+clean: ## Export data, re-create database
 	$(eval TS := $(shell date +%Y%m%d-%H%M%S))
 	$(call header,Exporting companies and contacts)
-	mailpilot company export $(DATA_DIR)/companies-$(TS).json
-	mailpilot contact export $(DATA_DIR)/contacts-$(TS).json
-	$(call header,Resetting database schema)
-	psql postgresql://localhost/mailpilot -c "DROP TABLE IF EXISTS task, email, workflow_contact, workflow, contact, company, account CASCADE"
+	mailpilot company export $(DATA_DIR)/companies-$(TS).json || true
+	mailpilot contact export $(DATA_DIR)/contacts-$(TS).json || true
+	$(call header,Re-creating database)
+	dropdb --if-exists mailpilot
+	createdb mailpilot
 	mailpilot status > /dev/null
 
 py-update:

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -62,20 +62,42 @@ def output_error(message: str, code: str) -> NoReturn:
 # -- Main CLI ------------------------------------------------------------------
 
 
+def _print_completion(
+    ctx: click.Context, param: click.Parameter, value: str | None
+) -> None:
+    """Eager callback: emit the shell completion script and exit.
+
+    Runs before Click validates that a subcommand was given, so
+    ``mailpilot --completion zsh`` works without supplying a subcommand.
+    """
+    if not value or ctx.resilient_parsing:
+        return
+    from click.shell_completion import get_completion_class
+
+    comp_cls = get_completion_class(value)
+    if comp_cls is None:
+        click.echo(f"unsupported shell: {value}", err=True)
+        ctx.exit(1)
+    click.echo(comp_cls(ctx.command, {}, "mailpilot", "_MAILPILOT_COMPLETE").source())
+    ctx.exit(0)
+
+
 @click.group()
 @click.version_option()
 @click.option("--debug", is_flag=True, help="Enable debug logging.")
-@click.option("--completion", type=str, default=None, hidden=True)
+@click.option(
+    "--completion",
+    type=click.Choice(["bash", "zsh", "fish"]),
+    default=None,
+    hidden=True,
+    is_eager=True,
+    expose_value=False,
+    callback=_print_completion,
+    help="Print shell completion script and exit.",
+)
 @click.pass_context
-def main(ctx: click.Context, debug: bool, completion: str | None) -> None:
+def main(ctx: click.Context, debug: bool) -> None:
     """MailPilot -- CRM for cold email outreach via Gmail."""
-    if completion:
-        from click.shell_completion import get_completion_class
-
-        comp_cls = get_completion_class(completion)
-        if comp_cls:
-            click.echo(comp_cls(main, {}, "mailpilot", "_MAILPILOT_COMPLETE").source())
-        raise SystemExit(0)
     ctx.ensure_object(dict)
     ctx.obj["debug"] = debug
 

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -89,7 +89,6 @@ def _print_completion(
     "--completion",
     type=click.Choice(["bash", "zsh", "fish"]),
     default=None,
-    hidden=True,
     is_eager=True,
     expose_value=False,
     callback=_print_completion,

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -195,6 +195,70 @@ def account() -> None:
     """Manage Gmail accounts."""
 
 
+@account.command("create")
+@click.option("--email", required=True, help="Gmail address.")
+@click.option("--display-name", default="", help="Display name.")
+def account_create(email: str, display_name: str) -> None:
+    """Create a new Gmail account."""
+    from mailpilot.database import create_account, initialize_database
+
+    connection = initialize_database(_database_url())
+    try:
+        created = create_account(connection, email=email, display_name=display_name)
+        output(created.model_dump(mode="json"))
+    finally:
+        connection.close()
+
+
+@account.command("list")
+def account_list() -> None:
+    """List all Gmail accounts."""
+    from mailpilot.database import initialize_database, list_accounts
+
+    connection = initialize_database(_database_url())
+    try:
+        accounts = list_accounts(connection)
+        output({"accounts": [a.model_dump(mode="json") for a in accounts]})
+    finally:
+        connection.close()
+
+
+@account.command("view")
+@click.argument("account_id")
+def account_view(account_id: str) -> None:
+    """Show a Gmail account by ID."""
+    from mailpilot.database import get_account, initialize_database
+
+    connection = initialize_database(_database_url())
+    try:
+        found = get_account(connection, account_id)
+        if found is None:
+            output_error(f"account not found: {account_id}", "not_found")
+        output(found.model_dump(mode="json"))
+    finally:
+        connection.close()
+
+
+@account.command("update")
+@click.argument("account_id")
+@click.option("--display-name", default=None, help="Display name.")
+def account_update(account_id: str, display_name: str | None) -> None:
+    """Update a Gmail account."""
+    from mailpilot.database import initialize_database, update_account
+
+    connection = initialize_database(_database_url())
+    try:
+        fields: dict[str, object] = {}
+        if display_name is not None:
+            fields["display_name"] = display_name
+        updated = update_account(connection, account_id, **fields)
+        if updated is None:
+            output_error(f"account not found: {account_id}", "not_found")
+        output(updated.model_dump(mode="json"))
+    finally:
+        connection.close()
+
+
 # -- Company commands ----------------------------------------------------------
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,27 @@ def mock_connection() -> MagicMock:
     return MagicMock()
 
 
+# -- --completion --------------------------------------------------------------
+
+
+def test_completion_zsh(runner: CliRunner) -> None:
+    result = runner.invoke(main, ["--completion", "zsh"])
+    assert result.exit_code == 0
+    assert "#compdef mailpilot" in result.output
+    assert "_MAILPILOT_COMPLETE=zsh_complete" in result.output
+
+
+def test_completion_bash(runner: CliRunner) -> None:
+    result = runner.invoke(main, ["--completion", "bash"])
+    assert result.exit_code == 0
+    assert "_MAILPILOT_COMPLETE=bash_complete" in result.output
+
+
+def test_completion_unsupported_shell(runner: CliRunner) -> None:
+    result = runner.invoke(main, ["--completion", "tcsh"])
+    assert result.exit_code != 0
+
+
 # -- account create ------------------------------------------------------------
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,219 @@
+"""CLI tests for account subcommands."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from conftest import make_test_settings
+from mailpilot.cli import main
+from mailpilot.models import Account
+
+_NOW = datetime(2024, 1, 1, tzinfo=UTC)
+
+
+def _make_account(**overrides: Any) -> Account:
+    defaults: dict[str, Any] = {
+        "id": "01234567-0000-7000-0000-000000000001",
+        "email": "test@example.com",
+        "display_name": "Test Account",
+        "created_at": _NOW,
+        "updated_at": _NOW,
+    }
+    return Account(**{**defaults, **overrides})
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_connection() -> MagicMock:
+    return MagicMock()
+
+
+# -- account create ------------------------------------------------------------
+
+
+def test_account_create(runner: CliRunner, mock_connection: MagicMock) -> None:
+    account = _make_account()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.create_account", return_value=account) as mock_create,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "account",
+                "create",
+                "--email",
+                "test@example.com",
+                "--display-name",
+                "Test Account",
+            ],
+        )
+
+    assert result.exit_code == 0
+    mock_create.assert_called_once_with(
+        mock_connection, email="test@example.com", display_name="Test Account"
+    )
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["email"] == "test@example.com"
+    assert data["display_name"] == "Test Account"
+
+
+def test_account_create_email_only(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    account = _make_account(display_name="")
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.create_account", return_value=account) as mock_create,
+    ):
+        result = runner.invoke(
+            main, ["account", "create", "--email", "test@example.com"]
+        )
+
+    assert result.exit_code == 0
+    mock_create.assert_called_once_with(
+        mock_connection, email="test@example.com", display_name=""
+    )
+
+
+# -- account list --------------------------------------------------------------
+
+
+def test_account_list(runner: CliRunner, mock_connection: MagicMock) -> None:
+    accounts = [
+        _make_account(id="id-1", email="a@example.com"),
+        _make_account(id="id-2", email="b@example.com"),
+    ]
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_accounts", return_value=accounts),
+    ):
+        result = runner.invoke(main, ["account", "list"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert len(data["accounts"]) == 2
+    assert data["accounts"][0]["email"] == "a@example.com"
+    assert data["accounts"][1]["email"] == "b@example.com"
+
+
+def test_account_list_empty(runner: CliRunner, mock_connection: MagicMock) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_accounts", return_value=[]),
+    ):
+        result = runner.invoke(main, ["account", "list"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["accounts"] == []
+
+
+# -- account view --------------------------------------------------------------
+
+
+def test_account_view(runner: CliRunner, mock_connection: MagicMock) -> None:
+    account = _make_account()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_account", return_value=account) as mock_get,
+    ):
+        result = runner.invoke(main, ["account", "view", account.id])
+
+    assert result.exit_code == 0
+    mock_get.assert_called_once_with(mock_connection, account.id)
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["id"] == account.id
+
+
+def test_account_view_not_found(runner: CliRunner, mock_connection: MagicMock) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_account", return_value=None),
+    ):
+        result = runner.invoke(main, ["account", "view", "nonexistent-id"])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["ok"] is False
+    assert data["error"] == "not_found"
+
+
+# -- account update ------------------------------------------------------------
+
+
+def test_account_update_display_name(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    updated = _make_account(display_name="New Name")
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.update_account", return_value=updated) as mock_update,
+    ):
+        result = runner.invoke(
+            main, ["account", "update", updated.id, "--display-name", "New Name"]
+        )
+
+    assert result.exit_code == 0
+    mock_update.assert_called_once_with(
+        mock_connection, updated.id, display_name="New Name"
+    )
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["display_name"] == "New Name"
+
+
+def test_account_update_no_fields(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    account = _make_account()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.update_account", return_value=account) as mock_update,
+    ):
+        result = runner.invoke(main, ["account", "update", account.id])
+
+    assert result.exit_code == 0
+    mock_update.assert_called_once_with(mock_connection, account.id)
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["id"] == account.id
+
+
+def test_account_update_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.update_account", return_value=None),
+    ):
+        result = runner.invoke(
+            main, ["account", "update", "nonexistent-id", "--display-name", "X"]
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["ok"] is False
+    assert data["error"] == "not_found"


### PR DESCRIPTION
## Summary

Implements the `account` CLI subcommands (`create`, `list`, `view`, `update`) per issue #3, plus several dev-environment improvements discovered during verification: a robust `make clean` target, direnv-based per-repo PATH scoping, and a fix to the broken `--completion` option.

## Changes

**feat(cli): account subcommands**
- `mailpilot account create --email E [--display-name N]` -- creates account, outputs JSON
- `mailpilot account list` -- lists all accounts as JSON array
- `mailpilot account view ID` -- outputs account JSON, exits 1 if not found
- `mailpilot account update ID [--display-name N]` -- updates account, exits 1 if not found
- 12 tests in new `tests/test_cli.py` (CliRunner + mocks at source module)

**chore(makefile): re-create database in make clean**
- Replaces hard-coded `DROP TABLE` list (missed `sync_status`) with `dropdb` + `createdb`
- Adds `/opt/homebrew/opt/postgresql@18/bin` to Makefile PATH; uses `export PATH :=` for GNU Make compatibility

**chore: direnv .envrc for per-repo PATH scoping**
- `.envrc` prepends GNU Make 4.x, PostgreSQL 18 bin, and `.venv/bin` to PATH when inside the repo
- Requires `brew install direnv` + `eval "$(direnv hook zsh)"` in `~/.zshrc` once per machine

**fix(cli): --completion actually emits the completion script**
- Was broken: `@click.group()` rejected invocations without a subcommand before the group callback ran
- Switched to `is_eager=True` + `expose_value=False` callback (same pattern as `--version`)
- Restricted to `Choice(["bash", "zsh", "fish"])` for early validation
- Removed `hidden=True` so the option appears in `--help`

**docs(CLAUDE.md): instruct Claude to use /github-* skills**
- Adds a "GitHub" section mandating `/github-issue-create`, `/github-pr-create`, `/github-pr-merge`, `/github-commit-staged` for all GitHub operations

Resolves #3