### PR TITLE
feat(cli): add one-shot account sync command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,10 +44,13 @@ The CLI must be LLM Agent friendly: JSON output only. Exit codes must be meaning
 ```
 mailpilot --version
 mailpilot --debug COMMAND
+mailpilot --completion bash|zsh|fish
 
 mailpilot account create --email E [--display-name N]
 mailpilot account list
 mailpilot account view ID
+mailpilot account update ID [--display-name N]
+mailpilot account sync [--account-id ID]
 
 mailpilot company create --domain D [--name N] [opts]
 mailpilot company update ID [--name N]
@@ -90,7 +93,7 @@ mailpilot status
 
 See `src/mailpilot/schema.sql`. Requires PostgreSQL 18. Connection: `database_url` setting (default: `postgresql://localhost/mailpilot`). Schema applied automatically on first connection.
 
-Tables: `account`, `company`, `contact`, `workflow`, `workflow_contact`, `email`, `task`.
+Tables: `account`, `company`, `contact`, `workflow`, `workflow_contact`, `email`, `task`, `sync_status`.
 
 Prefer atomic single-query operations: use `UPDATE ... FROM ... RETURNING` to join, mutate, and return in one round-trip instead of SELECT-then-UPDATE.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ API keys and config stored in `~/.mailpilot/config.json` via `mailpilot config s
 
 - `anthropic_api_key` -- Anthropic Claude API key
 - `anthropic_model` -- Anthropic model ID (default: `claude-sonnet-4-6`)
-- `google_project_id` -- Google Cloud project ID (for Pub/Sub)
+- `google_application_credentials` -- Path to service account JSON (falls back to `GOOGLE_APPLICATION_CREDENTIALS` env var). The file's `project_id` field is the source of truth for the GCP project.
 - `google_pubsub_topic` -- Pub/Sub topic name (default: `gmail-watch`)
 - `google_pubsub_subscription` -- Pub/Sub subscription name (default: `mailpilot-watch`)
 - `database_url` -- PostgreSQL connection (default: `postgresql://localhost/mailpilot`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,15 @@ API keys and config stored in `~/.mailpilot/config.json` via `mailpilot config s
 - `logfire_token` -- Pydantic Logfire token (optional)
 - `logfire_environment` -- deployment environment tag. Literal: `development` | `production` (default: `development`). Tags every span sent to Logfire so traces from dev runs can be filtered out when investigating production behaviour.
 
+### Test Accounts
+
+Two real Google Workspace accounts are provisioned for end-to-end smoke tests against Gmail API:
+
+- `inbound@lab5.ca` -- Inbound (receives messages, used for auto-reply flows)
+- `outbound@lab5.ca` -- Outbound (sends cold email, used for campaign flows)
+
+Both are delegated via the service account in `google_application_credentials` and can be re-created with `mailpilot account create --email ... --display-name ...` after a `make clean`.
+
 ## LLM-First Code Style
 
 - Explicit, fully descriptive names (no abbreviations)

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -273,6 +273,58 @@ def account_update(account_id: str, display_name: str | None) -> None:
         connection.close()
 
 
