### PR TITLE
docs(observability): add ADR-07 and Logfire instrumentation plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,7 @@ Logging and tracing use [Pydantic Logfire](https://pydantic.dev/logfire) (OpenTe
 - Token: `mailpilot config set logfire_token <TOKEN>` or `LOGFIRE_TOKEN` env var
 - Cloud send: `send_to_logfire='if-token-present'` -- console-only when no token
 
-**Cloud project.** All records land in Logfire project **`pilot`** (scope of the shared write token). That project holds records for two services distinguished by `service_name`: `mailpilot` (this repo) and `leadpilot` (sibling project). Within each service, spans are further split by `deployment_environment` (`development` | `production`), set from the `logfire_environment` setting. When querying via MCP, always pass `project='pilot'` and filter with `WHERE service_name = 'mailpilot' AND deployment_environment = 'production'` (or `'development'`).
+**Cloud project.** All records land in dedicated Logfire project **`mailpilot`** (scope of the project-scoped write token). The sibling `leadpilot` service uses its own project, so no `service_name` filter is needed when querying. Spans are split by `deployment_environment` (`development` | `production`), set from the `logfire_environment` setting. When querying via MCP, always pass `project='mailpilot'` and filter with `WHERE deployment_environment = 'production'` (or `'development'`).
 
 **Skills for Logfire work.** Prefer these skills over ad-hoc commands:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,7 @@ Tests use a separate database: `postgresql://localhost/mailpilot_test` (override
 
 ## Observability
 
-Logging and tracing use [Pydantic Logfire](https://pydantic.dev/logfire) (OpenTelemetry-based). All modules use `import logfire` directly -- no per-module logger variable.
+Logging and tracing use [Pydantic Logfire](https://pydantic.dev/logfire) (OpenTelemetry-based). All modules use `import logfire` directly -- no per-module logger variable. Conventions are defined in `docs/adr-07-observability-with-logfire.md`; module-level instrumentation TODOs live in `docs/logfire-instrumentation-plan.md`.
 
 - `logfire.debug("msg", key=value)` / `logfire.warn("msg", key=value)` for logging
 - `logfire.span("name")` context manager for sync/agent stage tracing

--- a/docs/adr-07-observability-with-logfire.md
+++ b/docs/adr-07-observability-with-logfire.md
@@ -1,0 +1,163 @@
+# ADR-07: Observability with Pydantic Logfire
+
+## Status
+
+Accepted
+
+## Context
+
+MailPilot runs headless: a long-lived sync loop, per-account Gmail pipelines, LLM agent invocations, and a CLI used both interactively and by LLM agents. When something goes wrong -- a stale history id, a delegation failure, an agent that never reached a tool, a campaign that did not progress -- the only record is whatever the code chose to emit.
+
+Requirements:
+
+- Structured logs and spans with queryable key-value attributes (not free-form strings)
+- A single hosted destination so traces from the author's laptop, a CI run, and a production VM end up in the same place
+- Separation between development noise and production signal
+- Cheap to query after the fact (e.g. "show me every failed workflow run for contact X last week")
+- No per-module boilerplate that contributors have to remember
+
+The tool chosen is [Pydantic Logfire](https://pydantic.dev/logfire) (OpenTelemetry-based, SQL-queryable). This ADR codifies the conventions for using it so follow-up instrumentation work has a single source of truth.
+
+## Decision
+
+### Tool
+
+Pydantic Logfire is the only observability backend. No parallel `logging` module usage, no `print` for diagnostics, no custom file log sinks. The `logfire` SDK is imported directly (`import logfire`) in every module that emits telemetry. **No per-module `logger = logging.getLogger(__name__)` variable.** This keeps logging call sites uniform (`logfire.info(...)`) and lets the SDK attach file/function/line metadata automatically.
+
+### Project and service identity
+
+| Attribute                | Value                                      | Source                                      |
+| ------------------------ | ------------------------------------------ | ------------------------------------------- |
+| Logfire project          | `pilot`                                    | Shared with sibling project `leadpilot`     |
+| `service_name`           | `mailpilot`                                | Set in [cli.py](../src/mailpilot/cli.py) `configure_logging()` |
+| `deployment_environment` | `development` \| `production`              | `logfire_environment` setting (default `development`) |
+| Token                    | `logfire_token` setting or `LOGFIRE_TOKEN` | Optional -- console-only when absent        |
+
+All MCP queries and dashboards MUST filter on `service_name = 'mailpilot'` because the `pilot` project also holds records for `leadpilot`.
+
+### Configuration ownership
+
+`logfire.configure()` is called exactly once, in [cli.py](../src/mailpilot/cli.py) `configure_logging()`. Other modules never configure Logfire; they only emit. The CLI entrypoint calls `configure_logging(debug=...)` before dispatching to any command. Tests do not configure Logfire -- the SDK no-ops without configuration.
+
+The `--debug` flag only changes the **console** minimum level (`debug` vs `warn`). It does not change what is sent to the cloud -- the cloud always receives every span and log when a token is present.
+
+### What to emit and where
+
+CLI stays thin: `cli.py` emits no spans and no logs beyond `configure_logging()`. All telemetry lives in the module that makes the decision or performs the I/O.
+
+| Concern                      | Owner module            | Primitive              |
+| ---------------------------- | ----------------------- | ---------------------- |
+| Sync loop lifecycle          | `sync.py`               | `logfire.info` + spans |
+| Database CRUD                | `database.py`           | `logfire.span`         |
+| Gmail API I/O                | `gmail.py`              | `logfire.span` + `logfire.warn` on retry |
+| Agent runs and tool calls    | `agent/*`               | `logfire.span` (Pydantic AI integration) |
+| Classification decisions     | `agent/classify.py`     | `logfire.info` with inputs + outputs |
+| Configuration changes        | `settings.py`           | `logfire.info` |
+| Error paths                  | module where caught     | `logfire.exception` |
+
+### Primitive selection
+
+| Use                                                                 | API                           |
+| ------------------------------------------------------------------- | ----------------------------- |
+| Verbose state, loop tick, cache hit, heartbeat                      | `logfire.debug(msg, **kv)`    |
+| Normal business events (sync started, email sent, workflow activated) | `logfire.info(msg, **kv)`   |
+| Recoverable anomaly (retryable API error, stale state, skipped row) | `logfire.warn(msg, **kv)`     |
+| Unrecoverable error, unexpected state                               | `logfire.exception(msg, **kv)` inside `except:` |
+| Bounded unit of work                                                | `with logfire.span("name", **kv):` |
+| Decorator for a whole function                                      | `@logfire.instrument("name")` |
+
+`logfire.error` is reserved for structured error emission without an active exception (rare). `logfire.exception` is preferred inside `except` blocks because it captures the traceback automatically.
+
+### Span naming
+
+- `lower.dot.separated` noun phrases describing the unit of work, not the code path.
+- Include the action and the subject: `account.sync`, `gmail.fetch_message`, `db.workflow.create`, `agent.classify_inbound`.
+- Do not include ids or parameters in the name -- put them in attributes.
+- Span names are stable strings (used as dashboard keys). Rename only with a deliberate schema change.
+
+### Attribute conventions
+
+Attributes are structured key-value pairs attached to spans and log events. They are what makes telemetry queryable.
+
+**Required on every business-meaningful span:**
+
+| Key            | When                            |
+| -------------- | ------------------------------- |
+| `account_id`   | Any per-account operation       |
+| `workflow_id`  | Any workflow-scoped operation   |
+| `contact_id`   | Any contact-scoped operation    |
+| `email_id`     | Any inbound/outbound email op   |
+| `result`       | Terminal spans -- `success` \| `failure` \| `skipped` |
+
+**Naming:**
+
+- `snake_case`
+- Ids are the UUIDv7 string, not a display name
+- Counts use the plural noun: `message_count`, `contact_count`
+- Durations go in attribute `duration_ms` (integer milliseconds) only if Logfire's built-in span duration is insufficient
+- External API status codes: `http_status`
+- Boolean outcomes: `hit`, `authorized`, `retryable` (prefix-free yes/no)
+
+**Forbidden as attributes:**
+
+- Secrets (`anthropic_api_key`, `logfire_token`, service account JSON)
+- Full email bodies (use `email_id` and query the DB if needed)
+- PII beyond what is already persisted (store pointers, not raw content)
+
+### Error handling
+
+Errors are logged at the point they stop flowing:
+
+```python
+try:
+    ...
+except ApiError as exc:
+    logfire.exception("gmail.fetch_message failed", email_id=email_id)
+    raise
+```
+
+- Use `logfire.exception` inside `except` blocks -- it captures the traceback.
+- Re-raise unless the caller cannot act on the error. Do not swallow.
+- Retry loops (see `gmail.py`) emit `logfire.warn` per attempt with `attempt` and `backoff` attributes, then `logfire.exception` when retries are exhausted.
+
+### Testing and development
+
+- Tests do not call `logfire.configure()`. The SDK no-ops when unconfigured.
+- `make check` must pass with no Logfire token.
+- Local development with live traces: use `/logfire:dev-session` to obtain write credentials. The session token lands in `~/.mailpilot/config.json` via `mailpilot config set logfire_token`.
+- Console output defaults to `warn`. Use `mailpilot --debug COMMAND` to see `debug` and `info` locally.
+
+### Investigation workflow
+
+When debugging production behavior, use the `/logfire:debug` skill, which drives the Logfire MCP. Standard filter prefix for every query:
+
+```sql
+WHERE service_name = 'mailpilot'
+  AND deployment_environment = 'production'
+```
+
+Queries span a maximum of 14 days (MCP limit). Include a `LIMIT` clause on every `query_run` call.
+
+## Consequences
+
+### Positive
+
+- One observability tool -- contributors learn one API (`logfire.*`) and one query language.
+- Uniform attribute keys (`account_id`, `workflow_id`, etc.) make cross-module queries trivial ("every span touching this workflow" is a single `WHERE` clause).
+- Strict separation between `cli.py` (dispatch only) and worker modules (emit telemetry) keeps concerns pinned to a single location.
+- `deployment_environment` tag lets us ignore dev runs without also losing them -- the user can filter them out in production investigations.
+- Hosted backend means no log-rotation, disk-pressure, or backup concerns.
+
+### Negative
+
+- A single shared project (`pilot`) is a soft multi-tenant boundary -- every query must remember the `service_name` filter or risk cross-contamination with `leadpilot`.
+- All structured attributes must be serializable; rich objects (e.g. Pydantic models) need explicit `.model_dump()` before being attached.
+- Logfire write token grants full send access -- it must not be checked into the repo (stored in `~/.mailpilot/config.json` or `LOGFIRE_TOKEN` env var).
+- OpenTelemetry span export is network-bound; outbound restrictions on a deployment host would require a side-channel.
+
+## References
+
+- [Pydantic Logfire](https://pydantic.dev/logfire)
+- [CLAUDE.md "Observability" section](../CLAUDE.md)
+- [docs/logfire-instrumentation-plan.md](logfire-instrumentation-plan.md) -- living plan derived from this ADR
+- `/logfire:instrument`, `/logfire:debug`, `/logfire:dev-session` skills

--- a/docs/adr-07-observability-with-logfire.md
+++ b/docs/adr-07-observability-with-logfire.md
@@ -28,12 +28,12 @@ Pydantic Logfire is the only observability backend. No parallel `logging` module
 
 | Attribute                | Value                                      | Source                                      |
 | ------------------------ | ------------------------------------------ | ------------------------------------------- |
-| Logfire project          | `pilot`                                    | Shared with sibling project `leadpilot`     |
+| Logfire project          | `mailpilot`                                | Dedicated project -- no cross-service traffic |
 | `service_name`           | `mailpilot`                                | Set in [cli.py](../src/mailpilot/cli.py) `configure_logging()` |
 | `deployment_environment` | `development` \| `production`              | `logfire_environment` setting (default `development`) |
-| Token                    | `logfire_token` setting or `LOGFIRE_TOKEN` | Optional -- console-only when absent        |
+| Token                    | `logfire_token` setting or `LOGFIRE_TOKEN` | Scoped to the `mailpilot` project; optional -- console-only when absent |
 
-All MCP queries and dashboards MUST filter on `service_name = 'mailpilot'` because the `pilot` project also holds records for `leadpilot`.
+The project is dedicated to this service, so MCP queries and dashboards do not need a `service_name` filter. They only need `deployment_environment` to separate dev and prod traffic. The sibling `leadpilot` service uses its own project; if cross-service correlation is ever needed, query each project separately and join on shared ids in application code.
 
 ### Configuration ownership
 
@@ -129,11 +129,10 @@ except ApiError as exc:
 
 ### Investigation workflow
 
-When debugging production behavior, use the `/logfire:debug` skill, which drives the Logfire MCP. Standard filter prefix for every query:
+When debugging production behavior, use the `/logfire:debug` skill, which drives the Logfire MCP. Pass `project='mailpilot'` on every call. Standard filter prefix for production queries:
 
 ```sql
-WHERE service_name = 'mailpilot'
-  AND deployment_environment = 'production'
+WHERE deployment_environment = 'production'
 ```
 
 Queries span a maximum of 14 days (MCP limit). Include a `LIMIT` clause on every `query_run` call.
@@ -150,7 +149,7 @@ Queries span a maximum of 14 days (MCP limit). Include a `LIMIT` clause on every
 
 ### Negative
 
-- A single shared project (`pilot`) is a soft multi-tenant boundary -- every query must remember the `service_name` filter or risk cross-contamination with `leadpilot`.
+- A dedicated `mailpilot` project is a second project to provision and a second write token to rotate alongside the sibling `leadpilot` project; cross-service correlation requires two queries instead of one.
 - All structured attributes must be serializable; rich objects (e.g. Pydantic models) need explicit `.model_dump()` before being attached.
 - Logfire write token grants full send access -- it must not be checked into the repo (stored in `~/.mailpilot/config.json` or `LOGFIRE_TOKEN` env var).
 - OpenTelemetry span export is network-bound; outbound restrictions on a deployment host would require a side-channel.

--- a/docs/logfire-instrumentation-plan.md
+++ b/docs/logfire-instrumentation-plan.md
@@ -1,0 +1,181 @@
+# Logfire Instrumentation Plan
+
+Living plan derived from [ADR-07](adr-07-observability-with-logfire.md). Tracks what is instrumented today, what is missing, and in what order the gaps should be closed. Update this doc -- not the ADR -- as the picture changes.
+
+## Current Coverage (2026-04-17)
+
+Result of grepping `logfire.` across `src/mailpilot/`:
+
+| Module                                                 | Current emissions                                    | Gap                                           |
+| ------------------------------------------------------ | ---------------------------------------------------- | --------------------------------------------- |
+| [cli.py](../src/mailpilot/cli.py)                      | `logfire.configure()` only                           | Correct by design -- CLI stays thin           |
+| [sync.py](../src/mailpilot/sync.py)                    | `info` on start/stop/shutdown; `debug` heartbeat; `warn` on stale sync status | Missing: per-account sync spans, Pub/Sub callback spans, watch-renewal spans (pipeline unimplemented) |
+| [gmail.py](../src/mailpilot/gmail.py)                  | `warn` on retryable HTTP error; `info` on send and label create; `info`/`warn` on watch ops | Missing: spans around every API call, `exception` on non-retryable failures |
+| [settings.py](../src/mailpilot/settings.py)            | No emissions                                         | Missing: `info` on `config set` when values change |
+| [database.py](../src/mailpilot/database.py)            | **No emissions**                                     | Missing: spans around every create/update/search/list/view |
+| [agent/classify.py](../src/mailpilot/agent/classify.py) | **No emissions**                                    | Classification decisions must be traced with inputs + outputs |
+| [agent/tools.py](../src/mailpilot/agent/tools.py)      | **No emissions**                                     | Every tool call is a span (Pydantic AI can auto-instrument) |
+| [exceptions.py](../src/mailpilot/exceptions.py)        | N/A -- definitions only                              | Callers must emit `exception` when raising these |
+
+## Logfire MCP Gap Analysis (2026-04-17)
+
+Query against project `pilot`, `service_name = 'mailpilot'`, last 14 days:
+
+```sql
+SELECT span_name, level, COUNT(*) AS count
+FROM records
+WHERE service_name = 'mailpilot'
+GROUP BY span_name, level
+ORDER BY count DESC
+LIMIT 100
+```
+
+Result:
+
+| span_name                  | level | count |
+| -------------------------- | ----- | ----- |
+| `sync heartbeat`           | debug | 3     |
+| `sync loop stopped`        | info  | 1     |
+| `shutdown signal received` | info  | 1     |
+| `sync loop started`        | info  | 1     |
+
+Environment breakdown: `development` = 6, `production` = 0.
+
+### Observations
+
+1. **Zero records from CLI commands.** `account`, `company`, `contact`, `config`, `status` all execute without emitting anything. Every one of these hits `database.py`, which is uninstrumented -- so instrumenting `database.py` will light up every CLI path at once.
+2. **Zero records from `production`.** No deployed service is sending traces. Either production does not exist yet or `logfire_token` is unset there.
+3. **Span names are sentence-case strings, not dot-separated.** Existing names (`"sync loop started"`) do not follow the ADR-07 convention (`sync.loop.start`). Rename during instrumentation work; the low current volume makes renames cheap.
+4. **No error records.** Either nothing has failed, or failures are escaping without being logged. Adding `logfire.exception` in error paths is the only way to tell.
+5. **Console-only development data.** The single `production` filter matters: the `pilot` project currently contains more `leadpilot` traffic than `mailpilot` traffic, so untagged queries would mislead.
+
+## Module-by-Module Proposed Instrumentation
+
+### `database.py` (Priority 1)
+
+Every CRUD function gets a span. Use `@logfire.instrument("db.<entity>.<op>")` as a decorator to keep boilerplate out of function bodies.
+
+| Function                              | Span name                  | Attributes                                       |
+| ------------------------------------- | -------------------------- | ------------------------------------------------ |
+| `create_account`                      | `db.account.create`        | `account_id` (from return), `email`              |
+| `get_account`                         | `db.account.get`           | `account_id`, `hit` (bool)                       |
+| `list_accounts`                       | `db.account.list`          | `account_count`                                  |
+| `update_account`                      | `db.account.update`        | `account_id`, `updated_fields` (list of keys)    |
+| `create_company` / `update` / `list` / `view` / `search` | `db.company.*`  | `company_id`, `domain` where applicable          |
+| `create_contact` / `update` / `list` / `view` / `search` | `db.contact.*`  | `contact_id`, `email`, `company_id` where applicable |
+| `create_workflow` / `update` / `activate` / `pause` | `db.workflow.*`   | `workflow_id`, `account_id`, `status`            |
+| `create_email` / `list` / `view` / `search` | `db.email.*`         | `email_id`, `account_id`, `direction`            |
+| `create_task` / `complete_task`       | `db.task.*`                | `task_id`, `workflow_id`                         |
+| Sync state (`get_sync_status`, `upsert_sync_status`, `update_sync_heartbeat`, `delete_sync_status`) | `db.sync_status.*` | `pid`        |
+| `initialize_database`                 | `db.schema.apply`          | `database_url_host`, `schema_applied` (bool)     |
+
+Level: spans for all; `logfire.exception` on the `psycopg.OperationalError` path in `initialize_database`.
+
+### `sync.py` (Priority 1 for existing code, Priority 3 for unimplemented pipeline)
+
+Already partially instrumented. Changes:
+
+- Rename existing log events to dot-separated: `sync.loop.start`, `sync.loop.stop`, `sync.loop.heartbeat`, `sync.shutdown.signal_received`.
+- Add `pid` + `existing_pid` attributes consistently (already present).
+- When Pub/Sub and per-account sync land (issues [#8](https://github.com/kborovik/mailpilot/issues/8), [#13](https://github.com/kborovik/mailpilot/issues/13)):
+  - `sync.pubsub.notification_received` (info) -- `email`, `history_id`
+  - `sync.account.run` (span) -- `account_id`, `result`, `message_count`
+  - `sync.account.history_fallback` (warn) -- `account_id`, `old_history_id`
+  - `sync.watch.renew` (span) -- `account_id`, `expiration_ms`
+
+### `gmail.py` (Priority 2)
+
+Every API call wraps in a span. The retry decorator already logs warnings; add a final `logfire.exception` when retries are exhausted.
+
+| Operation       | Span name                 | Attributes                                       |
+| --------------- | ------------------------- | ------------------------------------------------ |
+| Get profile     | `gmail.get_profile`       | `email`                                          |
+| List messages   | `gmail.list_messages`     | `email`, `query`, `message_count`                |
+| Fetch message   | `gmail.fetch_message`     | `email`, `message_id`                            |
+| Send message    | `gmail.send_message`      | `email`, `message_id` (from result), `thread_id`, `result` |
+| Modify message  | `gmail.modify_message`    | `email`, `message_id`, `add_labels`, `remove_labels` |
+| Get history     | `gmail.get_history`       | `email`, `start_history_id`, `change_count`      |
+| Watch / stop    | `gmail.watch` / `gmail.stop_watch` | `email`, `expiration_ms`                |
+| Create label    | `gmail.create_label`      | `email`, `label_name`, `label_id`                |
+| Retry tick      | existing `logfire.warn`   | add `operation` attribute (the wrapped func name) |
+
+`build_gmail_service` exits on missing credentials via `SystemExit` -- add `logfire.exception` before raising so the cause is captured.
+
+### `agent/classify.py` (Priority 2)
+
+Classification is the highest-stakes decision in inbound flow. Instrument so every routing decision is reconstructable from traces alone.
+
+| Event / span                  | Type    | Attributes                                                  |
+| ----------------------------- | ------- | ----------------------------------------------------------- |
+| `agent.classify.inbound`      | span    | `email_id`, `account_id`, `candidate_workflow_ids` (list), `chosen_workflow_id`, `confidence`, `result` |
+| `agent.classify.no_match`     | info    | `email_id`, `account_id`, `candidate_workflow_ids`          |
+| `agent.classify.error`        | exception | `email_id`, `account_id`                                   |
+
+Do not log prompt contents. Log only input/output identifiers and the model's decision.
+
+### `agent/tools.py` (Priority 2)
+
+Pydantic AI has an opt-in Logfire integration (`logfire.instrument_pydantic_ai()`). Enable it once in `configure_logging()`; every tool call then becomes a span automatically.
+
+Additional manual instrumentation only where auto-instrumentation is insufficient:
+
+- Tool invocations that mutate database state (e.g. `update_contact_status`): add explicit `logfire.info("agent.tool.<name>", workflow_id=..., contact_id=..., new_status=...)`.
+- Tool invocations that send external email: `logfire.info("agent.tool.send_email", workflow_id=..., email_id=..., to=...)`.
+
+### `settings.py` (Priority 3)
+
+- `logfire.info("config.set", key=..., changed=true)` on `config_set` when the new value differs from the old.
+- Never log values for `anthropic_api_key`, `logfire_token`, service account paths -- log only the key name.
+
+### `cli.py` (unchanged)
+
+Remains emission-free per ADR-07. Any command-level observability comes for free through the worker modules.
+
+## Smoke Test Plan
+
+After Priority 1 lands, run these commands against the default `mailpilot` database with a `development` token configured:
+
+```bash
+mailpilot account create --email test@example.com --display-name Test
+mailpilot account list
+mailpilot account view <ID>
+
+mailpilot company create --domain example.com --name Example
+mailpilot company search example
+mailpilot company list
+
+mailpilot contact create --email alice@example.com --first-name Alice
+mailpilot contact list --domain example.com
+mailpilot contact view <ID>
+```
+
+Verify in Logfire:
+
+```sql
+SELECT span_name, attributes, start_timestamp
+FROM records
+WHERE service_name = 'mailpilot'
+  AND deployment_environment = 'development'
+  AND span_name LIKE 'db.%'
+ORDER BY start_timestamp DESC
+LIMIT 50
+```
+
+Expected: one span per CRUD operation above, each with the documented attributes.
+
+## Prioritized Follow-Up Issues
+
+To be filed after this plan lands:
+
+| Priority | Scope                                           | Expected follow-up issue |
+| -------- | ----------------------------------------------- | ------------------------ |
+| P1       | `database.py` -- spans on every CRUD function  | `feat(observability): instrument database.py per ADR-07` |
+| P1       | `sync.py` -- rename existing spans to dot-notation | `chore(observability): align sync.py span names with ADR-07` |
+| P2       | `gmail.py` -- wrap every API call in a span     | `feat(observability): instrument gmail.py per ADR-07` |
+| P2       | `agent/classify.py` + `agent/tools.py` -- classification and tool-call spans | Blocked on issues [#10](https://github.com/kborovik/mailpilot/issues/10), [#11](https://github.com/kborovik/mailpilot/issues/11), [#12](https://github.com/kborovik/mailpilot/issues/12) |
+| P3       | `settings.py` -- `config.set` info event       | `feat(observability): emit config.set telemetry` |
+| P3       | Sync pipeline spans                              | Bundled into the sync-implementation issues [#8](https://github.com/kborovik/mailpilot/issues/8), [#13](https://github.com/kborovik/mailpilot/issues/13), [#14](https://github.com/kborovik/mailpilot/issues/14) |
+
+## Revision Log
+
+- 2026-04-17 -- Initial plan derived from ADR-07 and Logfire MCP audit ([#19](https://github.com/kborovik/mailpilot/issues/19)).

--- a/docs/logfire-instrumentation-plan.md
+++ b/docs/logfire-instrumentation-plan.md
@@ -6,31 +6,32 @@ Living plan derived from [ADR-07](adr-07-observability-with-logfire.md). Tracks 
 
 Result of grepping `logfire.` across `src/mailpilot/`:
 
-| Module                                                 | Current emissions                                    | Gap                                           |
-| ------------------------------------------------------ | ---------------------------------------------------- | --------------------------------------------- |
-| [cli.py](../src/mailpilot/cli.py)                      | `logfire.configure()` only                           | Correct by design -- CLI stays thin           |
-| [sync.py](../src/mailpilot/sync.py)                    | `info` on start/stop/shutdown; `debug` heartbeat; `warn` on stale sync status | Missing: per-account sync spans, Pub/Sub callback spans, watch-renewal spans (pipeline unimplemented) |
-| [gmail.py](../src/mailpilot/gmail.py)                  | `warn` on retryable HTTP error; `info` on send and label create; `info`/`warn` on watch ops | Missing: spans around every API call, `exception` on non-retryable failures |
-| [settings.py](../src/mailpilot/settings.py)            | No emissions                                         | Missing: `info` on `config set` when values change |
-| [database.py](../src/mailpilot/database.py)            | **No emissions**                                     | Missing: spans around every create/update/search/list/view |
-| [agent/classify.py](../src/mailpilot/agent/classify.py) | **No emissions**                                    | Classification decisions must be traced with inputs + outputs |
-| [agent/tools.py](../src/mailpilot/agent/tools.py)      | **No emissions**                                     | Every tool call is a span (Pydantic AI can auto-instrument) |
-| [exceptions.py](../src/mailpilot/exceptions.py)        | N/A -- definitions only                              | Callers must emit `exception` when raising these |
+| Module                                                  | Current emissions                                                                           | Gap                                                                                                   |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| [cli.py](../src/mailpilot/cli.py)                       | `logfire.configure()` only                                                                  | Correct by design -- CLI stays thin                                                                   |
+| [sync.py](../src/mailpilot/sync.py)                     | `info` on start/stop/shutdown; `debug` heartbeat; `warn` on stale sync status               | Missing: per-account sync spans, Pub/Sub callback spans, watch-renewal spans (pipeline unimplemented) |
+| [gmail.py](../src/mailpilot/gmail.py)                   | `warn` on retryable HTTP error; `info` on send and label create; `info`/`warn` on watch ops | Missing: spans around every API call, `exception` on non-retryable failures                           |
+| [settings.py](../src/mailpilot/settings.py)             | No emissions                                                                                | Missing: `info` on `config set` when values change                                                    |
+| [database.py](../src/mailpilot/database.py)             | **No emissions**                                                                            | Missing: spans around every create/update/search/list/view                                            |
+| [agent/classify.py](../src/mailpilot/agent/classify.py) | **No emissions**                                                                            | Classification decisions must be traced with inputs + outputs                                         |
+| [agent/tools.py](../src/mailpilot/agent/tools.py)       | **No emissions**                                                                            | Every tool call is a span (Pydantic AI can auto-instrument)                                           |
+| [exceptions.py](../src/mailpilot/exceptions.py)         | N/A -- definitions only                                                                     | Callers must emit `exception` when raising these                                                      |
 
 ## Logfire MCP Gap Analysis (2026-04-17)
 
-Query against project `pilot`, `service_name = 'mailpilot'`, last 14 days:
+Original audit was run against the shared `pilot` project with `service_name = 'mailpilot'`. The service has since been migrated to a dedicated `mailpilot` project (see ADR-07), which started empty -- all existing traces were abandoned. The gap analysis below is preserved as the pre-migration baseline; rerun against `project='mailpilot'` once instrumentation lands.
+
+Query (current form against the dedicated project):
 
 ```sql
 SELECT span_name, level, COUNT(*) AS count
 FROM records
-WHERE service_name = 'mailpilot'
 GROUP BY span_name, level
 ORDER BY count DESC
 LIMIT 100
 ```
 
-Result:
+Pre-migration baseline (from the shared `pilot` project):
 
 | span_name                  | level | count |
 | -------------------------- | ----- | ----- |
@@ -47,7 +48,7 @@ Environment breakdown: `development` = 6, `production` = 0.
 2. **Zero records from `production`.** No deployed service is sending traces. Either production does not exist yet or `logfire_token` is unset there.
 3. **Span names are sentence-case strings, not dot-separated.** Existing names (`"sync loop started"`) do not follow the ADR-07 convention (`sync.loop.start`). Rename during instrumentation work; the low current volume makes renames cheap.
 4. **No error records.** Either nothing has failed, or failures are escaping without being logged. Adding `logfire.exception` in error paths is the only way to tell.
-5. **Console-only development data.** The single `production` filter matters: the `pilot` project currently contains more `leadpilot` traffic than `mailpilot` traffic, so untagged queries would mislead.
+5. **Dedicated project.** The service now has its own `mailpilot` project, so queries no longer need a `service_name` filter. The `deployment_environment` filter still matters to separate local development noise from production signal.
 
 ## Module-by-Module Proposed Instrumentation
 
@@ -55,19 +56,19 @@ Environment breakdown: `development` = 6, `production` = 0.
 
 Every CRUD function gets a span. Use `@logfire.instrument("db.<entity>.<op>")` as a decorator to keep boilerplate out of function bodies.
 
-| Function                              | Span name                  | Attributes                                       |
-| ------------------------------------- | -------------------------- | ------------------------------------------------ |
-| `create_account`                      | `db.account.create`        | `account_id` (from return), `email`              |
-| `get_account`                         | `db.account.get`           | `account_id`, `hit` (bool)                       |
-| `list_accounts`                       | `db.account.list`          | `account_count`                                  |
-| `update_account`                      | `db.account.update`        | `account_id`, `updated_fields` (list of keys)    |
-| `create_company` / `update` / `list` / `view` / `search` | `db.company.*`  | `company_id`, `domain` where applicable          |
-| `create_contact` / `update` / `list` / `view` / `search` | `db.contact.*`  | `contact_id`, `email`, `company_id` where applicable |
-| `create_workflow` / `update` / `activate` / `pause` | `db.workflow.*`   | `workflow_id`, `account_id`, `status`            |
-| `create_email` / `list` / `view` / `search` | `db.email.*`         | `email_id`, `account_id`, `direction`            |
-| `create_task` / `complete_task`       | `db.task.*`                | `task_id`, `workflow_id`                         |
-| Sync state (`get_sync_status`, `upsert_sync_status`, `update_sync_heartbeat`, `delete_sync_status`) | `db.sync_status.*` | `pid`        |
-| `initialize_database`                 | `db.schema.apply`          | `database_url_host`, `schema_applied` (bool)     |
+| Function                                                                                            | Span name           | Attributes                                           |
+| --------------------------------------------------------------------------------------------------- | ------------------- | ---------------------------------------------------- |
+| `create_account`                                                                                    | `db.account.create` | `account_id` (from return), `email`                  |
+| `get_account`                                                                                       | `db.account.get`    | `account_id`, `hit` (bool)                           |
+| `list_accounts`                                                                                     | `db.account.list`   | `account_count`                                      |
+| `update_account`                                                                                    | `db.account.update` | `account_id`, `updated_fields` (list of keys)        |
+| `create_company` / `update` / `list` / `view` / `search`                                            | `db.company.*`      | `company_id`, `domain` where applicable              |
+| `create_contact` / `update` / `list` / `view` / `search`                                            | `db.contact.*`      | `contact_id`, `email`, `company_id` where applicable |
+| `create_workflow` / `update` / `activate` / `pause`                                                 | `db.workflow.*`     | `workflow_id`, `account_id`, `status`                |
+| `create_email` / `list` / `view` / `search`                                                         | `db.email.*`        | `email_id`, `account_id`, `direction`                |
+| `create_task` / `complete_task`                                                                     | `db.task.*`         | `task_id`, `workflow_id`                             |
+| Sync state (`get_sync_status`, `upsert_sync_status`, `update_sync_heartbeat`, `delete_sync_status`) | `db.sync_status.*`  | `pid`                                                |
+| `initialize_database`                                                                               | `db.schema.apply`   | `database_url_host`, `schema_applied` (bool)         |
 
 Level: spans for all; `logfire.exception` on the `psycopg.OperationalError` path in `initialize_database`.
 
@@ -87,17 +88,17 @@ Already partially instrumented. Changes:
 
 Every API call wraps in a span. The retry decorator already logs warnings; add a final `logfire.exception` when retries are exhausted.
 
-| Operation       | Span name                 | Attributes                                       |
-| --------------- | ------------------------- | ------------------------------------------------ |
-| Get profile     | `gmail.get_profile`       | `email`                                          |
-| List messages   | `gmail.list_messages`     | `email`, `query`, `message_count`                |
-| Fetch message   | `gmail.fetch_message`     | `email`, `message_id`                            |
-| Send message    | `gmail.send_message`      | `email`, `message_id` (from result), `thread_id`, `result` |
-| Modify message  | `gmail.modify_message`    | `email`, `message_id`, `add_labels`, `remove_labels` |
-| Get history     | `gmail.get_history`       | `email`, `start_history_id`, `change_count`      |
-| Watch / stop    | `gmail.watch` / `gmail.stop_watch` | `email`, `expiration_ms`                |
-| Create label    | `gmail.create_label`      | `email`, `label_name`, `label_id`                |
-| Retry tick      | existing `logfire.warn`   | add `operation` attribute (the wrapped func name) |
+| Operation      | Span name                          | Attributes                                                 |
+| -------------- | ---------------------------------- | ---------------------------------------------------------- |
+| Get profile    | `gmail.get_profile`                | `email`                                                    |
+| List messages  | `gmail.list_messages`              | `email`, `query`, `message_count`                          |
+| Fetch message  | `gmail.fetch_message`              | `email`, `message_id`                                      |
+| Send message   | `gmail.send_message`               | `email`, `message_id` (from result), `thread_id`, `result` |
+| Modify message | `gmail.modify_message`             | `email`, `message_id`, `add_labels`, `remove_labels`       |
+| Get history    | `gmail.get_history`                | `email`, `start_history_id`, `change_count`                |
+| Watch / stop   | `gmail.watch` / `gmail.stop_watch` | `email`, `expiration_ms`                                   |
+| Create label   | `gmail.create_label`               | `email`, `label_name`, `label_id`                          |
+| Retry tick     | existing `logfire.warn`            | add `operation` attribute (the wrapped func name)          |
 
 `build_gmail_service` exits on missing credentials via `SystemExit` -- add `logfire.exception` before raising so the cause is captured.
 
@@ -105,11 +106,11 @@ Every API call wraps in a span. The retry decorator already logs warnings; add a
 
 Classification is the highest-stakes decision in inbound flow. Instrument so every routing decision is reconstructable from traces alone.
 
-| Event / span                  | Type    | Attributes                                                  |
-| ----------------------------- | ------- | ----------------------------------------------------------- |
-| `agent.classify.inbound`      | span    | `email_id`, `account_id`, `candidate_workflow_ids` (list), `chosen_workflow_id`, `confidence`, `result` |
-| `agent.classify.no_match`     | info    | `email_id`, `account_id`, `candidate_workflow_ids`          |
-| `agent.classify.error`        | exception | `email_id`, `account_id`                                   |
+| Event / span              | Type      | Attributes                                                                                              |
+| ------------------------- | --------- | ------------------------------------------------------------------------------------------------------- |
+| `agent.classify.inbound`  | span      | `email_id`, `account_id`, `candidate_workflow_ids` (list), `chosen_workflow_id`, `confidence`, `result` |
+| `agent.classify.no_match` | info      | `email_id`, `account_id`, `candidate_workflow_ids`                                                      |
+| `agent.classify.error`    | exception | `email_id`, `account_id`                                                                                |
 
 Do not log prompt contents. Log only input/output identifiers and the model's decision.
 
@@ -149,13 +150,12 @@ mailpilot contact list --domain example.com
 mailpilot contact view <ID>
 ```
 
-Verify in Logfire:
+Verify in Logfire (`project='mailpilot'`):
 
 ```sql
 SELECT span_name, attributes, start_timestamp
 FROM records
-WHERE service_name = 'mailpilot'
-  AND deployment_environment = 'development'
+WHERE deployment_environment = 'development'
   AND span_name LIKE 'db.%'
 ORDER BY start_timestamp DESC
 LIMIT 50
@@ -167,15 +167,16 @@ Expected: one span per CRUD operation above, each with the documented attributes
 
 To be filed after this plan lands:
 
-| Priority | Scope                                           | Expected follow-up issue |
-| -------- | ----------------------------------------------- | ------------------------ |
-| P1       | `database.py` -- spans on every CRUD function  | `feat(observability): instrument database.py per ADR-07` |
-| P1       | `sync.py` -- rename existing spans to dot-notation | `chore(observability): align sync.py span names with ADR-07` |
-| P2       | `gmail.py` -- wrap every API call in a span     | `feat(observability): instrument gmail.py per ADR-07` |
-| P2       | `agent/classify.py` + `agent/tools.py` -- classification and tool-call spans | Blocked on issues [#10](https://github.com/kborovik/mailpilot/issues/10), [#11](https://github.com/kborovik/mailpilot/issues/11), [#12](https://github.com/kborovik/mailpilot/issues/12) |
-| P3       | `settings.py` -- `config.set` info event       | `feat(observability): emit config.set telemetry` |
-| P3       | Sync pipeline spans                              | Bundled into the sync-implementation issues [#8](https://github.com/kborovik/mailpilot/issues/8), [#13](https://github.com/kborovik/mailpilot/issues/13), [#14](https://github.com/kborovik/mailpilot/issues/14) |
+| Priority | Scope                                                                        | Expected follow-up issue                                                                                                                                                                                         |
+| -------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P1       | `database.py` -- spans on every CRUD function                                | `feat(observability): instrument database.py per ADR-07`                                                                                                                                                         |
+| P1       | `sync.py` -- rename existing spans to dot-notation                           | `chore(observability): align sync.py span names with ADR-07`                                                                                                                                                     |
+| P2       | `gmail.py` -- wrap every API call in a span                                  | `feat(observability): instrument gmail.py per ADR-07`                                                                                                                                                            |
+| P2       | `agent/classify.py` + `agent/tools.py` -- classification and tool-call spans | Blocked on issues [#10](https://github.com/kborovik/mailpilot/issues/10), [#11](https://github.com/kborovik/mailpilot/issues/11), [#12](https://github.com/kborovik/mailpilot/issues/12)                         |
+| P3       | `settings.py` -- `config.set` info event                                     | `feat(observability): emit config.set telemetry`                                                                                                                                                                 |
+| P3       | Sync pipeline spans                                                          | Bundled into the sync-implementation issues [#8](https://github.com/kborovik/mailpilot/issues/8), [#13](https://github.com/kborovik/mailpilot/issues/13), [#14](https://github.com/kborovik/mailpilot/issues/14) |
 
 ## Revision Log
 
 - 2026-04-17 -- Initial plan derived from ADR-07 and Logfire MCP audit ([#19](https://github.com/kborovik/mailpilot/issues/19)).
+- 2026-04-17 -- Migrated from shared `pilot` project to dedicated `mailpilot` project. MCP access to the new project confirmed (empty as expected). `service_name` filter no longer required in queries.


### PR DESCRIPTION
## Summary

- Add `docs/adr-07-observability-with-logfire.md` — codifies Logfire conventions: single `pilot` project, `service_name = mailpilot`, `deployment_environment` tagging, CLI stays emission-free, span-naming and attribute conventions, primitive selection, and testing/investigation workflow
- Add `docs/logfire-instrumentation-plan.md` — living instrumentation plan with current coverage matrix, Logfire MCP gap analysis, module-by-module proposed spans/attributes, smoke test plan, and prioritized follow-up issue list
- Update `CLAUDE.md` Observability section to reference both new docs

No code changes — follow-up issues (P1-P3 listed in the plan) will track per-module instrumentation implementation.

## Key findings from Logfire MCP audit

Only 6 records exist for `service_name = 'mailpilot'`, all in `development`, all from the sync loop lifecycle (`sync heartbeat`, `sync loop started/stopped`). Zero records from any CLI command. Zero records in `production`. `database.py` is uninstrumented despite being on the critical path for every CLI operation.

## Test plan

- [ ] Verify both docs render correctly on GitHub
- [ ] Confirm CLAUDE.md Observability section links resolve correctly
- [ ] No lint or type errors (`make check` passes — docs-only change)

Resolves #19