### PR TITLE
feat(sync): implement per-account Gmail sync pipeline

### DIFF
--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -11,6 +11,7 @@ Convention:
 """
 
 import uuid
+from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 
@@ -488,6 +489,57 @@ def get_contact_by_email(
         if row is None:
             return None
         return Contact.model_validate(row)
+
+
+def create_or_get_contact_by_email(
+    connection: psycopg.Connection[dict[str, Any]],
+    email: str,
+    first_name: str | None = None,
+    last_name: str | None = None,
+) -> Contact:
+    """Return an existing contact by email, creating one if missing.
+
+    If the contact already exists, backfills ``first_name`` / ``last_name``
+    only when the stored value is NULL and the caller provided one. Existing
+    non-null names are never overwritten.
+
+    Used during inbound sync to resolve a ``From`` header to a contact row
+    without forcing callers to branch on existence.
+
+    Args:
+        connection: Open database connection.
+        email: Contact email address.
+        first_name: Optional first name (from From header display name).
+        last_name: Optional last name (from From header display name).
+
+    Returns:
+        Existing or newly created contact.
+    """
+    with logfire.span("db.contact.create_or_get", email=email) as span:
+        existing = get_contact_by_email(connection, email)
+        if existing is not None:
+            span.set_attribute("created", False)
+            span.set_attribute("contact_id", existing.id)
+            backfill: dict[str, object] = {}
+            if existing.first_name is None and first_name is not None:
+                backfill["first_name"] = first_name
+            if existing.last_name is None and last_name is not None:
+                backfill["last_name"] = last_name
+            if not backfill:
+                return existing
+            updated = update_contact(connection, existing.id, **backfill)
+            return updated if updated is not None else existing
+        domain = email.split("@", 1)[1] if "@" in email else ""
+        created = create_contact(
+            connection,
+            email=email,
+            domain=domain,
+            first_name=first_name,
+            last_name=last_name,
+        )
+        span.set_attribute("created", True)
+        span.set_attribute("contact_id", created.id)
+        return created
 
 
 def list_contacts(
@@ -1033,6 +1085,8 @@ def create_email(
     workflow_id: str | None = None,
     status: str = "received",
     is_routed: bool = False,
+    received_at: datetime | None = None,
+    labels: list[str] | None = None,
 ) -> Email:
     """Create a new email record.
 
