### PR TITLE
feat(cli): implement email subcommands

### DIFF
--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -621,7 +621,6 @@ def email_view(email_id: str) -> None:
         found = get_email(connection, email_id)
         if found is None:
             output_error(f"email not found: {email_id}", "not_found")
-            return
         output(found.model_dump(mode="json"))
     finally:
         connection.close()

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -575,3 +575,53 @@ def contact_import(file: str) -> None:
 @main.group()
 def email() -> None:
     """Manage emails."""
+
+
+@email.command("search")
+@click.argument("query")
+@click.option("--limit", default=100, help="Maximum number of results.")
+def email_search(query: str, limit: int) -> None:
+    """Search emails by subject or body."""
+    from mailpilot.database import initialize_database, search_emails
+
+    connection = initialize_database(_database_url())
+    try:
+        emails = search_emails(connection, query, limit=limit)
+        output({"emails": [e.model_dump(mode="json") for e in emails]})
+    finally:
+        connection.close()
+
+
+@email.command("list")
+@click.option("--limit", default=100, help="Maximum number of results.")
+@click.option("--contact-id", default=None, help="Filter by contact ID.")
+@click.option("--account-id", default=None, help="Filter by account ID.")
+def email_list(limit: int, contact_id: str | None, account_id: str | None) -> None:
+    """List emails with optional filters."""
+    from mailpilot.database import initialize_database, list_emails
+
+    connection = initialize_database(_database_url())
+    try:
+        emails = list_emails(
+            connection, limit=limit, contact_id=contact_id, account_id=account_id
+        )
+        output({"emails": [e.model_dump(mode="json") for e in emails]})
+    finally:
+        connection.close()
+
+
+@email.command("view")
+@click.argument("email_id")
+def email_view(email_id: str) -> None:
+    """View a single email by ID."""
+    from mailpilot.database import get_email, initialize_database
+
+    connection = initialize_database(_database_url())
+    try:
+        found = get_email(connection, email_id)
+        if found is None:
+            output_error(f"email not found: {email_id}", "not_found")
+            return
+        output(found.model_dump(mode="json"))
+    finally:
+        connection.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ from click.testing import CliRunner
 
 from conftest import make_test_settings
 from mailpilot.cli import main
-from mailpilot.models import Account, Company, Contact
+from mailpilot.models import Account, Company, Contact, Email
 
 _NOW = datetime(2024, 1, 1, tzinfo=UTC)
 
@@ -855,3 +855,123 @@ def test_contact_import(
     data = json.loads(result.output)
     assert data["ok"] is True
     assert data["imported"] == 2
+
+
+# -- Email ---------------------------------------------------------------------
+
+
+def _make_email(**overrides: Any) -> Email:
+    defaults: dict[str, Any] = {
+        "id": "01234567-0000-7000-0000-000000000004",
+        "account_id": "01234567-0000-7000-0000-000000000001",
+        "direction": "inbound",
+        "created_at": _NOW,
+    }
+    return Email(**{**defaults, **overrides})
+
+
+def test_email_search(runner: CliRunner, mock_connection: MagicMock) -> None:
+    email = _make_email()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.search_emails", return_value=[email]) as mock_search,
+    ):
+        result = runner.invoke(main, ["email", "search", "hello"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert len(data["emails"]) == 1
+    mock_search.assert_called_once_with(mock_connection, "hello", limit=100)
+
+
+def test_email_search_with_limit(runner: CliRunner, mock_connection: MagicMock) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.search_emails", return_value=[]) as mock_search,
+    ):
+        result = runner.invoke(main, ["email", "search", "hello", "--limit", "10"])
+    assert result.exit_code == 0
+    mock_search.assert_called_once_with(mock_connection, "hello", limit=10)
+
+
+def test_email_list(runner: CliRunner, mock_connection: MagicMock) -> None:
+    email = _make_email()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_emails", return_value=[email]) as mock_list,
+    ):
+        result = runner.invoke(main, ["email", "list"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert len(data["emails"]) == 1
+    mock_list.assert_called_once_with(
+        mock_connection, limit=100, contact_id=None, account_id=None
+    )
+
+
+def test_email_list_empty(runner: CliRunner, mock_connection: MagicMock) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_emails", return_value=[]),
+    ):
+        result = runner.invoke(main, ["email", "list"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["emails"] == []
+
+
+def test_email_list_with_filters(runner: CliRunner, mock_connection: MagicMock) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_emails", return_value=[]) as mock_list,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "email",
+                "list",
+                "--limit",
+                "5",
+                "--contact-id",
+                "cid",
+                "--account-id",
+                "aid",
+            ],
+        )
+    assert result.exit_code == 0
+    mock_list.assert_called_once_with(
+        mock_connection, limit=5, contact_id="cid", account_id="aid"
+    )
+
+
+def test_email_view(runner: CliRunner, mock_connection: MagicMock) -> None:
+    email = _make_email()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_email", return_value=email),
+    ):
+        result = runner.invoke(main, ["email", "view", email.id])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["id"] == email.id
+
+
+def test_email_view_not_found(runner: CliRunner, mock_connection: MagicMock) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_email", return_value=None),
+    ):
+        result = runner.invoke(main, ["email", "view", "nonexistent-id"])
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["ok"] is False
+    assert data["error"] == "not_found"


### PR DESCRIPTION
## Summary

Implement `email` CLI subcommands: `search`, `list`, and `view`.

- `mailpilot email search QUERY [--limit N]` — search emails, JSON array output
- `mailpilot email list [--limit N] [--contact-id ID] [--account-id ID]` — list with filters
- `mailpilot email view ID` — single email JSON, exit 1 if not found

All commands follow lazy import and settings-first conventions.

Resolves #7