+@account.command("sync")
+@click.option(
+    "--account-id",
+    default=None,
+    help="Sync only the given account; omit to sync all accounts.",
+)
+def account_sync(account_id: str | None) -> None:
+    """Run a one-shot Gmail sync for one or all accounts."""
+    import logfire
+
+    from mailpilot.database import get_account, initialize_database, list_accounts
+    from mailpilot.gmail import GmailClient
+    from mailpilot.settings import get_settings
+    from mailpilot.sync import sync_account
+
+    settings = get_settings()
+    connection = initialize_database(_database_url())
+    try:
+        if account_id is not None:
+            single = get_account(connection, account_id)
+            if single is None:
+                output_error(f"account not found: {account_id}", "not_found")
+            accounts = [single]
+        else:
+            accounts = list_accounts(connection)
+
+        results: list[dict[str, object]] = []
+        total_stored = 0
+        with logfire.span("cli.account.sync", account_count=len(accounts)):
+            for acc in accounts:
+                row: dict[str, object] = {
+                    "account_id": acc.id,
+                    "email": acc.email,
+                }
+                try:
+                    client = GmailClient(acc.email)
+                    stored = sync_account(connection, acc, client, settings)
+                    row["stored"] = stored
+                    total_stored += stored
+                except Exception as exc:
+                    logfire.exception(
+                        "cli.account.sync.failed",
+                        account_id=acc.id,
+                        email=acc.email,
+                    )
+                    row["error"] = str(exc)
+                results.append(row)
+        output({"results": results, "total_stored": total_stored})
+    finally:
+        connection.close()
+
+
 # -- Company commands ----------------------------------------------------------
 
 

--- a/src/mailpilot/gmail.py
+++ b/src/mailpilot/gmail.py
@@ -1,8 +1,9 @@
 """Gmail API client using service account with domain-wide delegation.
 
-Authentication: service account credentials resolved via
-``GOOGLE_APPLICATION_CREDENTIALS`` env var, falling back to Application
-Default Credentials (ADC). Per-account impersonation via ``.with_subject()``.
+Authentication: service account credentials path resolved from the
+``google_application_credentials`` setting, falling back to the
+``GOOGLE_APPLICATION_CREDENTIALS`` env var. Per-account impersonation via
+``.with_subject()``.
 
 Scope: ``https://www.googleapis.com/auth/gmail.modify``
 """
@@ -63,6 +64,9 @@ def _retry_on_transient(func: Any) -> Any:
 def _resolve_credentials_path() -> str:
     """Resolve the service account credentials file path.
 
+    Reads ``google_application_credentials`` from settings first, then
+    falls back to the ``GOOGLE_APPLICATION_CREDENTIALS`` env var.
+
     Returns:
         Path to the service account JSON file.
 
@@ -71,11 +75,16 @@ def _resolve_credentials_path() -> str:
     """
     import os
 
-    path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
+    from mailpilot.settings import get_settings
+
+    path = get_settings().google_application_credentials
+    if not path:
+        path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
     if not path:
         raise SystemExit(
-            "GOOGLE_APPLICATION_CREDENTIALS env var not set -- "
-            "point it to a service account JSON file"
+            "No service account credentials configured -- set via "
+            "'mailpilot config set google_application_credentials "
+            "/path/to/key.json' or the GOOGLE_APPLICATION_CREDENTIALS env var"
         )
     return path
 