@@ -1048,6 +1102,8 @@ def create_email(
         workflow_id: Optional workflow FK.
         status: Email status ("sent" or "received").
         is_routed: Whether the routing pipeline has processed this email.
+        received_at: When Gmail reports the message arrived (UTC datetime).
+        labels: Gmail label IDs attached to the message.
 
     Returns:
         Created email.
@@ -1063,11 +1119,12 @@ def create_email(
             """\
             INSERT INTO email (id, account_id, direction, subject,
                 body_text, gmail_message_id, gmail_thread_id,
-                contact_id, workflow_id, status, is_routed)
+                contact_id, workflow_id, status, is_routed,
+                received_at, labels)
             VALUES (%(id)s, %(account_id)s, %(direction)s,
                 %(subject)s, %(body_text)s, %(gmail_message_id)s,
                 %(gmail_thread_id)s, %(contact_id)s, %(workflow_id)s,
-                %(status)s, %(is_routed)s)
+                %(status)s, %(is_routed)s, %(received_at)s, %(labels)s)
             RETURNING *
             """,
             {
@@ -1082,6 +1139,8 @@ def create_email(
                 "workflow_id": workflow_id,
                 "status": status,
                 "is_routed": is_routed,
+                "received_at": received_at,
+                "labels": Json(labels or []),
             },
         ).fetchone()
         connection.commit()

--- a/src/mailpilot/sync.py
+++ b/src/mailpilot/sync.py
@@ -1,8 +1,10 @@
-"""Sync loop lifecycle: startup, heartbeat, signal handling, shutdown.
+"""Sync loop lifecycle and per-account Gmail sync pipeline.
 
-Runs as a foreground process managed by systemd. The actual Pub/Sub
-subscriber, per-account sync, and watch renewal are not yet implemented --
-this module provides the lifecycle shell that future pipeline code plugs into.
+Runs as a foreground process managed by systemd. Provides the lifecycle
+shell (``start_sync_loop``) plus the per-account sync entry point
+(``sync_account``) that is invoked from the Pub/Sub callback for each
+inbound notification. The Pub/Sub subscriber and watch renewal are not
+yet wired up.
 
 Usage::
 
@@ -16,6 +18,7 @@ from __future__ import annotations
 import os
 import signal
 import threading
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import click
@@ -23,13 +26,29 @@ import logfire
 import psycopg
 
 from mailpilot.database import (
+    create_email,
+    create_or_get_contact_by_email,
     delete_sync_status,
+    get_email_by_gmail_message_id,
+    get_emails_by_gmail_thread_id,
     get_sync_status,
+    update_account,
+    update_email,
     update_sync_heartbeat,
     upsert_sync_status,
 )
+from mailpilot.gmail import (
+    GmailClient,
+    extract_text_from_message,
+    get_message_headers,
+    parse_sender,
+)
+from mailpilot.models import Account, Email
+from mailpilot.settings import Settings
 
 _HEARTBEAT_INTERVAL = 30  # seconds
+_RECENCY_WINDOW = timedelta(days=7)
+_FULL_SYNC_MAX_RESULTS = 100
 
 
 def is_pid_alive(pid: int) -> bool:
@@ -102,3 +121,236 @@ def start_sync_loop(connection: psycopg.Connection[dict[str, Any]]) -> None:
         delete_sync_status(connection)
         logfire.info("sync.loop.stop", pid=pid)
         click.echo("Sync loop stopped")
+
+
+# -- Per-account sync ---------------------------------------------------------
+
+
+def sync_account(
+    connection: psycopg.Connection[dict[str, Any]],
+    account: Account,
+    gmail_client: GmailClient,
+    settings: Settings,
+) -> int:
+    """Sync new inbound messages for a single Gmail account.
+
+    Runs the per-account inbound pipeline (see ``docs/email-flow.md``):
+
+    1. Incremental sync via ``GmailClient.get_history`` when the account
+       has a stored ``gmail_history_id``. Falls back to a full INBOX
+       listing on history 404.
+    2. For each new message: fetch, extract text, auto-resolve the
+       sender to a contact, and store an ``inbound`` email row.
+    3. Apply the 7-day recency gate: messages older than the window land
+       with ``is_routed=True`` / ``workflow_id=NULL``; fresher messages
+       are handed to ``route_email`` for thread matching.
+    4. Update ``gmail_history_id`` and ``last_synced_at`` on the account.
+
+    Args:
+        connection: Open database connection.
+        account: Account to sync.
+        gmail_client: Gmail client scoped to the account.
+        settings: Application settings (reserved for future use).
+
+    Returns:
+        Number of newly stored email rows.
+    """
+    del settings  # reserved for future tuning (recency window, etc.)
+    with logfire.span(
+        "sync.account.run",
+        account_id=account.id,
+        email=account.email,
+    ) as span:
+        try:
+            # Snapshot the mailbox's current historyId BEFORE syncing. Any
+            # message that arrives during this run will still be above this
+            # checkpoint and be picked up on the next incremental sync.
+            checkpoint = gmail_client.get_profile().get("historyId") or ""
+            message_ids, mode = _collect_new_message_ids(account, gmail_client)
+            span.set_attribute("mode", mode)
+            stored = 0
+            for message_id in message_ids:
+                if get_email_by_gmail_message_id(connection, message_id) is not None:
+                    continue
+                message = gmail_client.get_message(message_id)
+                if message is None:
+                    continue
+                _store_inbound_message(connection, account, message)
+                stored += 1
+            update_account(
+                connection,
+                account.id,
+                gmail_history_id=checkpoint or account.gmail_history_id,
+                last_synced_at=datetime.now(UTC),
+            )
+            span.set_attribute("message_count", stored)
+            span.set_attribute("result", "success")
+            return stored
+        except Exception:
+            span.set_attribute("result", "failure")
+            logfire.exception("sync.account.run failed", account_id=account.id)
+            raise
+
+
+def _collect_new_message_ids(
+    account: Account,
+    gmail_client: GmailClient,
+) -> tuple[list[str], str]:
+    """Return message IDs to fetch and the sync mode used.
+
+    Tries incremental sync first when a history ID is known, falling
+    back to a full INBOX listing on a 404. Callers still dedupe against
+    the ``email`` table before fetching, so duplicates within the list
+    (e.g. same message in multiple history records) are harmless.
+    """
+    from googleapiclient.errors import HttpError
+
+    if account.gmail_history_id:
+        try:
+            history = gmail_client.get_history(
+                start_history_id=account.gmail_history_id,
+                history_types=["messageAdded"],
+                label_id="INBOX",
+            )
+        except HttpError as exc:
+            if exc.resp.status != 404:
+                raise
+            logfire.warn(
+                "sync.account.history_fallback",
+                account_id=account.id,
+                old_history_id=account.gmail_history_id,
+            )
+        else:
+            return (_extract_added_message_ids(history), "incremental")
+
+    stubs = gmail_client.list_messages(
+        max_results=_FULL_SYNC_MAX_RESULTS,
+        label_ids=["INBOX"],
+    )
+    ids = [stub["id"] for stub in stubs if stub.get("id")]
+    return (list(dict.fromkeys(ids)), "full")
+
+
+def _extract_added_message_ids(history: list[dict[str, Any]]) -> list[str]:
+    """Pull unique message IDs out of a ``messagesAdded`` history response."""
+    ids: list[str] = []
+    seen: set[str] = set()
+    for record in history:
+        for added in record.get("messagesAdded", []):
+            message_id = added.get("message", {}).get("id")
+            if message_id and message_id not in seen:
+                seen.add(message_id)
+                ids.append(message_id)
+    return ids
+
+
+def _store_inbound_message(
+    connection: psycopg.Connection[dict[str, Any]],
+    account: Account,
+    message: dict[str, Any],
+) -> Email:
+    """Persist a Gmail message as an inbound email and route when fresh."""
+    headers = get_message_headers(message)
+    sender_email, first_name, last_name = parse_sender(headers.get("from", ""))
+    contact = create_or_get_contact_by_email(
+        connection,
+        email=sender_email,
+        first_name=first_name,
+        last_name=last_name,
+    )
+    received_at = _received_at_from_message(message)
+    within_window = (
+        received_at is not None and datetime.now(UTC) - received_at <= _RECENCY_WINDOW
+    )
+    email = create_email(
+        connection,
+        account_id=account.id,
+        direction="inbound",
+        subject=headers.get("subject", ""),
+        body_text=extract_text_from_message(message),
+        gmail_message_id=message.get("id"),
+        gmail_thread_id=message.get("threadId"),
+        contact_id=contact.id,
+        is_routed=not within_window,
+        received_at=received_at,
+        labels=list(message.get("labelIds", [])),
+    )
+    logfire.debug(
+        "sync.account.message_stored",
+        account_id=account.id,
+        email_id=email.id,
+        gmail_message_id=message.get("id"),
+        within_recency_window=within_window,
+    )
+    if within_window:
+        email = route_email(connection, email)
+    return email
+
+
+def _received_at_from_message(message: dict[str, Any]) -> datetime | None:
+    """Parse Gmail's ``internalDate`` (epoch ms string) into a UTC datetime."""
+    raw = message.get("internalDate")
+    if not raw:
+        return None
+    try:
+        ms = int(raw)
+    except TypeError, ValueError:
+        return None
+    return datetime.fromtimestamp(ms / 1000, tz=UTC)
+
+
+# -- Routing ------------------------------------------------------------------
+
+
+def route_email(
+    connection: psycopg.Connection[dict[str, Any]],
+    email: Email,
+) -> Email:
+    """Route an inbound email to a workflow via thread matching.
+
+    Implements step 1 of the ADR-04 routing pipeline. If a prior email
+    in the same Gmail thread has a non-null ``workflow_id``, assign the
+    most recent such workflow and mark the email ``is_routed``. If no
+    thread match exists, the email is left unchanged -- a future
+    classification pass (see ``mailpilot.agent.classify.classify_email``)
+    resolves it.
+
+    Args:
+        connection: Open database connection.
+        email: Newly stored inbound email to route.
+
+    Returns:
+        Possibly updated email (unchanged on no thread match).
+    """
+    with logfire.span(
+        "sync.route_email",
+        email_id=email.id,
+        account_id=email.account_id,
+    ) as span:
+        try:
+            if not email.gmail_thread_id:
+                span.set_attribute("result", "skipped")
+                return email
+            thread_emails = get_emails_by_gmail_thread_id(
+                connection, email.gmail_thread_id
+            )
+            matches = [
+                prior
+                for prior in thread_emails
+                if prior.id != email.id and prior.workflow_id is not None
+            ]
+            if not matches:
+                span.set_attribute("result", "no_match")
+                return email
+            matches.sort(key=lambda e: e.created_at, reverse=True)
+            workflow_id = matches[0].workflow_id
+            updated = update_email(
+                connection, email.id, workflow_id=workflow_id, is_routed=True
+            )
+            span.set_attribute("result", "thread_match")
+            span.set_attribute("workflow_id", workflow_id)
+            return updated if updated is not None else email
+        except Exception:
+            span.set_attribute("result", "failure")
+            logfire.exception("sync.route_email failed", email_id=email.id)
+            raise

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -14,6 +14,7 @@ from conftest import (
 from mailpilot.database import (
     activate_workflow,
     create_email,
+    create_or_get_contact_by_email,
     get_account,
     get_company,
     get_contact,
@@ -183,6 +184,55 @@ def test_get_contact_by_email_not_found(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
     assert get_contact_by_email(database_connection, "nobody@test.com") is None
+
+
+def test_create_or_get_contact_by_email_creates_new(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = create_or_get_contact_by_email(
+        database_connection,
+        email="new@example.com",
+        first_name="Alice",
+        last_name="Smith",
+    )
+    assert contact.email == "new@example.com"
+    assert contact.domain == "example.com"
+    assert contact.first_name == "Alice"
+    assert contact.last_name == "Smith"
+
+
+def test_create_or_get_contact_by_email_returns_existing(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    first = create_or_get_contact_by_email(
+        database_connection, email="dup@example.com", first_name="Bob"
+    )
+    second = create_or_get_contact_by_email(
+        database_connection, email="dup@example.com", first_name="Robert"
+    )
+    assert first.id == second.id
+    # Non-null existing name is not overwritten.
+    assert second.first_name == "Bob"
+
+
+def test_create_or_get_contact_by_email_backfills_null_names(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    created = create_or_get_contact_by_email(
+        database_connection, email="nameless@example.com"
+    )
+    assert created.first_name is None
+    assert created.last_name is None
+
+    backfilled = create_or_get_contact_by_email(
+        database_connection,
+        email="nameless@example.com",
+        first_name="Jane",
+        last_name="Doe",
+    )
+    assert backfilled.id == created.id
+    assert backfilled.first_name == "Jane"
+    assert backfilled.last_name == "Doe"
 
 
 # -- Workflow ------------------------------------------------------------------

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,18 +1,35 @@
-"""Tests for sync status database operations and stale detection."""
+"""Tests for sync status database operations and the per-account sync pipeline."""
 
+import base64
 import os
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from unittest.mock import MagicMock
 
 import psycopg
+from googleapiclient.errors import HttpError
 
+from conftest import (
+    make_test_account,
+    make_test_settings,
+    make_test_workflow,
+)
 from mailpilot.database import (
+    activate_workflow,
+    create_email,
     delete_sync_status,
+    get_contact_by_email,
+    get_email,
+    get_email_by_gmail_message_id,
     get_sync_status,
+    list_emails,
+    update_account,
     update_sync_heartbeat,
+    update_workflow,
     upsert_sync_status,
 )
-from mailpilot.sync import is_pid_alive
+from mailpilot.gmail import GmailClient
+from mailpilot.sync import is_pid_alive, route_email, sync_account
 
 
 def test_upsert_and_get_sync_status(
@@ -83,3 +100,333 @@ def test_heartbeat_staleness(
     status = upsert_sync_status(database_connection, os.getpid())
     stale_threshold = datetime.now(tz=UTC) - timedelta(minutes=2)
     assert status.heartbeat_at > stale_threshold
+
+
+# -- sync_account --------------------------------------------------------------
+
+
+def _epoch_ms(dt: datetime) -> int:
+    return int(dt.timestamp() * 1000)
+
+
+def _make_gmail_message(
+    message_id: str,
+    thread_id: str = "thread-1",
+    from_header: str = "Alice Smith <alice@example.com>",
+    subject: str = "Hello there",
+    body: str = "Body of the email",
+    received_at: datetime | None = None,
+    label_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    received_at = received_at or datetime.now(UTC)
+    body_b64 = base64.urlsafe_b64encode(body.encode()).decode()
+    return {
+        "id": message_id,
+        "threadId": thread_id,
+        "internalDate": str(_epoch_ms(received_at)),
+        "labelIds": label_ids or ["INBOX"],
+        "payload": {
+            "mimeType": "text/plain",
+            "headers": [
+                {"name": "From", "value": from_header},
+                {"name": "Subject", "value": subject},
+            ],
+            "body": {"data": body_b64},
+        },
+    }
+
+
+def _make_mock_client(
+    email: str = "account@example.com",
+) -> tuple[GmailClient, MagicMock]:
+    service = MagicMock()
+    # getProfile returns a history id for post-sync account update.
+    service.users.return_value.getProfile.return_value.execute.return_value = {
+        "emailAddress": email,
+        "historyId": "9999",
+    }
+    client = GmailClient.from_service(email, service)
+    return client, service
+
+
+def _set_list_messages(service: MagicMock, stubs: list[dict[str, str]]) -> None:
+    service.users.return_value.messages.return_value.list.return_value.execute.return_value = {
+        "messages": stubs
+    }
+
+
+def _set_get_messages(
+    service: MagicMock, messages: list[dict[str, Any] | None]
+) -> None:
+    service.users.return_value.messages.return_value.get.return_value.execute.side_effect = messages
+
+
+def _set_history(
+    service: MagicMock,
+    history_records: list[dict[str, Any]] | None = None,
+    raise_exc: Exception | None = None,
+) -> None:
+    node = service.users.return_value.history.return_value.list.return_value.execute
+    if raise_exc is not None:
+        node.side_effect = raise_exc
+    else:
+        node.return_value = {"history": history_records or []}
+
+
+def _http_error_404() -> HttpError:
+    resp = MagicMock()
+    resp.status = 404
+    resp.reason = "Not Found"
+    return HttpError(resp=resp, content=b'{"error": "history not found"}')
+
+
+def test_sync_account_full_sync_when_no_history_id(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection, email="full@example.com")
+    client, service = _make_mock_client(account.email)
+    _set_list_messages(service, [{"id": "m1", "threadId": "t1"}])
+    _set_get_messages(service, [_make_gmail_message("m1", "t1")])
+
+    stored = sync_account(database_connection, account, client, make_test_settings())
+
+    assert stored == 1
+    email = get_email_by_gmail_message_id(database_connection, "m1")
+    assert email is not None
+    assert email.direction == "inbound"
+    assert email.body_text == "Body of the email"
+    assert email.subject == "Hello there"
+    assert email.labels == ["INBOX"]
+    contact = get_contact_by_email(database_connection, "alice@example.com")
+    assert contact is not None
+    assert contact.first_name == "Alice"
+    assert contact.last_name == "Smith"
+
+
+def test_sync_account_incremental_via_history_api(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection, email="inc@example.com")
+    account = update_account(database_connection, account.id, gmail_history_id="500")
+    assert account is not None
+    client, service = _make_mock_client(account.email)
+    _set_history(
+        service,
+        history_records=[
+            {
+                "id": "600",
+                "messagesAdded": [
+                    {"message": {"id": "mA", "threadId": "tA"}},
+                ],
+            }
+        ],
+    )
+    _set_get_messages(service, [_make_gmail_message("mA", "tA", subject="Incremental")])
+
+    stored = sync_account(database_connection, account, client, make_test_settings())
+
+    assert stored == 1
+    # list_messages must not be invoked on the incremental path.
+    service.users.return_value.messages.return_value.list.assert_not_called()
+    email = get_email_by_gmail_message_id(database_connection, "mA")
+    assert email is not None
+    assert email.subject == "Incremental"
+
+
+def test_sync_account_falls_back_to_full_sync_on_history_404(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection, email="stale@example.com")
+    account = update_account(
+        database_connection, account.id, gmail_history_id="ancient"
+    )
+    assert account is not None
+    client, service = _make_mock_client(account.email)
+    _set_history(service, raise_exc=_http_error_404())
+    _set_list_messages(service, [{"id": "mX", "threadId": "tX"}])
+    _set_get_messages(service, [_make_gmail_message("mX", "tX")])
+
+    stored = sync_account(database_connection, account, client, make_test_settings())
+
+    assert stored == 1
+    # history API was tried first...
+    service.users.return_value.history.return_value.list.assert_called()
+    # ...then full sync kicked in.
+    service.users.return_value.messages.return_value.list.assert_called()
+
+
+def test_sync_account_skips_duplicate_messages(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection, email="dup@example.com")
+    # Pre-seed an email with the same gmail_message_id.
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="old",
+        gmail_message_id="m1",
+        gmail_thread_id="t1",
+    )
+    client, service = _make_mock_client(account.email)
+    _set_list_messages(service, [{"id": "m1", "threadId": "t1"}])
+    # get_message should NOT be called for the duplicate; supply nothing.
+    _set_get_messages(service, [])
+
+    stored = sync_account(database_connection, account, client, make_test_settings())
+
+    assert stored == 0
+    service.users.return_value.messages.return_value.get.assert_not_called()
+
+
+def test_sync_account_recency_gate_marks_old_messages_routed(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection, email="old@example.com")
+    client, service = _make_mock_client(account.email)
+    _set_list_messages(service, [{"id": "old", "threadId": "t-old"}])
+    old_date = datetime.now(UTC) - timedelta(days=30)
+    _set_get_messages(
+        service, [_make_gmail_message("old", "t-old", received_at=old_date)]
+    )
+
+    stored = sync_account(database_connection, account, client, make_test_settings())
+
+    assert stored == 1
+    email = get_email_by_gmail_message_id(database_connection, "old")
+    assert email is not None
+    assert email.is_routed is True
+    assert email.workflow_id is None
+
+
+def test_sync_account_fresh_message_stays_unrouted_without_thread(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection, email="fresh@example.com")
+    client, service = _make_mock_client(account.email)
+    _set_list_messages(service, [{"id": "fresh", "threadId": "t-fresh"}])
+    _set_get_messages(service, [_make_gmail_message("fresh", "t-fresh")])
+
+    sync_account(database_connection, account, client, make_test_settings())
+
+    email = get_email_by_gmail_message_id(database_connection, "fresh")
+    assert email is not None
+    # No prior thread emails, classify not wired up -> deferred.
+    assert email.is_routed is False
+    assert email.workflow_id is None
+
+
+def test_sync_account_auto_creates_contact_only_once(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection, email="dual@example.com")
+    client, service = _make_mock_client(account.email)
+    _set_list_messages(
+        service,
+        [{"id": "m1", "threadId": "t1"}, {"id": "m2", "threadId": "t2"}],
+    )
+    _set_get_messages(
+        service,
+        [
+            _make_gmail_message("m1", "t1", from_header="Bob <bob@example.com>"),
+            _make_gmail_message("m2", "t2", from_header="Bob <bob@example.com>"),
+        ],
+    )
+
+    stored = sync_account(database_connection, account, client, make_test_settings())
+
+    assert stored == 2
+    # Only one contact row for Bob despite two messages.
+    contact = get_contact_by_email(database_connection, "bob@example.com")
+    assert contact is not None
+    emails = list_emails(database_connection, account_id=account.id)
+    assert len(emails) == 2
+    assert all(e.contact_id == contact.id for e in emails)
+
+
+def test_sync_account_updates_account_history_and_last_synced(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection, email="state@example.com")
+    client, service = _make_mock_client(account.email)
+    service.users.return_value.getProfile.return_value.execute.return_value = {
+        "historyId": "12345"
+    }
+    _set_list_messages(service, [])
+    _set_get_messages(service, [])
+
+    before = datetime.now(UTC)
+    sync_account(database_connection, account, client, make_test_settings())
+
+    from mailpilot.database import get_account
+
+    refreshed = get_account(database_connection, account.id)
+    assert refreshed is not None
+    assert refreshed.gmail_history_id == "12345"
+    assert refreshed.last_synced_at is not None
+    assert refreshed.last_synced_at >= before
+
+
+# -- route_email ---------------------------------------------------------------
+
+
+def test_route_email_thread_match_assigns_workflow(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection, email="route@example.com")
+    workflow = make_test_workflow(
+        database_connection, account_id=account.id, workflow_type="inbound"
+    )
+    # Make workflow active so it has a workflow_id we can reuse.
+    update_workflow(
+        database_connection,
+        workflow.id,
+        objective="o",
+        instructions="i",
+    )
+    activate_workflow(database_connection, workflow.id)
+
+    prior = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="prior",
+        gmail_thread_id="thread-xyz",
+        workflow_id=workflow.id,
+        is_routed=True,
+    )
+    assert prior.workflow_id == workflow.id
+
+    new_email = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="reply",
+        gmail_thread_id="thread-xyz",
+    )
+
+    routed = route_email(database_connection, new_email)
+
+    assert routed.workflow_id == workflow.id
+    assert routed.is_routed is True
+
+
+def test_route_email_no_thread_match_leaves_unrouted(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection, email="noroute@example.com")
+    new_email = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="orphan",
+        gmail_thread_id="thread-orphan",
+    )
+
+    routed = route_email(database_connection, new_email)
+
+    assert routed.workflow_id is None
+    assert routed.is_routed is False
+    stored = get_email(database_connection, new_email.id)
+    assert stored is not None
+    assert stored.is_routed is False


### PR DESCRIPTION
Resolves #8

## Summary

- `sync_account(connection, account, gmail_client, settings)` -- full per-account inbound pipeline: incremental sync via History API with `messagesAdded` filter; full INBOX listing on history 404
- `route_email(connection, email)` -- thread-match routing (ADR-04 step 1); unmatched fresh emails leave `is_routed=False` for the future LLM classify pass
- `create_or_get_contact_by_email()` -- upsert: reuses existing contact, backfills null `first_name`/`last_name` from the `From` header display name
- `create_email()` extended with `received_at` and `labels` to store both in one atomic INSERT
- 7-day recency gate: messages older than the window land `is_routed=True` / `workflow_id=NULL`; fresher messages go through `route_email()`
- `historyId` snapshotted from `get_profile()` **before** sync begins, so messages arriving mid-sync are safely caught on the next incremental run
- `logfire.span()` on `sync.account.run` and `sync.route_email` with `result` attribute (`success`/`failure`/`skipped`/`no_match`/`thread_match`)

## Test plan

- [x] `test_sync_account_full_sync_when_no_history_id` -- no history id -> list_messages path
- [x] `test_sync_account_incremental_via_history_api` -- history id present -> get_history, list_messages not called
- [x] `test_sync_account_falls_back_to_full_sync_on_history_404` -- 404 -> full sync fallback
- [x] `test_sync_account_skips_duplicate_messages` -- idempotency via gmail_message_id check
- [x] `test_sync_account_recency_gate_marks_old_messages_routed` -- >7d -> is_routed=True
- [x] `test_sync_account_fresh_message_stays_unrouted_without_thread` -- no prior thread -> is_routed=False
- [x] `test_sync_account_auto_creates_contact_only_once` -- two messages, same sender -> one contact
- [x] `test_sync_account_updates_account_history_and_last_synced` -- account state written
- [x] `test_route_email_thread_match_assigns_workflow` -- prior routed email in thread -> matched
- [x] `test_route_email_no_thread_match_leaves_unrouted` -- no prior thread -> unchanged
- [x] `test_create_or_get_contact_by_email_creates_new`
- [x] `test_create_or_get_contact_by_email_returns_existing`
- [x] `test_create_or_get_contact_by_email_backfills_null_names`
- [x] `make check` -- 148 tests, 0 ruff errors, 0 basedpyright errors