### PR TITLE
feat(cli): implement contact subcommands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ API keys and config stored in `~/.mailpilot/config.json` via `mailpilot config s
 - `google_pubsub_subscription` -- Pub/Sub subscription name (default: `mailpilot-watch`)
 - `database_url` -- PostgreSQL connection (default: `postgresql://localhost/mailpilot`)
 - `logfire_token` -- Pydantic Logfire token (optional)
-- `logfire_environment` -- deployment environment tag (default: `development`)
+- `logfire_environment` -- deployment environment tag. Literal: `development` | `production` (default: `development`). Tags every span sent to Logfire so traces from dev runs can be filtered out when investigating production behaviour.
 
 ## LLM-First Code Style
 
@@ -174,6 +174,15 @@ Logging and tracing use [Pydantic Logfire](https://pydantic.dev/logfire) (OpenTe
 - `configure_logging()` in `cli.py` enables console output only with `--debug` flag
 - Token: `mailpilot config set logfire_token <TOKEN>` or `LOGFIRE_TOKEN` env var
 - Cloud send: `send_to_logfire='if-token-present'` -- console-only when no token
+
+**Cloud project.** All records land in Logfire project **`pilot`** (scope of the shared write token). That project holds records for two services distinguished by `service_name`: `mailpilot` (this repo) and `leadpilot` (sibling project). Within each service, spans are further split by `deployment_environment` (`development` | `production`), set from the `logfire_environment` setting. When querying via MCP, always pass `project='pilot'` and filter with `WHERE service_name = 'mailpilot' AND deployment_environment = 'production'` (or `'development'`).
+
+**Skills for Logfire work.** Prefer these skills over ad-hoc commands:
+
+- `/logfire:instrument` -- add Logfire instrumentation to a language/framework in this repo
+- `/logfire:instrumentation` -- same, general-purpose variant (multi-language)
+- `/logfire:dev-session` -- start a local dev session with write tokens for sending traces while debugging
+- `/logfire:debug` -- investigate errors and debug production issues using existing traces
 
 ## Standards
 

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -414,6 +414,168 @@ def contact() -> None:
     """Manage contacts."""
 
 
+@contact.command("create")
+@click.option("--email", required=True, help="Email address.")
+@click.option("--first-name", default=None, help="First name.")
+@click.option("--last-name", default=None, help="Last name.")
+@click.option("--company-id", default=None, help="Company ID.")
+def contact_create(
+    email: str,
+    first_name: str | None,
+    last_name: str | None,
+    company_id: str | None,
+) -> None:
+    """Create a new contact."""
+    from mailpilot.database import create_contact, initialize_database
+
+    domain = email.rsplit("@", maxsplit=1)[-1]
+    connection = initialize_database(_database_url())
+    try:
+        created = create_contact(
+            connection,
+            email=email,
+            domain=domain,
+            first_name=first_name,
+            last_name=last_name,
+            company_id=company_id,
+        )
+        output(created.model_dump(mode="json"))
+    finally:
+        connection.close()
+
+
+@contact.command("update")
+@click.argument("contact_id")
+@click.option("--email", default=None, help="Email address.")
+@click.option("--first-name", default=None, help="First name.")
+@click.option("--last-name", default=None, help="Last name.")
+@click.option("--company-id", default=None, help="Company ID.")
+def contact_update(
+    contact_id: str,
+    email: str | None,
+    first_name: str | None,
+    last_name: str | None,
+    company_id: str | None,
+) -> None:
+    """Update a contact."""
+    from mailpilot.database import initialize_database, update_contact
+
+    connection = initialize_database(_database_url())
+    try:
+        fields: dict[str, object] = {}
+        if email is not None:
+            fields["email"] = email
+            fields["domain"] = email.split("@")[-1]
+        if first_name is not None:
+            fields["first_name"] = first_name
+        if last_name is not None:
+            fields["last_name"] = last_name
+        if company_id is not None:
+            fields["company_id"] = company_id
+        updated = update_contact(connection, contact_id, **fields)
+        if updated is None:
+            output_error(f"contact not found: {contact_id}", "not_found")
+        output(updated.model_dump(mode="json"))
+    finally:
+        connection.close()
+
+
+@contact.command("search")
+@click.argument("query")
+@click.option("--limit", default=100, help="Maximum results.")
+def contact_search(query: str, limit: int) -> None:
+    """Search contacts by email, name, or domain."""
+    from mailpilot.database import initialize_database, search_contacts
+
+    connection = initialize_database(_database_url())
+    try:
+        contacts = search_contacts(connection, query, limit=limit)
+        output({"contacts": [c.model_dump(mode="json") for c in contacts]})
+    finally:
+        connection.close()
+
+
+@contact.command("list")
+@click.option("--limit", default=100, help="Maximum results.")
+@click.option("--domain", default=None, help="Filter by domain.")
+@click.option("--company-id", default=None, help="Filter by company ID.")
+def contact_list(limit: int, domain: str | None, company_id: str | None) -> None:
+    """List contacts."""
+    from mailpilot.database import initialize_database, list_contacts
+
+    connection = initialize_database(_database_url())
+    try:
+        contacts = list_contacts(
+            connection, limit=limit, domain=domain, company_id=company_id
+        )
+        output({"contacts": [c.model_dump(mode="json") for c in contacts]})
+    finally:
+        connection.close()
+
+
+@contact.command("view")
+@click.argument("contact_id")
+def contact_view(contact_id: str) -> None:
+    """Show a contact by ID."""
+    from mailpilot.database import get_contact, initialize_database
+
+    connection = initialize_database(_database_url())
+    try:
+        found = get_contact(connection, contact_id)
+        if found is None:
+            output_error(f"contact not found: {contact_id}", "not_found")
+        output(found.model_dump(mode="json"))
+    finally:
+        connection.close()
+
+
+@contact.command("export")
+@click.argument("file", type=click.Path())
+def contact_export(file: str) -> None:
+    """Export all contacts to a JSON file."""
+    import pathlib
+
+    from mailpilot.database import initialize_database, list_contacts
+
+    connection = initialize_database(_database_url())
+    try:
+        contacts = list_contacts(connection)
+        data = [c.model_dump(mode="json") for c in contacts]
+        pathlib.Path(file).write_text(json.dumps(data, indent=2))
+        output({"exported": len(data), "file": file})
+    finally:
+        connection.close()
+
+
+@contact.command("import")
+@click.argument("file", type=click.Path(exists=True))
+def contact_import(file: str) -> None:
+    """Import contacts from a JSON file."""
+    import pathlib
+
+    from mailpilot.database import create_contact, initialize_database
+
+    connection = initialize_database(_database_url())
+    try:
+        entries = json.loads(pathlib.Path(file).read_text())
+        count = 0
+        for entry in entries:
+            email = entry["email"]
+            domain = entry.get("domain") or email.split("@")[-1]
+            create_contact(
+                connection,
+                email=email,
+                domain=domain,
+                first_name=entry.get("first_name"),
+                last_name=entry.get("last_name"),
+                company_id=entry.get("company_id"),
+            )
+            count += 1
+        output({"imported": count, "file": file})
+    finally:
+        connection.close()
+
+
 # -- Email commands ------------------------------------------------------------
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ from click.testing import CliRunner
 
 from conftest import make_test_settings
 from mailpilot.cli import main
-from mailpilot.models import Account, Company
+from mailpilot.models import Account, Company, Contact
 
 _NOW = datetime(2024, 1, 1, tzinfo=UTC)
 
@@ -515,6 +515,343 @@ def test_company_import(
     assert mock_create.call_count == 2
     mock_create.assert_any_call(mock_connection, name="Acme Corp", domain="acme.com")
     mock_create.assert_any_call(mock_connection, name="Beta Inc", domain="beta.com")
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["imported"] == 2
+
+
+# -- contact helpers -----------------------------------------------------------
+
+
+def _make_contact(**overrides: Any) -> Contact:
+    defaults: dict[str, Any] = {
+        "id": "01234567-0000-7000-0000-000000000003",
+        "email": "alice@example.com",
+        "domain": "example.com",
+        "created_at": _NOW,
+        "updated_at": _NOW,
+    }
+    return Contact(**{**defaults, **overrides})
+
+
+# -- contact create ------------------------------------------------------------
+
+
+def test_contact_create(runner: CliRunner, mock_connection: MagicMock) -> None:
+    contact = _make_contact(first_name="Alice", last_name="Smith")
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.create_contact", return_value=contact) as mock_create,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "contact",
+                "create",
+                "--email",
+                "alice@example.com",
+                "--first-name",
+                "Alice",
+                "--last-name",
+                "Smith",
+            ],
+        )
+
+    assert result.exit_code == 0
+    mock_create.assert_called_once_with(
+        mock_connection,
+        email="alice@example.com",
+        domain="example.com",
+        first_name="Alice",
+        last_name="Smith",
+        company_id=None,
+    )
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["email"] == "alice@example.com"
+    assert data["first_name"] == "Alice"
+
+
+def test_contact_create_email_only(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    contact = _make_contact()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.create_contact", return_value=contact) as mock_create,
+    ):
+        result = runner.invoke(
+            main, ["contact", "create", "--email", "alice@example.com"]
+        )
+
+    assert result.exit_code == 0
+    mock_create.assert_called_once_with(
+        mock_connection,
+        email="alice@example.com",
+        domain="example.com",
+        first_name=None,
+        last_name=None,
+        company_id=None,
+    )
+
+
+# -- contact update ------------------------------------------------------------
+
+
+def test_contact_update_first_name(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    updated = _make_contact(first_name="Alicia")
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.update_contact", return_value=updated) as mock_update,
+    ):
+        result = runner.invoke(
+            main, ["contact", "update", updated.id, "--first-name", "Alicia"]
+        )
+
+    assert result.exit_code == 0
+    mock_update.assert_called_once_with(
+        mock_connection, updated.id, first_name="Alicia"
+    )
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["first_name"] == "Alicia"
+
+
+def test_contact_update_no_fields(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    contact = _make_contact()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.update_contact", return_value=contact) as mock_update,
+    ):
+        result = runner.invoke(main, ["contact", "update", contact.id])
+
+    assert result.exit_code == 0
+    mock_update.assert_called_once_with(mock_connection, contact.id)
+
+
+def test_contact_update_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.update_contact", return_value=None),
+    ):
+        result = runner.invoke(
+            main, ["contact", "update", "nonexistent-id", "--first-name", "X"]
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["ok"] is False
+    assert data["error"] == "not_found"
+
+
+# -- contact search ------------------------------------------------------------
+
+
+def test_contact_search(runner: CliRunner, mock_connection: MagicMock) -> None:
+    contacts = [_make_contact()]
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch(
+            "mailpilot.database.search_contacts", return_value=contacts
+        ) as mock_search,
+    ):
+        result = runner.invoke(main, ["contact", "search", "alice"])
+
+    assert result.exit_code == 0
+    mock_search.assert_called_once_with(mock_connection, "alice", limit=100)
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert len(data["contacts"]) == 1
+
+
+def test_contact_search_with_limit(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.search_contacts", return_value=[]) as mock_search,
+    ):
+        result = runner.invoke(main, ["contact", "search", "alice", "--limit", "10"])
+
+    assert result.exit_code == 0
+    mock_search.assert_called_once_with(mock_connection, "alice", limit=10)
+
+
+# -- contact list --------------------------------------------------------------
+
+
+def test_contact_list(runner: CliRunner, mock_connection: MagicMock) -> None:
+    contacts = [
+        _make_contact(id="id-1", email="a@example.com"),
+        _make_contact(id="id-2", email="b@example.com"),
+    ]
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_contacts", return_value=contacts),
+    ):
+        result = runner.invoke(main, ["contact", "list"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert len(data["contacts"]) == 2
+
+
+def test_contact_list_empty(runner: CliRunner, mock_connection: MagicMock) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_contacts", return_value=[]),
+    ):
+        result = runner.invoke(main, ["contact", "list"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["contacts"] == []
+
+
+def test_contact_list_with_filters(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_contacts", return_value=[]) as mock_list,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "contact",
+                "list",
+                "--limit",
+                "5",
+                "--domain",
+                "example.com",
+                "--company-id",
+                "cid-1",
+            ],
+        )
+
+    assert result.exit_code == 0
+    mock_list.assert_called_once_with(
+        mock_connection, limit=5, domain="example.com", company_id="cid-1"
+    )
+
+
+# -- contact view --------------------------------------------------------------
+
+
+def test_contact_view(runner: CliRunner, mock_connection: MagicMock) -> None:
+    contact = _make_contact()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=contact) as mock_get,
+    ):
+        result = runner.invoke(main, ["contact", "view", contact.id])
+
+    assert result.exit_code == 0
+    mock_get.assert_called_once_with(mock_connection, contact.id)
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["id"] == contact.id
+
+
+def test_contact_view_not_found(runner: CliRunner, mock_connection: MagicMock) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=None),
+    ):
+        result = runner.invoke(main, ["contact", "view", "nonexistent-id"])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["ok"] is False
+    assert data["error"] == "not_found"
+
+
+# -- contact export ------------------------------------------------------------
+
+
+def test_contact_export(
+    runner: CliRunner, mock_connection: MagicMock, tmp_path: Any
+) -> None:
+    contacts = [_make_contact(id="id-1"), _make_contact(id="id-2")]
+    export_file = str(tmp_path / "contacts.json")
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_contacts", return_value=contacts),
+    ):
+        result = runner.invoke(main, ["contact", "export", export_file])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["exported"] == 2
+    exported = json.loads(pathlib.Path(export_file).read_text())
+    assert len(exported) == 2
+    assert exported[0]["id"] == "id-1"
+
+
+# -- contact import ------------------------------------------------------------
+
+
+def test_contact_import(
+    runner: CliRunner, mock_connection: MagicMock, tmp_path: Any
+) -> None:
+    entries = [
+        {"email": "alice@acme.com", "first_name": "Alice", "last_name": "Smith"},
+        {"email": "bob@beta.com"},
+    ]
+    import_file = tmp_path / "contacts.json"
+    import_file.write_text(json.dumps(entries))
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch(
+            "mailpilot.database.create_contact",
+            side_effect=[
+                _make_contact(email=e["email"], domain=e["email"].split("@")[-1])
+                for e in entries
+            ],
+        ) as mock_create,
+    ):
+        result = runner.invoke(main, ["contact", "import", str(import_file)])
+
+    assert result.exit_code == 0
+    assert mock_create.call_count == 2
+    mock_create.assert_any_call(
+        mock_connection,
+        email="alice@acme.com",
+        domain="acme.com",
+        first_name="Alice",
+        last_name="Smith",
+        company_id=None,
+    )
+    mock_create.assert_any_call(
+        mock_connection,
+        email="bob@beta.com",
+        domain="beta.com",
+        first_name=None,
+        last_name=None,
+        company_id=None,
+    )
     data = json.loads(result.output)
     assert data["ok"] is True
     assert data["imported"] == 2


### PR DESCRIPTION
## Summary

Implement `contact` CLI subcommands: `create`, `update`, `search`, `list`, `view`, `export`, and `import`.

- Hooks into the existing `contact` group in `cli.py` (currently empty)
- Uses existing database layer functions (`create_contact`, `get_contact`, `list_contacts`, etc.)
- Follows lazy-import, settings-first, JSON-output conventions from CLAUDE.md

## Changes

- `src/mailpilot/cli.py` — add all contact subcommands to existing group
- `tests/test_cli.py` — CLI tests with mocked database functions

Resolves #5