@@ -84,8 +93,8 @@ def build_gmail_service(email: str) -> GmailService:
     """Build a Gmail API service instance with delegated credentials.
 
     Uses service account credentials to impersonate the given email address.
-    Credentials are resolved from ``GOOGLE_APPLICATION_CREDENTIALS`` env var
-    or Application Default Credentials (ADC).
+    Credentials are resolved from the ``google_application_credentials``
+    setting or the ``GOOGLE_APPLICATION_CREDENTIALS`` env var.
 
     Args:
         email: Gmail address to impersonate via domain-wide delegation.

--- a/src/mailpilot/settings.py
+++ b/src/mailpilot/settings.py
@@ -53,7 +53,6 @@ class Settings(BaseSettings):
     logfire_environment: LogfireEnvironment = "development"
     anthropic_api_key: str = ""
     anthropic_model: str = DEFAULT_ANTHROPIC_MODEL
-    google_project_id: str = ""
     google_pubsub_topic: str = "gmail-watch"
     google_pubsub_subscription: str = "mailpilot-watch"
     google_application_credentials: str = ""

--- a/src/mailpilot/settings.py
+++ b/src/mailpilot/settings.py
@@ -56,6 +56,7 @@ class Settings(BaseSettings):
     google_project_id: str = ""
     google_pubsub_topic: str = "gmail-watch"
     google_pubsub_subscription: str = "mailpilot-watch"
+    google_application_credentials: str = ""
 
     @classmethod
     def settings_customise_sources(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -241,6 +241,104 @@ def test_account_update_not_found(
     assert data["error"] == "not_found"
 
 
+# -- account sync --------------------------------------------------------------
+
+
+def test_account_sync_all_accounts(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    acc_a = _make_account(
+        id="01234567-0000-7000-0000-0000000000a1", email="a@example.com"
+    )
+    acc_b = _make_account(
+        id="01234567-0000-7000-0000-0000000000b2", email="b@example.com"
+    )
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_accounts", return_value=[acc_a, acc_b]),
+        patch("mailpilot.gmail.GmailClient") as mock_client_cls,
+        patch("mailpilot.sync.sync_account", side_effect=[3, 5]) as mock_sync,
+    ):
+        result = runner.invoke(main, ["account", "sync"])
+
+    assert result.exit_code == 0, result.output
+    assert mock_client_cls.call_count == 2
+    assert mock_sync.call_count == 2
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["total_stored"] == 8
+    assert [r["email"] for r in data["results"]] == ["a@example.com", "b@example.com"]
+    assert [r["stored"] for r in data["results"]] == [3, 5]
+
+
+def test_account_sync_single_account(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    account = _make_account(email="only@example.com")
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_account", return_value=account) as mock_get,
+        patch("mailpilot.database.list_accounts") as mock_list,
+        patch("mailpilot.gmail.GmailClient"),
+        patch("mailpilot.sync.sync_account", return_value=2),
+    ):
+        result = runner.invoke(main, ["account", "sync", "--account-id", account.id])
+
+    assert result.exit_code == 0, result.output
+    mock_get.assert_called_once_with(mock_connection, account.id)
+    mock_list.assert_not_called()
+    data = json.loads(result.output)
+    assert data["total_stored"] == 2
+    assert len(data["results"]) == 1
+    assert data["results"][0]["email"] == "only@example.com"
+
+
+def test_account_sync_unknown_id(runner: CliRunner, mock_connection: MagicMock) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_account", return_value=None),
+    ):
+        result = runner.invoke(main, ["account", "sync", "--account-id", "missing"])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["ok"] is False
+    assert data["error"] == "not_found"
+
+
+def test_account_sync_error_isolated_per_account(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    acc_a = _make_account(
+        id="01234567-0000-7000-0000-0000000000a1", email="a@example.com"
+    )
+    acc_b = _make_account(
+        id="01234567-0000-7000-0000-0000000000b2", email="b@example.com"
+    )
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_accounts", return_value=[acc_a, acc_b]),
+        patch("mailpilot.gmail.GmailClient"),
+        patch("logfire.exception"),
+        patch(
+            "mailpilot.sync.sync_account",
+            side_effect=[RuntimeError("gmail 500"), 4],
+        ),
+    ):
+        result = runner.invoke(main, ["account", "sync"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["total_stored"] == 4
+    assert data["results"][0]["error"] == "gmail 500"
+    assert "stored" not in data["results"][0]
+    assert data["results"][1]["stored"] == 4
+
+
 # -- company helpers -----------------------------------------------------------
 
 

--- a/tests/test_gmail_utils.py
+++ b/tests/test_gmail_utils.py
@@ -1,12 +1,17 @@
 """Tests for Gmail utility functions (no service/network needed)."""
 
 import base64
+from unittest.mock import patch
 
+import pytest
+
+from mailpilot import gmail
 from mailpilot.gmail import (
     extract_text_from_message,
     get_message_headers,
     parse_sender,
 )
+from mailpilot.settings import Settings
 
 
 def _b64(text: str) -> str:
@@ -164,3 +169,50 @@ def test_parse_sender_three_part_name():
     assert email == "mj@example.com"
     assert first == "Mary"
     assert last == "Jane Watson"
+
+
+# -- credentials resolution ---------------------------------------------------
+
+
+def test_resolve_credentials_path_from_settings(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    settings = Settings(google_application_credentials="/tmp/service-account.json")
+    with patch("mailpilot.settings.get_settings", return_value=settings):
+        assert (
+            gmail._resolve_credentials_path()  # pyright: ignore[reportPrivateUsage]
+            == "/tmp/service-account.json"
+        )
+
+
+def test_resolve_credentials_path_falls_back_to_env(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/env/key.json")
+    settings = Settings(google_application_credentials="")
+    with patch("mailpilot.settings.get_settings", return_value=settings):
+        assert (
+            gmail._resolve_credentials_path()  # pyright: ignore[reportPrivateUsage]
+            == "/env/key.json"
+        )
+
+
+def test_resolve_credentials_path_settings_wins_over_env(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/env/key.json")
+    settings = Settings(google_application_credentials="/cfg/key.json")
+    with patch("mailpilot.settings.get_settings", return_value=settings):
+        assert (
+            gmail._resolve_credentials_path()  # pyright: ignore[reportPrivateUsage]
+            == "/cfg/key.json"
+        )
+
+
+def test_resolve_credentials_path_missing(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    settings = Settings(google_application_credentials="")
+    with (
+        patch("mailpilot.settings.get_settings", return_value=settings),
+        pytest.raises(SystemExit, match="No service account credentials"),
+    ):
+        gmail._resolve_credentials_path()  # pyright: ignore[reportPrivateUsage]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -16,7 +16,6 @@ def test_default_settings():
     assert settings.anthropic_model == "claude-sonnet-4-6"
     assert settings.logfire_environment == "development"
     assert settings.google_pubsub_topic == "gmail-watch"
-    assert settings.google_application_credentials == ""
 
 
 def test_settings_from_kwargs():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -16,6 +16,7 @@ def test_default_settings():
     assert settings.anthropic_model == "claude-sonnet-4-6"
     assert settings.logfire_environment == "development"
     assert settings.google_pubsub_topic == "gmail-watch"
+    assert settings.google_application_credentials == ""
 
 
 def test_settings_from_kwargs():


### PR DESCRIPTION
## Summary

Land the one-shot `mailpilot account sync` command plus the config cleanup needed to run it against real Google Workspace accounts. Resolves #25.

## Changes

- **CLI** (`src/mailpilot/cli.py`) -- new `account sync [--account-id ID]` subcommand. JSON output `{results: [{account_id, email, stored | error}], total_stored}`. Per-account error isolation; full run wrapped in `logfire.span("cli.account.sync")`.
- **Settings** (`src/mailpilot/settings.py`, `src/mailpilot/gmail.py`) -- add `google_application_credentials` setting (path to service-account JSON, falls back to `GOOGLE_APPLICATION_CREDENTIALS` env var). The file's `project_id` field is the source of truth; redundant `google_project_id` setting removed.
- **Docs** (`CLAUDE.md`) -- sync CLI command list with code; document `inbound@lab5.ca` / `outbound@lab5.ca` as delegated smoke-test accounts.
- **Tests** -- 4 CLI tests for sync (all accounts, single account, unknown ID, per-account error isolation) and Gmail credential-resolution tests.

## Behaviour

| Invocation | Effect |
|---|---|
| `mailpilot account sync` | Syncs every account in sequence |
| `mailpilot account sync --account-id ID` | Syncs a single account |

One `GmailClient` is built per account; credentials come from `settings.google_application_credentials` via domain-wide delegation.

## Test plan

- [x] `make check` passes
- [x] Smoke test on real accounts: `make clean`, recreate `inbound@lab5.ca` + `outbound@lab5.ca`, `mailpilot account sync` stored 93 emails (47 + 46), incremental `--account-id` sync returns 0