### PR TITLE
feat(observability): instrument database.py, sync.py, and settings.py

### DIFF
--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -99,7 +99,8 @@ def main(ctx: click.Context, debug: bool) -> None:
     """MailPilot -- CRM for cold email outreach via Gmail."""
     ctx.ensure_object(dict)
     ctx.obj["debug"] = debug
-    configure_logging(debug=debug)
+    if ctx.invoked_subcommand is not None:
+        configure_logging(debug=debug)
 
 
 # -- Status command ------------------------------------------------------------
@@ -108,8 +109,6 @@ def main(ctx: click.Context, debug: bool) -> None:
 @main.command()
 def status() -> None:
     """Show application state summary including sync loop status."""
-    configure_logging()
-
     from mailpilot.database import (
         get_status_counts,
         get_sync_status,
@@ -139,11 +138,8 @@ def status() -> None:
 
 
 @main.command()
-@click.pass_context
-def run(ctx: click.Context) -> None:
+def run() -> None:
     """Start the sync loop (foreground, managed by systemd)."""
-    configure_logging(debug=ctx.obj.get("debug", False))
-
     from mailpilot.database import initialize_database
     from mailpilot.sync import start_sync_loop
 

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -99,6 +99,7 @@ def main(ctx: click.Context, debug: bool) -> None:
     """MailPilot -- CRM for cold email outreach via Gmail."""
     ctx.ensure_object(dict)
     ctx.obj["debug"] = debug
+    configure_logging(debug=debug)
 
 
 # -- Status command ------------------------------------------------------------

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -183,9 +183,8 @@ def config_get(key: str | None) -> None:
 @click.argument("value")
 def config_set(key: str, value: str) -> None:
     """Set a config value."""
-    from mailpilot.settings import Settings, get_settings, save_settings
+    from mailpilot.settings import Settings, set_setting
 
-    settings = get_settings()
     if key not in Settings.model_fields:
         output_error(f"unknown config key: {key}", "invalid_key")
 
@@ -201,10 +200,7 @@ def config_set(key: str, value: str) -> None:
     else:
         parsed_value = value
 
-    data = settings.model_dump(mode="json")
-    data[key] = parsed_value
-    updated = Settings(**{k: v for k, v in data.items() if k in Settings.model_fields})
-    save_settings(updated)
+    set_setting(key, parsed_value)
     output({"key": key, "value": parsed_value})
 
 

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -229,7 +229,9 @@ def update_account(
         updated_fields=sorted(updates.keys()),
     ) as span:
         if not updates:
-            return get_account(connection, account_id)
+            existing = get_account(connection, account_id)
+            span.set_attribute("hit", existing is not None)
+            return existing
         updates["id"] = account_id
         query = _build_update("account", updates, SQL("id = %(id)s"))
         row = connection.execute(query, updates).fetchone()
@@ -375,7 +377,9 @@ def update_company(
         updated_fields=sorted(updates.keys()),
     ) as span:
         if not updates:
-            return get_company(connection, company_id)
+            existing = get_company(connection, company_id)
+            span.set_attribute("hit", existing is not None)
+            return existing
         updates["id"] = company_id
         query = _build_update("company", updates, SQL("id = %(id)s"))
         row = connection.execute(query, updates).fetchone()
@@ -584,7 +588,9 @@ def update_contact(
         updated_fields=sorted(updates.keys()),
     ) as span:
         if not updates:
-            return get_contact(connection, contact_id)
+            existing = get_contact(connection, contact_id)
+            span.set_attribute("hit", existing is not None)
+            return existing
         updates["id"] = contact_id
         query = _build_update("contact", updates, SQL("id = %(id)s"))
         row = connection.execute(query, updates).fetchone()
@@ -769,7 +775,9 @@ def update_workflow(
         updated_fields=sorted(updates.keys()),
     ) as span:
         if not updates:
-            return get_workflow(connection, workflow_id)
+            existing = get_workflow(connection, workflow_id)
+            span.set_attribute("hit", existing is not None)
+            return existing
         updates["id"] = workflow_id
         query = _build_update("workflow", updates, SQL("id = %(id)s"))
         row = connection.execute(query, updates).fetchone()
@@ -822,6 +830,7 @@ def activate_workflow(
             {"id": workflow_id},
         ).fetchone()
         connection.commit()
+        span.set_attribute("result", "success")
         return Workflow.model_validate(row)
 
 
@@ -860,6 +869,7 @@ def pause_workflow(
             {"id": workflow_id},
         ).fetchone()
         connection.commit()
+        span.set_attribute("result", "success")
         return Workflow.model_validate(row)
 
 
@@ -924,7 +934,9 @@ def update_workflow_contact(
         updated_fields=sorted(updates.keys()),
     ) as span:
         if not updates:
-            return get_workflow_contact(connection, workflow_id, contact_id)
+            existing = get_workflow_contact(connection, workflow_id, contact_id)
+            span.set_attribute("hit", existing is not None)
+            return existing
         updates["workflow_id"] = workflow_id
         updates["contact_id"] = contact_id
         where = SQL("workflow_id = %(workflow_id)s AND contact_id = %(contact_id)s")
@@ -1255,7 +1267,9 @@ def update_email(
         updated_fields=sorted(updates.keys()),
     ) as span:
         if not updates:
-            return get_email(connection, email_id)
+            existing = get_email(connection, email_id)
+            span.set_attribute("hit", existing is not None)
+            return existing
         updates["id"] = email_id
         # email table has no updated_at column -- use raw SQL instead of _build_update
         set_parts = [

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -14,6 +14,7 @@ import uuid
 from pathlib import Path
 from typing import Any, cast
 
+import logfire
 import psycopg
 from psycopg.rows import dict_row
 from psycopg.sql import SQL, Composed, Identifier, Placeholder
@@ -69,25 +70,28 @@ def initialize_database(database_url: str) -> psycopg.Connection[dict[str, Any]]
     Returns:
         Open database connection with schema applied.
     """
-    try:
-        connection = cast(
-            psycopg.Connection[dict[str, Any]],
-            psycopg.connect(database_url, row_factory=dict_row, autocommit=True),  # type: ignore[arg-type]
-        )
-    except psycopg.OperationalError as exc:
-        db_name = database_url.rsplit("/", 1)[-1]
-        message = str(exc)
-        if "does not exist" in message:
-            hint = f"run 'createdb {db_name}' to create it"
-        elif "Connection refused" in message:
-            hint = "is PostgreSQL running? check your system's service manager"
-        else:
-            hint = "check your database_url setting"
-        raise SystemExit(f"database connection failed: {hint}") from None
-    schema_sql = SCHEMA_PATH.read_text()
-    connection.execute(schema_sql)  # type: ignore[arg-type]
-    connection.autocommit = False
-    return connection
+    host = database_url.rsplit("/", 1)[-1]
+    with logfire.span("db.schema.apply", database=host) as span:
+        try:
+            connection = cast(
+                psycopg.Connection[dict[str, Any]],
+                psycopg.connect(database_url, row_factory=dict_row, autocommit=True),  # type: ignore[arg-type]
+            )
+        except psycopg.OperationalError as exc:
+            message = str(exc)
+            if "does not exist" in message:
+                hint = f"run 'createdb {host}' to create it"
+            elif "Connection refused" in message:
+                hint = "is PostgreSQL running? check your system's service manager"
+            else:
+                hint = "check your database_url setting"
+            logfire.exception("database connection failed", database=host, hint=hint)
+            raise SystemExit(f"database connection failed: {hint}") from None
+        schema_sql = SCHEMA_PATH.read_text()
+        connection.execute(schema_sql)  # type: ignore[arg-type]
+        connection.autocommit = False
+        span.set_attribute("schema_applied", True)
+        return connection
 
 
 # -- Status --------------------------------------------------------------------
@@ -104,24 +108,25 @@ def get_status_counts(
     Returns:
         Dict with accounts, companies, contacts, workflows, emails counts.
     """
-    row = connection.execute(
-        """\
-        SELECT
-            (SELECT COUNT(*) FROM account) AS accounts,
-            (SELECT COUNT(*) FROM company) AS companies,
-            (SELECT COUNT(*) FROM contact) AS contacts,
-            (SELECT COUNT(*) FROM workflow) AS workflows,
-            (SELECT COUNT(*) FROM email) AS emails
-        FROM (SELECT 1) AS _dummy
-        """
-    ).fetchone()
-    return {
-        "accounts": row["accounts"],  # type: ignore[index]
-        "companies": row["companies"],  # type: ignore[index]
-        "contacts": row["contacts"],  # type: ignore[index]
-        "workflows": row["workflows"],  # type: ignore[index]
-        "emails": row["emails"],  # type: ignore[index]
-    }
+    with logfire.span("db.status.counts"):
+        row = connection.execute(
+            """\
+            SELECT
+                (SELECT COUNT(*) FROM account) AS accounts,
+                (SELECT COUNT(*) FROM company) AS companies,
+                (SELECT COUNT(*) FROM contact) AS contacts,
+                (SELECT COUNT(*) FROM workflow) AS workflows,
+                (SELECT COUNT(*) FROM email) AS emails
+            FROM (SELECT 1) AS _dummy
+            """
+        ).fetchone()
+        return {
+            "accounts": row["accounts"],  # type: ignore[index]
+            "companies": row["companies"],  # type: ignore[index]
+            "contacts": row["contacts"],  # type: ignore[index]
+            "workflows": row["workflows"],  # type: ignore[index]
+            "emails": row["emails"],  # type: ignore[index]
+        }
 
 
 # -- Account -------------------------------------------------------------------
@@ -142,16 +147,19 @@ def create_account(
     Returns:
         Created account.
     """
-    row = connection.execute(
-        """\
-        INSERT INTO account (id, email, display_name)
-        VALUES (%(id)s, %(email)s, %(display_name)s)
-        RETURNING *
-        """,
-        {"id": _new_id(), "email": email, "display_name": display_name},
-    ).fetchone()
-    connection.commit()
-    return Account.model_validate(row)
+    with logfire.span("db.account.create", email=email) as span:
+        row = connection.execute(
+            """\
+            INSERT INTO account (id, email, display_name)
+            VALUES (%(id)s, %(email)s, %(display_name)s)
+            RETURNING *
+            """,
+            {"id": _new_id(), "email": email, "display_name": display_name},
+        ).fetchone()
+        connection.commit()
+        account = Account.model_validate(row)
+        span.set_attribute("account_id", account.id)
+        return account
 
 
 def get_account(
@@ -167,13 +175,15 @@ def get_account(
     Returns:
         Account if found, None otherwise.
     """
-    row = connection.execute(
-        "SELECT * FROM account WHERE id = %(id)s",
-        {"id": account_id},
-    ).fetchone()
-    if row is None:
-        return None
-    return Account.model_validate(row)
+    with logfire.span("db.account.get", account_id=account_id) as span:
+        row = connection.execute(
+            "SELECT * FROM account WHERE id = %(id)s",
+            {"id": account_id},
+        ).fetchone()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return Account.model_validate(row)
 
 
 def list_accounts(
@@ -187,8 +197,13 @@ def list_accounts(
     Returns:
         List of accounts ordered by creation time.
     """
-    rows = connection.execute("SELECT * FROM account ORDER BY created_at").fetchall()
-    return [Account.model_validate(row) for row in rows]
+    with logfire.span("db.account.list") as span:
+        rows = connection.execute(
+            "SELECT * FROM account ORDER BY created_at"
+        ).fetchall()
+        accounts = [Account.model_validate(row) for row in rows]
+        span.set_attribute("account_count", len(accounts))
+        return accounts
 
 
 def update_account(
@@ -212,13 +227,19 @@ def update_account(
     updates = {k: v for k, v in fields.items() if k in allowed}
     if not updates:
         return get_account(connection, account_id)
-    updates["id"] = account_id
-    query = _build_update("account", updates, SQL("id = %(id)s"))
-    row = connection.execute(query, updates).fetchone()
-    connection.commit()
-    if row is None:
-        return None
-    return Account.model_validate(row)
+    with logfire.span(
+        "db.account.update",
+        account_id=account_id,
+        updated_fields=sorted(updates.keys()),
+    ) as span:
+        updates["id"] = account_id
+        query = _build_update("account", updates, SQL("id = %(id)s"))
+        row = connection.execute(query, updates).fetchone()
+        connection.commit()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return Account.model_validate(row)
 
 
 # -- Company -------------------------------------------------------------------
@@ -239,16 +260,19 @@ def create_company(
     Returns:
         Created company.
     """
-    row = connection.execute(
-        """\
-        INSERT INTO company (id, name, domain)
-        VALUES (%(id)s, %(name)s, %(domain)s)
-        RETURNING *
-        """,
-        {"id": _new_id(), "name": name, "domain": domain},
-    ).fetchone()
-    connection.commit()
-    return Company.model_validate(row)
+    with logfire.span("db.company.create", domain=domain) as span:
+        row = connection.execute(
+            """\
+            INSERT INTO company (id, name, domain)
+            VALUES (%(id)s, %(name)s, %(domain)s)
+            RETURNING *
+            """,
+            {"id": _new_id(), "name": name, "domain": domain},
+        ).fetchone()
+        connection.commit()
+        company = Company.model_validate(row)
+        span.set_attribute("company_id", company.id)
+        return company
 
 
 def get_company(
@@ -264,13 +288,15 @@ def get_company(
     Returns:
         Company if found, None otherwise.
     """
-    row = connection.execute(
-        "SELECT * FROM company WHERE id = %(id)s",
-        {"id": company_id},
-    ).fetchone()
-    if row is None:
-        return None
-    return Company.model_validate(row)
+    with logfire.span("db.company.get", company_id=company_id) as span:
+        row = connection.execute(
+            "SELECT * FROM company WHERE id = %(id)s",
+            {"id": company_id},
+        ).fetchone()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return Company.model_validate(row)
 
 
 def list_companies(
@@ -286,11 +312,14 @@ def list_companies(
     Returns:
         List of companies ordered by name.
     """
-    rows = connection.execute(
-        "SELECT * FROM company ORDER BY LOWER(name) LIMIT %(limit)s",
-        {"limit": limit},
-    ).fetchall()
-    return [Company.model_validate(row) for row in rows]
+    with logfire.span("db.company.list", limit=limit) as span:
+        rows = connection.execute(
+            "SELECT * FROM company ORDER BY LOWER(name) LIMIT %(limit)s",
+            {"limit": limit},
+        ).fetchall()
+        companies = [Company.model_validate(row) for row in rows]
+        span.set_attribute("company_count", len(companies))
+        return companies
 
 
 def search_companies(
@@ -308,18 +337,21 @@ def search_companies(
     Returns:
         Matching companies ordered by name.
     """
-    pattern = f"%{query}%"
-    rows = connection.execute(
-        """\
-        SELECT * FROM company
-        WHERE LOWER(name) LIKE LOWER(%(pattern)s)
-           OR LOWER(domain) LIKE LOWER(%(pattern)s)
-        ORDER BY LOWER(name)
-        LIMIT %(limit)s
-        """,
-        {"pattern": pattern, "limit": limit},
-    ).fetchall()
-    return [Company.model_validate(row) for row in rows]
+    with logfire.span("db.company.search", query=query, limit=limit) as span:
+        pattern = f"%{query}%"
+        rows = connection.execute(
+            """\
+            SELECT * FROM company
+            WHERE LOWER(name) LIKE LOWER(%(pattern)s)
+               OR LOWER(domain) LIKE LOWER(%(pattern)s)
+            ORDER BY LOWER(name)
+            LIMIT %(limit)s
+            """,
+            {"pattern": pattern, "limit": limit},
+        ).fetchall()
+        companies = [Company.model_validate(row) for row in rows]
+        span.set_attribute("company_count", len(companies))
+        return companies
 
 
 def update_company(
@@ -343,13 +375,19 @@ def update_company(
     updates = {k: v for k, v in fields.items() if k in allowed}
     if not updates:
         return get_company(connection, company_id)
-    updates["id"] = company_id
-    query = _build_update("company", updates, SQL("id = %(id)s"))
-    row = connection.execute(query, updates).fetchone()
-    connection.commit()
-    if row is None:
-        return None
-    return Company.model_validate(row)
+    with logfire.span(
+        "db.company.update",
+        company_id=company_id,
+        updated_fields=sorted(updates.keys()),
+    ) as span:
+        updates["id"] = company_id
+        query = _build_update("company", updates, SQL("id = %(id)s"))
+        row = connection.execute(query, updates).fetchone()
+        connection.commit()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return Company.model_validate(row)
 
 
 # -- Contact -------------------------------------------------------------------
@@ -376,24 +414,32 @@ def create_contact(
     Returns:
         Created contact.
     """
-    row = connection.execute(
-        """\
-        INSERT INTO contact (id, email, domain, company_id, first_name, last_name)
-        VALUES (%(id)s, %(email)s, %(domain)s, %(company_id)s,
-                %(first_name)s, %(last_name)s)
-        RETURNING *
-        """,
-        {
-            "id": _new_id(),
-            "email": email,
-            "domain": domain,
-            "company_id": company_id,
-            "first_name": first_name,
-            "last_name": last_name,
-        },
-    ).fetchone()
-    connection.commit()
-    return Contact.model_validate(row)
+    with logfire.span(
+        "db.contact.create",
+        email=email,
+        domain=domain,
+        company_id=company_id,
+    ) as span:
+        row = connection.execute(
+            """\
+            INSERT INTO contact (id, email, domain, company_id, first_name, last_name)
+            VALUES (%(id)s, %(email)s, %(domain)s, %(company_id)s,
+                    %(first_name)s, %(last_name)s)
+            RETURNING *
+            """,
+            {
+                "id": _new_id(),
+                "email": email,
+                "domain": domain,
+                "company_id": company_id,
+                "first_name": first_name,
+                "last_name": last_name,
+            },
+        ).fetchone()
+        connection.commit()
+        contact = Contact.model_validate(row)
+        span.set_attribute("contact_id", contact.id)
+        return contact
 
 
 def get_contact(
@@ -409,13 +455,15 @@ def get_contact(
     Returns:
         Contact if found, None otherwise.
     """
-    row = connection.execute(
-        "SELECT * FROM contact WHERE id = %(id)s",
-        {"id": contact_id},
-    ).fetchone()
-    if row is None:
-        return None
-    return Contact.model_validate(row)
+    with logfire.span("db.contact.get", contact_id=contact_id) as span:
+        row = connection.execute(
+            "SELECT * FROM contact WHERE id = %(id)s",
+            {"id": contact_id},
+        ).fetchone()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return Contact.model_validate(row)
 
 
 def get_contact_by_email(
@@ -431,13 +479,15 @@ def get_contact_by_email(
     Returns:
         Contact if found, None otherwise.
     """
-    row = connection.execute(
-        "SELECT * FROM contact WHERE email = %(email)s",
-        {"email": email},
-    ).fetchone()
-    if row is None:
-        return None
-    return Contact.model_validate(row)
+    with logfire.span("db.contact.get_by_email", email=email) as span:
+        row = connection.execute(
+            "SELECT * FROM contact WHERE email = %(email)s",
+            {"email": email},
+        ).fetchone()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return Contact.model_validate(row)
 
 
 def list_contacts(
@@ -457,18 +507,28 @@ def list_contacts(
     Returns:
         List of contacts ordered by email.
     """
-    conditions: list[SQL] = []
-    params: dict[str, object] = {"limit": limit}
-    if domain is not None:
-        conditions.append(SQL("domain = %(domain)s"))
-        params["domain"] = domain
-    if company_id is not None:
-        conditions.append(SQL("company_id = %(company_id)s"))
-        params["company_id"] = company_id
-    where = SQL("WHERE ") + SQL(" AND ").join(conditions) if conditions else SQL("")
-    query = SQL("SELECT * FROM contact {} ORDER BY email LIMIT %(limit)s").format(where)
-    rows = connection.execute(query, params).fetchall()
-    return [Contact.model_validate(row) for row in rows]
+    with logfire.span(
+        "db.contact.list",
+        limit=limit,
+        domain=domain,
+        company_id=company_id,
+    ) as span:
+        conditions: list[SQL] = []
+        params: dict[str, object] = {"limit": limit}
+        if domain is not None:
+            conditions.append(SQL("domain = %(domain)s"))
+            params["domain"] = domain
+        if company_id is not None:
+            conditions.append(SQL("company_id = %(company_id)s"))
+            params["company_id"] = company_id
+        where = SQL("WHERE ") + SQL(" AND ").join(conditions) if conditions else SQL("")
+        query = SQL("SELECT * FROM contact {} ORDER BY email LIMIT %(limit)s").format(
+            where
+        )
+        rows = connection.execute(query, params).fetchall()
+        contacts = [Contact.model_validate(row) for row in rows]
+        span.set_attribute("contact_count", len(contacts))
+        return contacts
 
 
 def search_contacts(
@@ -486,20 +546,23 @@ def search_contacts(
     Returns:
         Matching contacts ordered by email.
     """
-    pattern = f"%{query}%"
-    rows = connection.execute(
-        """\
-        SELECT * FROM contact
-        WHERE LOWER(email) LIKE LOWER(%(pattern)s)
-           OR LOWER(COALESCE(first_name, '')) LIKE LOWER(%(pattern)s)
-           OR LOWER(COALESCE(last_name, '')) LIKE LOWER(%(pattern)s)
-           OR LOWER(domain) LIKE LOWER(%(pattern)s)
-        ORDER BY email
-        LIMIT %(limit)s
-        """,
-        {"pattern": pattern, "limit": limit},
-    ).fetchall()
-    return [Contact.model_validate(row) for row in rows]
+    with logfire.span("db.contact.search", query=query, limit=limit) as span:
+        pattern = f"%{query}%"
+        rows = connection.execute(
+            """\
+            SELECT * FROM contact
+            WHERE LOWER(email) LIKE LOWER(%(pattern)s)
+               OR LOWER(COALESCE(first_name, '')) LIKE LOWER(%(pattern)s)
+               OR LOWER(COALESCE(last_name, '')) LIKE LOWER(%(pattern)s)
+               OR LOWER(domain) LIKE LOWER(%(pattern)s)
+            ORDER BY email
+            LIMIT %(limit)s
+            """,
+            {"pattern": pattern, "limit": limit},
+        ).fetchall()
+        contacts = [Contact.model_validate(row) for row in rows]
+        span.set_attribute("contact_count", len(contacts))
+        return contacts
 
 
 def update_contact(
@@ -523,13 +586,19 @@ def update_contact(
     updates = {k: v for k, v in fields.items() if k in allowed}
     if not updates:
         return get_contact(connection, contact_id)
-    updates["id"] = contact_id
-    query = _build_update("contact", updates, SQL("id = %(id)s"))
-    row = connection.execute(query, updates).fetchone()
-    connection.commit()
-    if row is None:
-        return None
-    return Contact.model_validate(row)
+    with logfire.span(
+        "db.contact.update",
+        contact_id=contact_id,
+        updated_fields=sorted(updates.keys()),
+    ) as span:
+        updates["id"] = contact_id
+        query = _build_update("contact", updates, SQL("id = %(id)s"))
+        row = connection.execute(query, updates).fetchone()
+        connection.commit()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return Contact.model_validate(row)
 
 
 def disable_contact(
@@ -552,21 +621,27 @@ def disable_contact(
     Returns:
         Updated contact, or None if not found.
     """
-    row = connection.execute(
-        """\
-        UPDATE contact
-        SET status = %(status)s,
-            status_reason = %(status_reason)s,
-            updated_at = CURRENT_TIMESTAMP
-        WHERE id = %(id)s
-        RETURNING *
-        """,
-        {"id": contact_id, "status": status, "status_reason": status_reason},
-    ).fetchone()
-    connection.commit()
-    if row is None:
-        return None
-    return Contact.model_validate(row)
+    with logfire.span(
+        "db.contact.disable",
+        contact_id=contact_id,
+        status=status,
+    ) as span:
+        row = connection.execute(
+            """\
+            UPDATE contact
+            SET status = %(status)s,
+                status_reason = %(status_reason)s,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = %(id)s
+            RETURNING *
+            """,
+            {"id": contact_id, "status": status, "status_reason": status_reason},
+        ).fetchone()
+        connection.commit()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return Contact.model_validate(row)
 
 
 # -- Workflow ------------------------------------------------------------------
@@ -589,21 +664,28 @@ def create_workflow(
     Returns:
         Created workflow.
     """
-    row = connection.execute(
-        """\
-        INSERT INTO workflow (id, name, type, account_id)
-        VALUES (%(id)s, %(name)s, %(type)s, %(account_id)s)
-        RETURNING *
-        """,
-        {
-            "id": _new_id(),
-            "name": name,
-            "type": workflow_type,
-            "account_id": account_id,
-        },
-    ).fetchone()
-    connection.commit()
-    return Workflow.model_validate(row)
+    with logfire.span(
+        "db.workflow.create",
+        account_id=account_id,
+        workflow_type=workflow_type,
+    ) as span:
+        row = connection.execute(
+            """\
+            INSERT INTO workflow (id, name, type, account_id)
+            VALUES (%(id)s, %(name)s, %(type)s, %(account_id)s)
+            RETURNING *
+            """,
+            {
+                "id": _new_id(),
+                "name": name,
+                "type": workflow_type,
+                "account_id": account_id,
+            },
+        ).fetchone()
+        connection.commit()
+        workflow = Workflow.model_validate(row)
+        span.set_attribute("workflow_id", workflow.id)
+        return workflow
 
 
 def get_workflow(
@@ -619,13 +701,15 @@ def get_workflow(
     Returns:
         Workflow if found, None otherwise.
     """
-    row = connection.execute(
-        "SELECT * FROM workflow WHERE id = %(id)s",
-        {"id": workflow_id},
-    ).fetchone()
-    if row is None:
-        return None
-    return Workflow.model_validate(row)
+    with logfire.span("db.workflow.get", workflow_id=workflow_id) as span:
+        row = connection.execute(
+            "SELECT * FROM workflow WHERE id = %(id)s",
+            {"id": workflow_id},
+        ).fetchone()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return Workflow.model_validate(row)
 
 
 def list_workflows(
@@ -643,18 +727,25 @@ def list_workflows(
     Returns:
         List of workflows ordered by creation time.
     """
-    conditions: list[SQL] = []
-    params: dict[str, object] = {}
-    if account_id is not None:
-        conditions.append(SQL("account_id = %(account_id)s"))
-        params["account_id"] = account_id
-    if status is not None:
-        conditions.append(SQL("status = %(status)s"))
-        params["status"] = status
-    where = SQL("WHERE ") + SQL(" AND ").join(conditions) if conditions else SQL("")
-    query = SQL("SELECT * FROM workflow {} ORDER BY created_at").format(where)
-    rows = connection.execute(query, params).fetchall()
-    return [Workflow.model_validate(row) for row in rows]
+    with logfire.span(
+        "db.workflow.list",
+        account_id=account_id,
+        status=status,
+    ) as span:
+        conditions: list[SQL] = []
+        params: dict[str, object] = {}
+        if account_id is not None:
+            conditions.append(SQL("account_id = %(account_id)s"))
+            params["account_id"] = account_id
+        if status is not None:
+            conditions.append(SQL("status = %(status)s"))
+            params["status"] = status
+        where = SQL("WHERE ") + SQL(" AND ").join(conditions) if conditions else SQL("")
+        query = SQL("SELECT * FROM workflow {} ORDER BY created_at").format(where)
+        rows = connection.execute(query, params).fetchall()
+        workflows = [Workflow.model_validate(row) for row in rows]
+        span.set_attribute("workflow_count", len(workflows))
+        return workflows
 
 
 def update_workflow(
@@ -682,13 +773,19 @@ def update_workflow(
     updates = {k: v for k, v in fields.items() if k in allowed}
     if not updates:
         return get_workflow(connection, workflow_id)
-    updates["id"] = workflow_id
-    query = _build_update("workflow", updates, SQL("id = %(id)s"))
-    row = connection.execute(query, updates).fetchone()
-    connection.commit()
-    if row is None:
-        return None
-    return Workflow.model_validate(row)
+    with logfire.span(
+        "db.workflow.update",
+        workflow_id=workflow_id,
+        updated_fields=sorted(updates.keys()),
+    ) as span:
+        updates["id"] = workflow_id
+        query = _build_update("workflow", updates, SQL("id = %(id)s"))
+        row = connection.execute(query, updates).fetchone()
+        connection.commit()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return Workflow.model_validate(row)
 
 
 def activate_workflow(
@@ -711,26 +808,29 @@ def activate_workflow(
         ValueError: If workflow not found, already active, or missing
             objective/instructions.
     """
-    workflow = get_workflow(connection, workflow_id)
-    if workflow is None:
-        raise ValueError(f"workflow {workflow_id} not found")
-    if workflow.status == "active":
-        raise ValueError("workflow is already active")
-    if not workflow.objective.strip():
-        raise ValueError("objective must be non-empty to activate")
-    if not workflow.instructions.strip():
-        raise ValueError("instructions must be non-empty to activate")
-    row = connection.execute(
-        """\
-        UPDATE workflow
-        SET status = 'active', updated_at = CURRENT_TIMESTAMP
-        WHERE id = %(id)s
-        RETURNING *
-        """,
-        {"id": workflow_id},
-    ).fetchone()
-    connection.commit()
-    return Workflow.model_validate(row)
+    with logfire.span("db.workflow.activate", workflow_id=workflow_id) as span:
+        workflow = get_workflow(connection, workflow_id)
+        if workflow is None:
+            raise ValueError(f"workflow {workflow_id} not found")
+        if workflow.status == "active":
+            raise ValueError("workflow is already active")
+        if not workflow.objective.strip():
+            raise ValueError("objective must be non-empty to activate")
+        if not workflow.instructions.strip():
+            raise ValueError("instructions must be non-empty to activate")
+        span.set_attribute("account_id", workflow.account_id)
+        span.set_attribute("prior_status", workflow.status)
+        row = connection.execute(
+            """\
+            UPDATE workflow
+            SET status = 'active', updated_at = CURRENT_TIMESTAMP
+            WHERE id = %(id)s
+            RETURNING *
+            """,
+            {"id": workflow_id},
+        ).fetchone()
+        connection.commit()
+        return Workflow.model_validate(row)
 
 
 def pause_workflow(
@@ -751,22 +851,24 @@ def pause_workflow(
     Raises:
         ValueError: If workflow not found or not active.
     """
-    workflow = get_workflow(connection, workflow_id)
-    if workflow is None:
-        raise ValueError(f"workflow {workflow_id} not found")
-    if workflow.status != "active":
-        raise ValueError(f"cannot pause workflow in status '{workflow.status}'")
-    row = connection.execute(
-        """\
-        UPDATE workflow
-        SET status = 'paused', updated_at = CURRENT_TIMESTAMP
-        WHERE id = %(id)s
-        RETURNING *
-        """,
-        {"id": workflow_id},
-    ).fetchone()
-    connection.commit()
-    return Workflow.model_validate(row)
+    with logfire.span("db.workflow.pause", workflow_id=workflow_id) as span:
+        workflow = get_workflow(connection, workflow_id)
+        if workflow is None:
+            raise ValueError(f"workflow {workflow_id} not found")
+        if workflow.status != "active":
+            raise ValueError(f"cannot pause workflow in status '{workflow.status}'")
+        span.set_attribute("account_id", workflow.account_id)
+        row = connection.execute(
+            """\
+            UPDATE workflow
+            SET status = 'paused', updated_at = CURRENT_TIMESTAMP
+            WHERE id = %(id)s
+            RETURNING *
+            """,
+            {"id": workflow_id},
+        ).fetchone()
+        connection.commit()
+        return Workflow.model_validate(row)
 
 
 # -- Workflow Contact ----------------------------------------------------------
@@ -787,16 +889,21 @@ def create_workflow_contact(
     Returns:
         Created workflow-contact link.
     """
-    row = connection.execute(
-        """\
-        INSERT INTO workflow_contact (workflow_id, contact_id)
-        VALUES (%(workflow_id)s, %(contact_id)s)
-        RETURNING *
-        """,
-        {"workflow_id": workflow_id, "contact_id": contact_id},
-    ).fetchone()
-    connection.commit()
-    return WorkflowContact.model_validate(row)
+    with logfire.span(
+        "db.workflow_contact.create",
+        workflow_id=workflow_id,
+        contact_id=contact_id,
+    ):
+        row = connection.execute(
+            """\
+            INSERT INTO workflow_contact (workflow_id, contact_id)
+            VALUES (%(workflow_id)s, %(contact_id)s)
+            RETURNING *
+            """,
+            {"workflow_id": workflow_id, "contact_id": contact_id},
+        ).fetchone()
+        connection.commit()
+        return WorkflowContact.model_validate(row)
 
 
 def update_workflow_contact(
@@ -820,15 +927,22 @@ def update_workflow_contact(
     updates = {k: v for k, v in fields.items() if k in allowed}
     if not updates:
         return get_workflow_contact(connection, workflow_id, contact_id)
-    updates["workflow_id"] = workflow_id
-    updates["contact_id"] = contact_id
-    where = SQL("workflow_id = %(workflow_id)s AND contact_id = %(contact_id)s")
-    query = _build_update("workflow_contact", updates, where)
-    row = connection.execute(query, updates).fetchone()
-    connection.commit()
-    if row is None:
-        return None
-    return WorkflowContact.model_validate(row)
+    with logfire.span(
+        "db.workflow_contact.update",
+        workflow_id=workflow_id,
+        contact_id=contact_id,
+        updated_fields=sorted(updates.keys()),
+    ) as span:
+        updates["workflow_id"] = workflow_id
+        updates["contact_id"] = contact_id
+        where = SQL("workflow_id = %(workflow_id)s AND contact_id = %(contact_id)s")
+        query = _build_update("workflow_contact", updates, where)
+        row = connection.execute(query, updates).fetchone()
+        connection.commit()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return WorkflowContact.model_validate(row)
 
 
 def get_workflow_contact(
@@ -846,16 +960,22 @@ def get_workflow_contact(
     Returns:
         WorkflowContact if found, None otherwise.
     """
-    row = connection.execute(
-        """\
-        SELECT * FROM workflow_contact
-        WHERE workflow_id = %(workflow_id)s AND contact_id = %(contact_id)s
-        """,
-        {"workflow_id": workflow_id, "contact_id": contact_id},
-    ).fetchone()
-    if row is None:
-        return None
-    return WorkflowContact.model_validate(row)
+    with logfire.span(
+        "db.workflow_contact.get",
+        workflow_id=workflow_id,
+        contact_id=contact_id,
+    ) as span:
+        row = connection.execute(
+            """\
+            SELECT * FROM workflow_contact
+            WHERE workflow_id = %(workflow_id)s AND contact_id = %(contact_id)s
+            """,
+            {"workflow_id": workflow_id, "contact_id": contact_id},
+        ).fetchone()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return WorkflowContact.model_validate(row)
 
 
 def list_workflow_contacts(
@@ -873,18 +993,25 @@ def list_workflow_contacts(
     Returns:
         List of workflow-contact links.
     """
-    params: dict[str, object] = {"workflow_id": workflow_id}
-    status_filter = SQL("")
-    if status is not None:
-        status_filter = SQL("AND status = %(status)s")
-        params["status"] = status
-    query = SQL(
-        "SELECT * FROM workflow_contact "
-        "WHERE workflow_id = %(workflow_id)s {} "
-        "ORDER BY created_at"
-    ).format(status_filter)
-    rows = connection.execute(query, params).fetchall()
-    return [WorkflowContact.model_validate(row) for row in rows]
+    with logfire.span(
+        "db.workflow_contact.list",
+        workflow_id=workflow_id,
+        status=status,
+    ) as span:
+        params: dict[str, object] = {"workflow_id": workflow_id}
+        status_filter = SQL("")
+        if status is not None:
+            status_filter = SQL("AND status = %(status)s")
+            params["status"] = status
+        query = SQL(
+            "SELECT * FROM workflow_contact "
+            "WHERE workflow_id = %(workflow_id)s {} "
+            "ORDER BY created_at"
+        ).format(status_filter)
+        rows = connection.execute(query, params).fetchall()
+        links = [WorkflowContact.model_validate(row) for row in rows]
+        span.set_attribute("contact_count", len(links))
+        return links
 
 
 # -- Email ---------------------------------------------------------------------
@@ -921,33 +1048,42 @@ def create_email(
     Returns:
         Created email.
     """
-    row = connection.execute(
-        """\
-        INSERT INTO email (id, account_id, direction, subject,
-            body_text, gmail_message_id, gmail_thread_id,
-            contact_id, workflow_id, status, is_routed)
-        VALUES (%(id)s, %(account_id)s, %(direction)s,
-            %(subject)s, %(body_text)s, %(gmail_message_id)s,
-            %(gmail_thread_id)s, %(contact_id)s, %(workflow_id)s,
-            %(status)s, %(is_routed)s)
-        RETURNING *
-        """,
-        {
-            "id": _new_id(),
-            "account_id": account_id,
-            "direction": direction,
-            "subject": subject,
-            "body_text": body_text,
-            "gmail_message_id": gmail_message_id,
-            "gmail_thread_id": gmail_thread_id,
-            "contact_id": contact_id,
-            "workflow_id": workflow_id,
-            "status": status,
-            "is_routed": is_routed,
-        },
-    ).fetchone()
-    connection.commit()
-    return Email.model_validate(row)
+    with logfire.span(
+        "db.email.create",
+        account_id=account_id,
+        direction=direction,
+        contact_id=contact_id,
+        workflow_id=workflow_id,
+    ) as span:
+        row = connection.execute(
+            """\
+            INSERT INTO email (id, account_id, direction, subject,
+                body_text, gmail_message_id, gmail_thread_id,
+                contact_id, workflow_id, status, is_routed)
+            VALUES (%(id)s, %(account_id)s, %(direction)s,
+                %(subject)s, %(body_text)s, %(gmail_message_id)s,
+                %(gmail_thread_id)s, %(contact_id)s, %(workflow_id)s,
+                %(status)s, %(is_routed)s)
+            RETURNING *
+            """,
+            {
+                "id": _new_id(),
+                "account_id": account_id,
+                "direction": direction,
+                "subject": subject,
+                "body_text": body_text,
+                "gmail_message_id": gmail_message_id,
+                "gmail_thread_id": gmail_thread_id,
+                "contact_id": contact_id,
+                "workflow_id": workflow_id,
+                "status": status,
+                "is_routed": is_routed,
+            },
+        ).fetchone()
+        connection.commit()
+        email = Email.model_validate(row)
+        span.set_attribute("email_id", email.id)
+        return email
 
 
 def get_email(
@@ -963,13 +1099,15 @@ def get_email(
     Returns:
         Email if found, None otherwise.
     """
-    row = connection.execute(
-        "SELECT * FROM email WHERE id = %(id)s",
-        {"id": email_id},
-    ).fetchone()
-    if row is None:
-        return None
-    return Email.model_validate(row)
+    with logfire.span("db.email.get", email_id=email_id) as span:
+        row = connection.execute(
+            "SELECT * FROM email WHERE id = %(id)s",
+            {"id": email_id},
+        ).fetchone()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return Email.model_validate(row)
 
 
 def list_emails(
@@ -989,20 +1127,28 @@ def list_emails(
     Returns:
         List of emails ordered by creation time descending.
     """
-    conditions: list[SQL] = []
-    params: dict[str, object] = {"limit": limit}
-    if contact_id is not None:
-        conditions.append(SQL("contact_id = %(contact_id)s"))
-        params["contact_id"] = contact_id
-    if account_id is not None:
-        conditions.append(SQL("account_id = %(account_id)s"))
-        params["account_id"] = account_id
-    where = SQL("WHERE ") + SQL(" AND ").join(conditions) if conditions else SQL("")
-    query = SQL(
-        "SELECT * FROM email {} ORDER BY created_at DESC LIMIT %(limit)s"
-    ).format(where)
-    rows = connection.execute(query, params).fetchall()
-    return [Email.model_validate(row) for row in rows]
+    with logfire.span(
+        "db.email.list",
+        limit=limit,
+        contact_id=contact_id,
+        account_id=account_id,
+    ) as span:
+        conditions: list[SQL] = []
+        params: dict[str, object] = {"limit": limit}
+        if contact_id is not None:
+            conditions.append(SQL("contact_id = %(contact_id)s"))
+            params["contact_id"] = contact_id
+        if account_id is not None:
+            conditions.append(SQL("account_id = %(account_id)s"))
+            params["account_id"] = account_id
+        where = SQL("WHERE ") + SQL(" AND ").join(conditions) if conditions else SQL("")
+        query = SQL(
+            "SELECT * FROM email {} ORDER BY created_at DESC LIMIT %(limit)s"
+        ).format(where)
+        rows = connection.execute(query, params).fetchall()
+        emails = [Email.model_validate(row) for row in rows]
+        span.set_attribute("email_count", len(emails))
+        return emails
 
 
 def search_emails(
@@ -1020,18 +1166,21 @@ def search_emails(
     Returns:
         Matching emails ordered by creation time descending.
     """
-    pattern = f"%{query}%"
-    rows = connection.execute(
-        """\
-        SELECT * FROM email
-        WHERE LOWER(subject) LIKE LOWER(%(pattern)s)
-           OR LOWER(body_text) LIKE LOWER(%(pattern)s)
-        ORDER BY created_at DESC
-        LIMIT %(limit)s
-        """,
-        {"pattern": pattern, "limit": limit},
-    ).fetchall()
-    return [Email.model_validate(row) for row in rows]
+    with logfire.span("db.email.search", query=query, limit=limit) as span:
+        pattern = f"%{query}%"
+        rows = connection.execute(
+            """\
+            SELECT * FROM email
+            WHERE LOWER(subject) LIKE LOWER(%(pattern)s)
+               OR LOWER(body_text) LIKE LOWER(%(pattern)s)
+            ORDER BY created_at DESC
+            LIMIT %(limit)s
+            """,
+            {"pattern": pattern, "limit": limit},
+        ).fetchall()
+        emails = [Email.model_validate(row) for row in rows]
+        span.set_attribute("email_count", len(emails))
+        return emails
 
 
 def get_email_by_gmail_message_id(
@@ -1047,13 +1196,18 @@ def get_email_by_gmail_message_id(
     Returns:
         Email if found, None otherwise.
     """
-    row = connection.execute(
-        "SELECT * FROM email WHERE gmail_message_id = %(gmail_message_id)s",
-        {"gmail_message_id": gmail_message_id},
-    ).fetchone()
-    if row is None:
-        return None
-    return Email.model_validate(row)
+    with logfire.span(
+        "db.email.get_by_gmail_message_id",
+        gmail_message_id=gmail_message_id,
+    ) as span:
+        row = connection.execute(
+            "SELECT * FROM email WHERE gmail_message_id = %(gmail_message_id)s",
+            {"gmail_message_id": gmail_message_id},
+        ).fetchone()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return Email.model_validate(row)
 
 
 def get_emails_by_gmail_thread_id(
@@ -1069,15 +1223,21 @@ def get_emails_by_gmail_thread_id(
     Returns:
         Emails in the thread ordered by creation time.
     """
-    rows = connection.execute(
-        """\
-        SELECT * FROM email
-        WHERE gmail_thread_id = %(gmail_thread_id)s
-        ORDER BY created_at
-        """,
-        {"gmail_thread_id": gmail_thread_id},
-    ).fetchall()
-    return [Email.model_validate(row) for row in rows]
+    with logfire.span(
+        "db.email.get_by_gmail_thread_id",
+        gmail_thread_id=gmail_thread_id,
+    ) as span:
+        rows = connection.execute(
+            """\
+            SELECT * FROM email
+            WHERE gmail_thread_id = %(gmail_thread_id)s
+            ORDER BY created_at
+            """,
+            {"gmail_thread_id": gmail_thread_id},
+        ).fetchall()
+        emails = [Email.model_validate(row) for row in rows]
+        span.set_attribute("email_count", len(emails))
+        return emails
 
 
 def update_email(
@@ -1101,20 +1261,28 @@ def update_email(
     updates = {k: v for k, v in fields.items() if k in allowed}
     if not updates:
         return get_email(connection, email_id)
-    updates["id"] = email_id
-    # email table has no updated_at column -- use raw SQL instead of _build_update
-    set_parts = [
-        SQL("{} = {}").format(Identifier(k), Placeholder(k))
-        for k in updates
-        if k != "id"
-    ]
-    set_clause = SQL(", ").join(set_parts)
-    query = SQL("UPDATE email SET {} WHERE id = %(id)s RETURNING *").format(set_clause)
-    row = connection.execute(query, updates).fetchone()
-    connection.commit()
-    if row is None:
-        return None
-    return Email.model_validate(row)
+    with logfire.span(
+        "db.email.update",
+        email_id=email_id,
+        updated_fields=sorted(updates.keys()),
+    ) as span:
+        updates["id"] = email_id
+        # email table has no updated_at column -- use raw SQL instead of _build_update
+        set_parts = [
+            SQL("{} = {}").format(Identifier(k), Placeholder(k))
+            for k in updates
+            if k != "id"
+        ]
+        set_clause = SQL(", ").join(set_parts)
+        query = SQL("UPDATE email SET {} WHERE id = %(id)s RETURNING *").format(
+            set_clause
+        )
+        row = connection.execute(query, updates).fetchone()
+        connection.commit()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return Email.model_validate(row)
 
 
 # -- Task ----------------------------------------------------------------------
@@ -1143,26 +1311,34 @@ def create_task(
     Returns:
         Created task.
     """
-    row = connection.execute(
-        """\
-        INSERT INTO task (id, workflow_id, contact_id, email_id,
-            description, context, scheduled_at)
-        VALUES (%(id)s, %(workflow_id)s, %(contact_id)s, %(email_id)s,
-                %(description)s, %(context)s, %(scheduled_at)s)
-        RETURNING *
-        """,
-        {
-            "id": _new_id(),
-            "workflow_id": workflow_id,
-            "contact_id": contact_id,
-            "email_id": email_id,
-            "description": description,
-            "context": Json(context or {}),
-            "scheduled_at": scheduled_at,
-        },
-    ).fetchone()
-    connection.commit()
-    return Task.model_validate(row)
+    with logfire.span(
+        "db.task.create",
+        workflow_id=workflow_id,
+        contact_id=contact_id,
+        email_id=email_id,
+    ) as span:
+        row = connection.execute(
+            """\
+            INSERT INTO task (id, workflow_id, contact_id, email_id,
+                description, context, scheduled_at)
+            VALUES (%(id)s, %(workflow_id)s, %(contact_id)s, %(email_id)s,
+                    %(description)s, %(context)s, %(scheduled_at)s)
+            RETURNING *
+            """,
+            {
+                "id": _new_id(),
+                "workflow_id": workflow_id,
+                "contact_id": contact_id,
+                "email_id": email_id,
+                "description": description,
+                "context": Json(context or {}),
+                "scheduled_at": scheduled_at,
+            },
+        ).fetchone()
+        connection.commit()
+        task = Task.model_validate(row)
+        span.set_attribute("task_id", task.id)
+        return task
 
 
 def get_task(
@@ -1178,13 +1354,15 @@ def get_task(
     Returns:
         Task if found, None otherwise.
     """
-    row = connection.execute(
-        "SELECT * FROM task WHERE id = %(id)s",
-        {"id": task_id},
-    ).fetchone()
-    if row is None:
-        return None
-    return Task.model_validate(row)
+    with logfire.span("db.task.get", task_id=task_id) as span:
+        row = connection.execute(
+            "SELECT * FROM task WHERE id = %(id)s",
+            {"id": task_id},
+        ).fetchone()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return Task.model_validate(row)
 
 
 def list_pending_tasks(
@@ -1198,14 +1376,17 @@ def list_pending_tasks(
     Returns:
         Pending tasks where scheduled_at <= now(), ordered by scheduled_at.
     """
-    rows = connection.execute(
-        """\
-        SELECT * FROM task
-        WHERE scheduled_at <= CURRENT_TIMESTAMP AND status = 'pending'
-        ORDER BY scheduled_at
-        """
-    ).fetchall()
-    return [Task.model_validate(row) for row in rows]
+    with logfire.span("db.task.list_pending") as span:
+        rows = connection.execute(
+            """\
+            SELECT * FROM task
+            WHERE scheduled_at <= CURRENT_TIMESTAMP AND status = 'pending'
+            ORDER BY scheduled_at
+            """
+        ).fetchall()
+        tasks = [Task.model_validate(row) for row in rows]
+        span.set_attribute("task_count", len(tasks))
+        return tasks
 
 
 def complete_task(
@@ -1223,17 +1404,19 @@ def complete_task(
     Returns:
         Updated task, or None if not found.
     """
-    row = connection.execute(
-        """\
-        UPDATE task SET status = %(status)s, completed_at = CURRENT_TIMESTAMP
-        WHERE id = %(id)s RETURNING *
-        """,
-        {"id": task_id, "status": status},
-    ).fetchone()
-    connection.commit()
-    if row is None:
-        return None
-    return Task.model_validate(row)
+    with logfire.span("db.task.complete", task_id=task_id, status=status) as span:
+        row = connection.execute(
+            """\
+            UPDATE task SET status = %(status)s, completed_at = CURRENT_TIMESTAMP
+            WHERE id = %(id)s RETURNING *
+            """,
+            {"id": task_id, "status": status},
+        ).fetchone()
+        connection.commit()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return Task.model_validate(row)
 
 
 def cancel_task(
@@ -1252,18 +1435,20 @@ def cancel_task(
     Returns:
         Cancelled task, or None if not found or not pending.
     """
-    row = connection.execute(
-        """\
-        UPDATE task SET status = 'cancelled', completed_at = CURRENT_TIMESTAMP
-        WHERE id = %(id)s AND status = 'pending'
-        RETURNING *
-        """,
-        {"id": task_id},
-    ).fetchone()
-    connection.commit()
-    if row is None:
-        return None
-    return Task.model_validate(row)
+    with logfire.span("db.task.cancel", task_id=task_id) as span:
+        row = connection.execute(
+            """\
+            UPDATE task SET status = 'cancelled', completed_at = CURRENT_TIMESTAMP
+            WHERE id = %(id)s AND status = 'pending'
+            RETURNING *
+            """,
+            {"id": task_id},
+        ).fetchone()
+        connection.commit()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return Task.model_validate(row)
 
 
 # -- Sync Status ---------------------------------------------------------------
@@ -1282,20 +1467,21 @@ def upsert_sync_status(
     Returns:
         Current sync status.
     """
-    row = connection.execute(
-        """\
-        INSERT INTO sync_status (id, pid)
-        VALUES ('singleton', %(pid)s)
-        ON CONFLICT (id) DO UPDATE
-            SET pid = %(pid)s,
-                started_at = CURRENT_TIMESTAMP,
-                heartbeat_at = CURRENT_TIMESTAMP
-        RETURNING *
-        """,
-        {"pid": pid},
-    ).fetchone()
-    connection.commit()
-    return SyncStatus.model_validate(row)
+    with logfire.span("db.sync_status.upsert", pid=pid):
+        row = connection.execute(
+            """\
+            INSERT INTO sync_status (id, pid)
+            VALUES ('singleton', %(pid)s)
+            ON CONFLICT (id) DO UPDATE
+                SET pid = %(pid)s,
+                    started_at = CURRENT_TIMESTAMP,
+                    heartbeat_at = CURRENT_TIMESTAMP
+            RETURNING *
+            """,
+            {"pid": pid},
+        ).fetchone()
+        connection.commit()
+        return SyncStatus.model_validate(row)
 
 
 def get_sync_status(
@@ -1309,12 +1495,14 @@ def get_sync_status(
     Returns:
         SyncStatus if sync is registered, None otherwise.
     """
-    row = connection.execute(
-        "SELECT * FROM sync_status WHERE id = 'singleton'"
-    ).fetchone()
-    if row is None:
-        return None
-    return SyncStatus.model_validate(row)
+    with logfire.span("db.sync_status.get") as span:
+        row = connection.execute(
+            "SELECT * FROM sync_status WHERE id = 'singleton'"
+        ).fetchone()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return SyncStatus.model_validate(row)
 
 
 def delete_sync_status(
@@ -1325,8 +1513,9 @@ def delete_sync_status(
     Args:
         connection: Open database connection.
     """
-    connection.execute("DELETE FROM sync_status WHERE id = 'singleton'")
-    connection.commit()
+    with logfire.span("db.sync_status.delete"):
+        connection.execute("DELETE FROM sync_status WHERE id = 'singleton'")
+        connection.commit()
 
 
 def update_sync_heartbeat(
@@ -1337,11 +1526,12 @@ def update_sync_heartbeat(
     Args:
         connection: Open database connection.
     """
-    connection.execute(
-        """\
-        UPDATE sync_status
-        SET heartbeat_at = CURRENT_TIMESTAMP
-        WHERE id = 'singleton'
-        """
-    )
-    connection.commit()
+    with logfire.span("db.sync_status.heartbeat"):
+        connection.execute(
+            """\
+            UPDATE sync_status
+            SET heartbeat_at = CURRENT_TIMESTAMP
+            WHERE id = 'singleton'
+            """
+        )
+        connection.commit()

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -70,8 +70,8 @@ def initialize_database(database_url: str) -> psycopg.Connection[dict[str, Any]]
     Returns:
         Open database connection with schema applied.
     """
-    host = database_url.rsplit("/", 1)[-1]
-    with logfire.span("db.schema.apply", database=host) as span:
+    db_name = database_url.rsplit("/", 1)[-1]
+    with logfire.span("db.schema.apply", database=db_name) as span:
         try:
             connection = cast(
                 psycopg.Connection[dict[str, Any]],
@@ -80,12 +80,12 @@ def initialize_database(database_url: str) -> psycopg.Connection[dict[str, Any]]
         except psycopg.OperationalError as exc:
             message = str(exc)
             if "does not exist" in message:
-                hint = f"run 'createdb {host}' to create it"
+                hint = f"run 'createdb {db_name}' to create it"
             elif "Connection refused" in message:
                 hint = "is PostgreSQL running? check your system's service manager"
             else:
                 hint = "check your database_url setting"
-            logfire.exception("database connection failed", database=host, hint=hint)
+            logfire.exception("database connection failed", database=db_name, hint=hint)
             raise SystemExit(f"database connection failed: {hint}") from None
         schema_sql = SCHEMA_PATH.read_text()
         connection.execute(schema_sql)  # type: ignore[arg-type]
@@ -221,17 +221,15 @@ def update_account(
     Returns:
         Updated account, or None if not found.
     """
-    if not fields:
-        return get_account(connection, account_id)
     allowed = set(Account.model_fields) - {"id", "created_at"}
     updates = {k: v for k, v in fields.items() if k in allowed}
-    if not updates:
-        return get_account(connection, account_id)
     with logfire.span(
         "db.account.update",
         account_id=account_id,
         updated_fields=sorted(updates.keys()),
     ) as span:
+        if not updates:
+            return get_account(connection, account_id)
         updates["id"] = account_id
         query = _build_update("account", updates, SQL("id = %(id)s"))
         row = connection.execute(query, updates).fetchone()
@@ -369,17 +367,15 @@ def update_company(
     Returns:
         Updated company, or None if not found.
     """
-    if not fields:
-        return get_company(connection, company_id)
     allowed = set(Company.model_fields) - {"id", "created_at"}
     updates = {k: v for k, v in fields.items() if k in allowed}
-    if not updates:
-        return get_company(connection, company_id)
     with logfire.span(
         "db.company.update",
         company_id=company_id,
         updated_fields=sorted(updates.keys()),
     ) as span:
+        if not updates:
+            return get_company(connection, company_id)
         updates["id"] = company_id
         query = _build_update("company", updates, SQL("id = %(id)s"))
         row = connection.execute(query, updates).fetchone()
@@ -580,17 +576,15 @@ def update_contact(
     Returns:
         Updated contact, or None if not found.
     """
-    if not fields:
-        return get_contact(connection, contact_id)
     allowed = set(Contact.model_fields) - {"id", "created_at"}
     updates = {k: v for k, v in fields.items() if k in allowed}
-    if not updates:
-        return get_contact(connection, contact_id)
     with logfire.span(
         "db.contact.update",
         contact_id=contact_id,
         updated_fields=sorted(updates.keys()),
     ) as span:
+        if not updates:
+            return get_contact(connection, contact_id)
         updates["id"] = contact_id
         query = _build_update("contact", updates, SQL("id = %(id)s"))
         row = connection.execute(query, updates).fetchone()
@@ -767,17 +761,15 @@ def update_workflow(
     Returns:
         Updated workflow, or None if not found.
     """
-    if not fields:
-        return get_workflow(connection, workflow_id)
     allowed = {"name", "objective", "instructions"}
     updates = {k: v for k, v in fields.items() if k in allowed}
-    if not updates:
-        return get_workflow(connection, workflow_id)
     with logfire.span(
         "db.workflow.update",
         workflow_id=workflow_id,
         updated_fields=sorted(updates.keys()),
     ) as span:
+        if not updates:
+            return get_workflow(connection, workflow_id)
         updates["id"] = workflow_id
         query = _build_update("workflow", updates, SQL("id = %(id)s"))
         row = connection.execute(query, updates).fetchone()
@@ -925,14 +917,14 @@ def update_workflow_contact(
     """
     allowed = {"status", "reason"}
     updates = {k: v for k, v in fields.items() if k in allowed}
-    if not updates:
-        return get_workflow_contact(connection, workflow_id, contact_id)
     with logfire.span(
         "db.workflow_contact.update",
         workflow_id=workflow_id,
         contact_id=contact_id,
         updated_fields=sorted(updates.keys()),
     ) as span:
+        if not updates:
+            return get_workflow_contact(connection, workflow_id, contact_id)
         updates["workflow_id"] = workflow_id
         updates["contact_id"] = contact_id
         where = SQL("workflow_id = %(workflow_id)s AND contact_id = %(contact_id)s")
@@ -1255,17 +1247,15 @@ def update_email(
     Returns:
         Updated email, or None if not found.
     """
-    if not fields:
-        return get_email(connection, email_id)
     allowed = {"workflow_id", "is_routed", "status", "contact_id"}
     updates = {k: v for k, v in fields.items() if k in allowed}
-    if not updates:
-        return get_email(connection, email_id)
     with logfire.span(
         "db.email.update",
         email_id=email_id,
         updated_fields=sorted(updates.keys()),
     ) as span:
+        if not updates:
+            return get_email(connection, email_id)
         updates["id"] = email_id
         # email table has no updated_at column -- use raw SQL instead of _build_update
         set_parts = [

--- a/src/mailpilot/settings.py
+++ b/src/mailpilot/settings.py
@@ -146,5 +146,6 @@ def set_setting(key: str, value: object, config_path: Path = CONFIG_PATH) -> Set
     data[key] = value
     updated = Settings(**{k: v for k, v in data.items() if k in Settings.model_fields})
     save_settings(updated, config_path=config_path)
-    logfire.info("config.set", key=key, changed=old_value != value)
+    new_value = updated.model_dump(mode="json").get(key)
+    logfire.info("config.set", key=key, changed=old_value != new_value)
     return updated

--- a/src/mailpilot/settings.py
+++ b/src/mailpilot/settings.py
@@ -11,6 +11,7 @@ import json
 from pathlib import Path
 from typing import Any, Literal
 
+import logfire
 from pydantic import PostgresDsn
 from pydantic_settings import (
     BaseSettings,
@@ -117,3 +118,33 @@ def save_settings(settings: Settings, config_path: Path = CONFIG_PATH) -> None:
 def get_settings() -> Settings:
     """Load settings from the default config path."""
     return load_settings()
+
+
+def set_setting(key: str, value: object, config_path: Path = CONFIG_PATH) -> Settings:
+    """Update a single config key, persist, and emit telemetry.
+
+    Reads the current settings, swaps in ``value`` for ``key``, and writes
+    the result back. Emits ``config.set`` with the key name and whether the
+    value changed. Never logs the value itself (secrets live in this file).
+
+    Args:
+        key: Config field name (must be a valid ``Settings`` field).
+        value: Parsed value to store.
+        config_path: Path to the config file. Defaults to ``~/.mailpilot/config.json``.
+
+    Returns:
+        The updated ``Settings`` instance.
+
+    Raises:
+        KeyError: If ``key`` is not a valid Settings field.
+    """
+    if key not in Settings.model_fields:
+        raise KeyError(key)
+    current = load_settings(config_path=config_path)
+    data = current.model_dump(mode="json")
+    old_value = data.get(key)
+    data[key] = value
+    updated = Settings(**{k: v for k, v in data.items() if k in Settings.model_fields})
+    save_settings(updated, config_path=config_path)
+    logfire.info("config.set", key=key, changed=old_value != value)
+    return updated

--- a/src/mailpilot/sync.py
+++ b/src/mailpilot/sync.py
@@ -63,7 +63,8 @@ def start_sync_loop(connection: psycopg.Connection[dict[str, Any]]) -> None:
     existing = get_sync_status(connection)
     if existing is not None and is_pid_alive(existing.pid):
         logfire.warn(
-            "sync loop already running",
+            "sync.loop.already_running",
+            pid=pid,
             existing_pid=existing.pid,
         )
         raise SystemExit(
@@ -75,7 +76,7 @@ def start_sync_loop(connection: psycopg.Connection[dict[str, Any]]) -> None:
 
     # Register this process.
     upsert_sync_status(connection, pid)
-    logfire.info("sync loop started", pid=pid)
+    logfire.info("sync.loop.start", pid=pid)
     click.echo(f"Sync loop started (pid {pid})")
     click.echo(f"Heartbeat interval: {_HEARTBEAT_INTERVAL}s")
     click.echo("Press Ctrl+C or send SIGTERM to stop")
@@ -83,7 +84,7 @@ def start_sync_loop(connection: psycopg.Connection[dict[str, Any]]) -> None:
     # Signal handlers set the shutdown event.
     def _handle_shutdown(signum: int, frame: object) -> None:
         signal_name = signal.Signals(signum).name
-        logfire.info("shutdown signal received", signal=signum)
+        logfire.info("sync.shutdown.signal_received", pid=pid, signal=signum)
         click.echo(f"\nReceived {signal_name}, shutting down...")
         shutdown_event.set()
 
@@ -96,8 +97,8 @@ def start_sync_loop(connection: psycopg.Connection[dict[str, Any]]) -> None:
             shutdown_event.wait(timeout=_HEARTBEAT_INTERVAL)
             if not shutdown_event.is_set():
                 update_sync_heartbeat(connection)
-                logfire.debug("sync heartbeat", pid=pid)
+                logfire.debug("sync.loop.heartbeat", pid=pid)
     finally:
         delete_sync_status(connection)
-        logfire.info("sync loop stopped", pid=pid)
+        logfire.info("sync.loop.stop", pid=pid)
         click.echo("Sync loop stopped")

--- a/tests/test_database_telemetry.py
+++ b/tests/test_database_telemetry.py
@@ -1,0 +1,139 @@
+"""ADR-07 span-emission contract tests for database.py.
+
+These tests lock the span naming and attribute conventions defined in
+``docs/adr-07-observability-with-logfire.md``. They cover one function per
+pattern shape (create / get-hit / get-miss / list / search / update /
+update-noop / error) rather than every CRUD function, since all functions
+within a shape share the same wrapper.
+"""
+
+import json
+from typing import Any
+
+import psycopg
+import pytest
+from logfire.testing import CaptureLogfire
+
+from conftest import make_test_account, make_test_company, make_test_contact
+from mailpilot.database import (
+    get_account,
+    initialize_database,
+    list_companies,
+    search_companies,
+    update_account,
+    update_contact,
+)
+
+
+def _db_spans(capfire: CaptureLogfire, name: str) -> list[dict[str, Any]]:
+    """Return exported spans with the given name."""
+    return [
+        span
+        for span in capfire.exporter.exported_spans_as_dict()
+        if span["name"] == name
+    ]
+
+
+def test_create_span_sets_entity_id(
+    capfire: CaptureLogfire,
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    spans = _db_spans(capfire, "db.account.create")
+    assert len(spans) == 1
+    attrs = spans[0]["attributes"]
+    assert attrs["email"] == "test@example.com"
+    assert attrs["account_id"] == account.id
+
+
+def test_get_span_hit_true_when_found(
+    capfire: CaptureLogfire,
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    get_account(database_connection, account.id)
+    spans = _db_spans(capfire, "db.account.get")
+    assert len(spans) == 1
+    assert spans[0]["attributes"]["hit"] is True
+
+
+def test_get_span_hit_false_when_missing(
+    capfire: CaptureLogfire,
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    get_account(database_connection, "does-not-exist")
+    spans = _db_spans(capfire, "db.account.get")
+    assert len(spans) == 1
+    assert spans[0]["attributes"]["hit"] is False
+
+
+def test_list_span_sets_count(
+    capfire: CaptureLogfire,
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    make_test_company(database_connection, name="A", domain="a.com")
+    make_test_company(database_connection, name="B", domain="b.com")
+    list_companies(database_connection)
+    spans = _db_spans(capfire, "db.company.list")
+    assert len(spans) == 1
+    assert spans[0]["attributes"]["company_count"] == 2
+
+
+def test_search_span_sets_count(
+    capfire: CaptureLogfire,
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    make_test_company(database_connection, name="Acme", domain="acme.com")
+    make_test_company(database_connection, name="Other", domain="other.com")
+    search_companies(database_connection, query="acme")
+    spans = _db_spans(capfire, "db.company.search")
+    assert len(spans) == 1
+    attrs = spans[0]["attributes"]
+    assert attrs["query"] == "acme"
+    assert attrs["company_count"] == 1
+
+
+def test_update_span_sets_updated_fields_sorted(
+    capfire: CaptureLogfire,
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    update_contact(
+        database_connection,
+        contact.id,
+        last_name="Z",
+        first_name="A",
+    )
+    spans = _db_spans(capfire, "db.contact.update")
+    assert len(spans) == 1
+    attrs = spans[0]["attributes"]
+    assert json.loads(attrs["updated_fields"]) == ["first_name", "last_name"]
+    assert attrs["hit"] is True
+
+
+def test_update_noop_still_emits_span(
+    capfire: CaptureLogfire,
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Empty-update calls must emit a span so the call-site is discoverable."""
+    account = make_test_account(database_connection)
+    update_account(database_connection, account.id)
+    spans = _db_spans(capfire, "db.account.update")
+    assert len(spans) == 1
+    assert json.loads(spans[0]["attributes"]["updated_fields"]) == []
+
+
+def test_initialize_database_error_emits_error_span(capfire: CaptureLogfire):
+    with pytest.raises(SystemExit):
+        initialize_database("postgresql://localhost/mailpilot_does_not_exist_xyz")
+
+    error_spans = _db_spans(capfire, "database connection failed")
+    assert len(error_spans) == 1
+    attrs = error_spans[0]["attributes"]
+    assert attrs["database"] == "mailpilot_does_not_exist_xyz"
+    assert "createdb" in attrs["hint"]
+    assert attrs["logfire.span_type"] == "log"
+
+    schema_spans = _db_spans(capfire, "db.schema.apply")
+    assert len(schema_spans) == 1
+    assert any(e["name"] == "exception" for e in schema_spans[0].get("events", []))

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from mailpilot.settings import Settings, load_settings, save_settings
+from mailpilot.settings import Settings, load_settings, save_settings, set_setting
 
 
 def test_default_settings():
@@ -61,3 +61,30 @@ def test_load_settings_ignores_unknown_keys(tmp_path: Path):
     settings = load_settings(config_path=config_path)
     assert settings.logfire_environment == "production"
     assert not hasattr(settings, "unknown_key")
+
+
+def test_set_setting_persists_value(tmp_path: Path):
+    config_path = tmp_path / "config.json"
+    updated = set_setting("anthropic_api_key", "sk-new", config_path=config_path)
+    assert updated.anthropic_api_key == "sk-new"
+    reloaded = load_settings(config_path=config_path)
+    assert reloaded.anthropic_api_key == "sk-new"
+
+
+def test_set_setting_rejects_unknown_key(tmp_path: Path):
+    config_path = tmp_path / "config.json"
+    with pytest.raises(KeyError):
+        set_setting("not_a_real_field", "x", config_path=config_path)
+
+
+def test_set_setting_preserves_other_fields(tmp_path: Path):
+    config_path = tmp_path / "config.json"
+    save_settings(
+        Settings(anthropic_api_key="sk-keep", logfire_environment="production"),
+        config_path=config_path,
+    )
+    set_setting("anthropic_model", "claude-opus-4-7", config_path=config_path)
+    reloaded = load_settings(config_path=config_path)
+    assert reloaded.anthropic_api_key == "sk-keep"
+    assert reloaded.logfire_environment == "production"
+    assert reloaded.anthropic_model == "claude-opus-4-7"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,8 +2,10 @@
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
+from logfire.testing import CaptureLogfire
 
 from mailpilot.settings import Settings, load_settings, save_settings, set_setting
 
@@ -88,3 +90,54 @@ def test_set_setting_preserves_other_fields(tmp_path: Path):
     assert reloaded.anthropic_api_key == "sk-keep"
     assert reloaded.logfire_environment == "production"
     assert reloaded.anthropic_model == "claude-opus-4-7"
+
+
+def _config_set_logs(capfire: CaptureLogfire) -> list[dict[str, Any]]:
+    return [
+        span
+        for span in capfire.exporter.exported_spans_as_dict()
+        if span["name"] == "config.set"
+    ]
+
+
+def test_set_setting_emits_telemetry_without_value(
+    capfire: CaptureLogfire, tmp_path: Path
+):
+    """config.set must log the key + changed flag but never the value itself."""
+    config_path = tmp_path / "config.json"
+    new_model = "claude-opus-4-7"
+    set_setting("anthropic_model", new_model, config_path=config_path)
+
+    logs = _config_set_logs(capfire)
+    assert len(logs) == 1
+    attrs = logs[0]["attributes"]
+    assert attrs["key"] == "anthropic_model"
+    assert attrs["changed"] is True
+    for attr_value in attrs.values():
+        assert new_model not in str(attr_value)
+
+
+def test_set_setting_does_not_leak_secret_values(
+    capfire: CaptureLogfire, tmp_path: Path
+):
+    """Sanity check: setting a secret must not appear in any exported attribute."""
+    config_path = tmp_path / "config.json"
+    secret = "sk-super-secret-do-not-leak"
+    set_setting("anthropic_api_key", secret, config_path=config_path)
+
+    for span in capfire.exporter.exported_spans_as_dict():
+        for attr_value in span.get("attributes", {}).values():
+            assert secret not in str(attr_value)
+
+
+def test_set_setting_changed_false_when_value_unchanged(
+    capfire: CaptureLogfire, tmp_path: Path
+):
+    config_path = tmp_path / "config.json"
+    set_setting("anthropic_model", "claude-opus-4-7", config_path=config_path)
+    capfire.exporter.clear()
+    set_setting("anthropic_model", "claude-opus-4-7", config_path=config_path)
+
+    logs = _config_set_logs(capfire)
+    assert len(logs) == 1
+    assert logs[0]["attributes"]["changed"] is False


### PR DESCRIPTION
## Summary

Implements P1 and P3 of [docs/logfire-instrumentation-plan.md](docs/logfire-instrumentation-plan.md) per [ADR-07](docs/adr-07-observability-with-logfire.md). Every CLI command that touches the database now produces traces in the Logfire project \`mailpilot\`.

## Changes

**database.py (P1)** -- wrap every CRUD function in \`logfire.span("db.<entity>.<op>", ...)\` with ADR-07 attribute conventions:
- Entity ids set from return values (\`account_id\`, \`company_id\`, \`contact_id\`, \`workflow_id\`, \`email_id\`, \`task_id\`)
- \`hit\` bool on get/update spans (including no-op early-return paths)
- \`<entity>_count\` on list/search spans
- \`updated_fields\` (sorted list) on partial updates
- \`result="success"\` on terminal transition spans (\`activate_workflow\`, \`pause_workflow\`)
- \`logfire.exception\` on the \`psycopg.OperationalError\` path in \`initialize_database\`

**sync.py (P1)** -- rename log events to dot-notation:
- \`sync.loop.start\` / \`sync.loop.stop\` / \`sync.loop.heartbeat\`
- \`sync.shutdown.signal_received\` / \`sync.loop.already_running\`

**settings.py + cli.py (P3)** -- new \`set_setting(key, value)\` helper persists the change and emits \`config.set\` info with \`key\` and \`changed\` (never the value itself). \`cli.py config_set\` delegates to the helper so the CLI stays emission-free per ADR-07.

**cli.py (fix)** -- guard \`configure_logging()\` with \`invoked_subcommand is not None\` to preserve the ~50ms \`--help\`/\`--version\` startup guarantee; remove duplicate calls from \`status\` and \`run\` that were clobbering the \`--debug\` flag.

## Test plan

- [x] \`make check\` -- 128/128 pass, lint + basedpyright clean
- [x] Span contract tests in \`tests/test_database_telemetry.py\` (8 tests covering create/get-hit/get-miss/list/search/update/update-noop/error shapes)
- [x] \`config.set\` telemetry contract tests in \`tests/test_settings.py\` (key logged, value never logged, \`changed=false\` on no-op)
- [ ] Manual smoke: run the account/company/contact CLI commands from the plan doc against the default \`mailpilot\` DB; verify spans appear in Logfire project \`mailpilot\` with the documented attributes

## Follow-ups (still open in the plan)

- P2: \`gmail.py\` spans on every API call
- P2: \`agent/classify.py\` + \`agent/tools.py\` -- blocked on #10 / #11 / #12
- P3 sync-pipeline spans -- bundled into sync-impl issues #8 / #13 / #14