### PR TITLE
feat(cli): implement workflow subcommands

### DIFF
--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -676,3 +676,223 @@ def email_view(email_id: str) -> None:
         output(found.model_dump(mode="json"))
     finally:
         connection.close()
+
+
+# -- Workflow commands ---------------------------------------------------------
+
+
+@main.group()
+def workflow() -> None:
+    """Manage workflows (inbound + outbound)."""
+
+
+@workflow.command("create")
+@click.option("--name", required=True, help="Workflow name.")
+@click.option(
+    "--type",
+    "workflow_type",
+    required=True,
+    type=click.Choice(["inbound", "outbound"]),
+    help="Workflow direction. Immutable after creation.",
+)
+@click.option("--account-id", required=True, help="Owning Gmail account ID.")
+@click.option("--objective", default=None, help="Workflow objective.")
+@click.option(
+    "--instructions-file",
+    default=None,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to a file with the workflow instructions (system prompt).",
+)
+def workflow_create(
+    name: str,
+    workflow_type: str,
+    account_id: str,
+    objective: str | None,
+    instructions_file: str | None,
+) -> None:
+    """Create a new workflow."""
+    import pathlib
+
+    from mailpilot.database import (
+        create_workflow,
+        initialize_database,
+        update_workflow,
+    )
+
+    connection = initialize_database(_database_url())
+    try:
+        created = create_workflow(
+            connection,
+            name=name,
+            workflow_type=workflow_type,
+            account_id=account_id,
+        )
+        extras: dict[str, object] = {}
+        if objective is not None:
+            extras["objective"] = objective
+        if instructions_file is not None:
+            extras["instructions"] = pathlib.Path(instructions_file).read_text()
+        if extras:
+            updated = update_workflow(connection, created.id, **extras)
+            if updated is not None:
+                created = updated
+        output(created.model_dump(mode="json"))
+    finally:
+        connection.close()
+
+
+@workflow.command("update")
+@click.argument("workflow_id")
+@click.option("--name", default=None, help="Workflow name.")
+@click.option("--objective", default=None, help="Workflow objective.")
+@click.option(
+    "--instructions-file",
+    default=None,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to a file with the workflow instructions (system prompt).",
+)
+def workflow_update(
+    workflow_id: str,
+    name: str | None,
+    objective: str | None,
+    instructions_file: str | None,
+) -> None:
+    """Update a workflow."""
+    import pathlib
+
+    from mailpilot.database import initialize_database, update_workflow
+
+    connection = initialize_database(_database_url())
+    try:
+        fields: dict[str, object] = {}
+        if name is not None:
+            fields["name"] = name
+        if objective is not None:
+            fields["objective"] = objective
+        if instructions_file is not None:
+            fields["instructions"] = pathlib.Path(instructions_file).read_text()
+        updated = update_workflow(connection, workflow_id, **fields)
+        if updated is None:
+            output_error(f"workflow not found: {workflow_id}", "not_found")
+        output(updated.model_dump(mode="json"))
+    finally:
+        connection.close()
+
+
+@workflow.command("search")
+@click.argument("query")
+@click.option("--limit", default=100, help="Maximum results.")
+def workflow_search(query: str, limit: int) -> None:
+    """Search workflows by name or objective."""
+    from mailpilot.database import initialize_database, search_workflows
+
+    connection = initialize_database(_database_url())
+    try:
+        workflows = search_workflows(connection, query, limit=limit)
+        output({"workflows": [w.model_dump(mode="json") for w in workflows]})
+    finally:
+        connection.close()
+
+
+@workflow.command("list")
+@click.option("--account-id", default=None, help="Filter by account ID.")
+def workflow_list(account_id: str | None) -> None:
+    """List workflows."""
+    from mailpilot.database import initialize_database, list_workflows
+
+    connection = initialize_database(_database_url())
+    try:
+        workflows = list_workflows(connection, account_id=account_id)
+        output({"workflows": [w.model_dump(mode="json") for w in workflows]})
+    finally:
+        connection.close()
+
+
+@workflow.command("view")
+@click.argument("workflow_id")
+def workflow_view(workflow_id: str) -> None:
+    """Show a workflow by ID."""
+    from mailpilot.database import get_workflow, initialize_database
+
+    connection = initialize_database(_database_url())
+    try:
+        found = get_workflow(connection, workflow_id)
+        if found is None:
+            output_error(f"workflow not found: {workflow_id}", "not_found")
+        output(found.model_dump(mode="json"))
+    finally:
+        connection.close()
+
+
+@workflow.command("activate")
+@click.argument("workflow_id")
+def workflow_activate(workflow_id: str) -> None:
+    """Activate a workflow (requires non-empty objective and instructions)."""
+    from mailpilot.database import activate_workflow, initialize_database
+
+    connection = initialize_database(_database_url())
+    try:
+        try:
+            activated = activate_workflow(connection, workflow_id)
+        except ValueError as exc:
+            output_error(str(exc), "invalid_state")
+        output(activated.model_dump(mode="json"))
+    finally:
+        connection.close()
+
+
+@workflow.command("pause")
+@click.argument("workflow_id")
+def workflow_pause(workflow_id: str) -> None:
+    """Pause an active workflow."""
+    from mailpilot.database import initialize_database, pause_workflow
+
+    connection = initialize_database(_database_url())
+    try:
+        try:
+            paused = pause_workflow(connection, workflow_id)
+        except ValueError as exc:
+            output_error(str(exc), "invalid_state")
+        output(paused.model_dump(mode="json"))
+    finally:
+        connection.close()
+
+
+@workflow.command("run")
+@click.option("--workflow-id", required=True, help="Workflow ID.")
+@click.option("--contact-id", required=True, help="Contact ID.")
+def workflow_run(workflow_id: str, contact_id: str) -> None:
+    """Invoke the workflow agent for a single contact (outbound only)."""
+    import asyncio
+
+    from mailpilot.agent import invoke_workflow_agent
+    from mailpilot.database import get_contact, get_workflow, initialize_database
+
+    connection = initialize_database(_database_url())
+    try:
+        wf = get_workflow(connection, workflow_id)
+        if wf is None:
+            output_error(f"workflow not found: {workflow_id}", "not_found")
+        if wf.status != "active":
+            output_error(
+                f"workflow is not active (status={wf.status})", "invalid_state"
+            )
+        if wf.type != "outbound":
+            output_error(
+                f"workflow run requires type=outbound (got {wf.type})", "invalid_state"
+            )
+        contact = get_contact(connection, contact_id)
+        if contact is None:
+            output_error(f"contact not found: {contact_id}", "not_found")
+        result = invoke_workflow_agent(wf)
+        if asyncio.iscoroutine(result):
+            asyncio.run(result)
+        output(
+            {
+                "workflow_id": wf.id,
+                "contact_id": contact.id,
+                "status": "invoked",
+            }
+        )
+    finally:
+        connection.close()

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -800,6 +800,38 @@ def list_workflows(
         return workflows
 
 
+def search_workflows(
+    connection: psycopg.Connection[dict[str, Any]],
+    query: str,
+    limit: int = 100,
+) -> list[Workflow]:
+    """Search workflows by name or objective.
+
+    Args:
+        connection: Open database connection.
+        query: Search term (matched against name and objective).
+        limit: Maximum number of results.
+
+    Returns:
+        Matching workflows ordered by name.
+    """
+    with logfire.span("db.workflow.search", query=query, limit=limit) as span:
+        pattern = f"%{query}%"
+        rows = connection.execute(
+            """\
+            SELECT * FROM workflow
+            WHERE LOWER(name) LIKE LOWER(%(pattern)s)
+               OR LOWER(objective) LIKE LOWER(%(pattern)s)
+            ORDER BY LOWER(name)
+            LIMIT %(limit)s
+            """,
+            {"pattern": pattern, "limit": limit},
+        ).fetchall()
+        workflows = [Workflow.model_validate(row) for row in rows]
+        span.set_attribute("workflow_count", len(workflows))
+        return workflows
+
+
 def update_workflow(
     connection: psycopg.Connection[dict[str, Any]],
     workflow_id: str,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ from click.testing import CliRunner
 
 from conftest import make_test_settings
 from mailpilot.cli import main
-from mailpilot.models import Account, Company, Contact, Email
+from mailpilot.models import Account, Company, Contact, Email, Workflow
 
 _NOW = datetime(2024, 1, 1, tzinfo=UTC)
 
@@ -1072,4 +1072,507 @@ def test_email_view_not_found(runner: CliRunner, mock_connection: MagicMock) -> 
     assert result.exit_code == 1
     data = json.loads(result.output)
     assert data["ok"] is False
+    assert data["error"] == "not_found"
+
+
+# -- workflow helpers ----------------------------------------------------------
+
+
+_WORKFLOW_ID = "01234567-0000-7000-0000-000000000005"
+_ACCOUNT_ID = "01234567-0000-7000-0000-000000000001"
+_CONTACT_ID = "01234567-0000-7000-0000-000000000006"
+
+
+def _make_workflow(**overrides: Any) -> Workflow:
+    defaults: dict[str, Any] = {
+        "id": _WORKFLOW_ID,
+        "name": "Demo outreach",
+        "type": "outbound",
+        "account_id": _ACCOUNT_ID,
+        "status": "draft",
+        "objective": "",
+        "instructions": "",
+        "created_at": _NOW,
+        "updated_at": _NOW,
+    }
+    return Workflow(**{**defaults, **overrides})
+
+
+# -- workflow create -----------------------------------------------------------
+
+
+def test_workflow_create(runner: CliRunner, mock_connection: MagicMock) -> None:
+    workflow = _make_workflow()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch(
+            "mailpilot.database.create_workflow", return_value=workflow
+        ) as mock_create,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "workflow",
+                "create",
+                "--name",
+                "Demo outreach",
+                "--type",
+                "outbound",
+                "--account-id",
+                _ACCOUNT_ID,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_create.assert_called_once_with(
+        mock_connection,
+        name="Demo outreach",
+        workflow_type="outbound",
+        account_id=_ACCOUNT_ID,
+    )
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["id"] == workflow.id
+    assert data["type"] == "outbound"
+
+
+def test_workflow_create_with_objective_and_instructions(
+    runner: CliRunner, mock_connection: MagicMock, tmp_path: pathlib.Path
+) -> None:
+    workflow = _make_workflow(
+        objective="Book demo", instructions="You are a sales rep."
+    )
+    instructions_file = tmp_path / "instructions.md"
+    instructions_file.write_text("You are a sales rep.")
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.create_workflow", return_value=_make_workflow()),
+        patch(
+            "mailpilot.database.update_workflow", return_value=workflow
+        ) as mock_update,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "workflow",
+                "create",
+                "--name",
+                "Demo outreach",
+                "--type",
+                "outbound",
+                "--account-id",
+                _ACCOUNT_ID,
+                "--objective",
+                "Book demo",
+                "--instructions-file",
+                str(instructions_file),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_update.assert_called_once_with(
+        mock_connection,
+        _WORKFLOW_ID,
+        objective="Book demo",
+        instructions="You are a sales rep.",
+    )
+    data = json.loads(result.output)
+    assert data["objective"] == "Book demo"
+    assert data["instructions"] == "You are a sales rep."
+
+
+def test_workflow_create_rejects_invalid_type(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    result = runner.invoke(
+        main,
+        [
+            "workflow",
+            "create",
+            "--name",
+            "Bad",
+            "--type",
+            "sideways",
+            "--account-id",
+            _ACCOUNT_ID,
+        ],
+    )
+    assert result.exit_code != 0
+
+
+# -- workflow update -----------------------------------------------------------
+
+
+def test_workflow_update_name(runner: CliRunner, mock_connection: MagicMock) -> None:
+    updated = _make_workflow(name="Renamed")
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch(
+            "mailpilot.database.update_workflow", return_value=updated
+        ) as mock_update,
+    ):
+        result = runner.invoke(
+            main, ["workflow", "update", _WORKFLOW_ID, "--name", "Renamed"]
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_update.assert_called_once_with(mock_connection, _WORKFLOW_ID, name="Renamed")
+    data = json.loads(result.output)
+    assert data["name"] == "Renamed"
+
+
+def test_workflow_update_with_instructions_file(
+    runner: CliRunner, mock_connection: MagicMock, tmp_path: pathlib.Path
+) -> None:
+    instructions_file = tmp_path / "instructions.md"
+    instructions_file.write_text("Reply politely.")
+    updated = _make_workflow(instructions="Reply politely.")
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch(
+            "mailpilot.database.update_workflow", return_value=updated
+        ) as mock_update,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "workflow",
+                "update",
+                _WORKFLOW_ID,
+                "--instructions-file",
+                str(instructions_file),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_update.assert_called_once_with(
+        mock_connection, _WORKFLOW_ID, instructions="Reply politely."
+    )
+
+
+def test_workflow_update_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.update_workflow", return_value=None),
+    ):
+        result = runner.invoke(main, ["workflow", "update", "nope", "--name", "X"])
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+
+
+# -- workflow list / view / search ---------------------------------------------
+
+
+def test_workflow_list(runner: CliRunner, mock_connection: MagicMock) -> None:
+    workflows = [_make_workflow(id="id-1"), _make_workflow(id="id-2", name="Other")]
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_workflows", return_value=workflows) as mock_list,
+    ):
+        result = runner.invoke(main, ["workflow", "list"])
+
+    assert result.exit_code == 0
+    mock_list.assert_called_once_with(mock_connection, account_id=None)
+    data = json.loads(result.output)
+    assert len(data["workflows"]) == 2
+
+
+def test_workflow_list_by_account(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_workflows", return_value=[]) as mock_list,
+    ):
+        result = runner.invoke(main, ["workflow", "list", "--account-id", _ACCOUNT_ID])
+
+    assert result.exit_code == 0
+    mock_list.assert_called_once_with(mock_connection, account_id=_ACCOUNT_ID)
+
+
+def test_workflow_view(runner: CliRunner, mock_connection: MagicMock) -> None:
+    workflow = _make_workflow()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_workflow", return_value=workflow),
+    ):
+        result = runner.invoke(main, ["workflow", "view", _WORKFLOW_ID])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["id"] == _WORKFLOW_ID
+
+
+def test_workflow_view_not_found(runner: CliRunner, mock_connection: MagicMock) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_workflow", return_value=None),
+    ):
+        result = runner.invoke(main, ["workflow", "view", "nope"])
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+
+
+def test_workflow_search(runner: CliRunner, mock_connection: MagicMock) -> None:
+    workflows = [_make_workflow(name="Demo")]
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch(
+            "mailpilot.database.search_workflows", return_value=workflows
+        ) as mock_search,
+    ):
+        result = runner.invoke(main, ["workflow", "search", "demo", "--limit", "5"])
+
+    assert result.exit_code == 0
+    mock_search.assert_called_once_with(mock_connection, "demo", limit=5)
+    data = json.loads(result.output)
+    assert len(data["workflows"]) == 1
+
+
+# -- workflow activate / pause -------------------------------------------------
+
+
+def test_workflow_activate(runner: CliRunner, mock_connection: MagicMock) -> None:
+    activated = _make_workflow(
+        status="active",
+        objective="Book demo",
+        instructions="You are a sales rep.",
+    )
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch(
+            "mailpilot.database.activate_workflow", return_value=activated
+        ) as mock_activate,
+    ):
+        result = runner.invoke(main, ["workflow", "activate", _WORKFLOW_ID])
+
+    assert result.exit_code == 0, result.output
+    mock_activate.assert_called_once_with(mock_connection, _WORKFLOW_ID)
+    data = json.loads(result.output)
+    assert data["status"] == "active"
+
+
+def test_workflow_activate_missing_objective(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch(
+            "mailpilot.database.activate_workflow",
+            side_effect=ValueError("objective must be non-empty to activate"),
+        ),
+    ):
+        result = runner.invoke(main, ["workflow", "activate", _WORKFLOW_ID])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["ok"] is False
+    assert data["error"] == "invalid_state"
+    assert "objective" in data["message"]
+
+
+def test_workflow_pause(runner: CliRunner, mock_connection: MagicMock) -> None:
+    paused = _make_workflow(status="paused")
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.pause_workflow", return_value=paused) as mock_pause,
+    ):
+        result = runner.invoke(main, ["workflow", "pause", _WORKFLOW_ID])
+
+    assert result.exit_code == 0, result.output
+    mock_pause.assert_called_once_with(mock_connection, _WORKFLOW_ID)
+    data = json.loads(result.output)
+    assert data["status"] == "paused"
+
+
+def test_workflow_pause_invalid_state(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch(
+            "mailpilot.database.pause_workflow",
+            side_effect=ValueError("cannot pause workflow in status 'draft'"),
+        ),
+    ):
+        result = runner.invoke(main, ["workflow", "pause", _WORKFLOW_ID])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "invalid_state"
+
+
+# -- workflow run --------------------------------------------------------------
+
+
+def test_workflow_run(runner: CliRunner, mock_connection: MagicMock) -> None:
+    workflow = _make_workflow(
+        status="active",
+        objective="Book demo",
+        instructions="You are a sales rep.",
+    )
+    contact = Contact(
+        id=_CONTACT_ID,
+        email="lead@acme.com",
+        domain="acme.com",
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_workflow", return_value=workflow),
+        patch("mailpilot.database.get_contact", return_value=contact),
+        patch("mailpilot.agent.invoke_workflow_agent") as mock_invoke,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "workflow",
+                "run",
+                "--workflow-id",
+                _WORKFLOW_ID,
+                "--contact-id",
+                _CONTACT_ID,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_invoke.assert_called_once()
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["workflow_id"] == _WORKFLOW_ID
+    assert data["contact_id"] == _CONTACT_ID
+
+
+def test_workflow_run_workflow_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_workflow", return_value=None),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "workflow",
+                "run",
+                "--workflow-id",
+                "nope",
+                "--contact-id",
+                _CONTACT_ID,
+            ],
+        )
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+
+
+def test_workflow_run_requires_active(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    workflow = _make_workflow(status="draft")
+    contact = Contact(
+        id=_CONTACT_ID,
+        email="lead@acme.com",
+        domain="acme.com",
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_workflow", return_value=workflow),
+        patch("mailpilot.database.get_contact", return_value=contact),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "workflow",
+                "run",
+                "--workflow-id",
+                _WORKFLOW_ID,
+                "--contact-id",
+                _CONTACT_ID,
+            ],
+        )
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "invalid_state"
+
+
+def test_workflow_run_requires_outbound(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    workflow = _make_workflow(type="inbound", status="active")
+    contact = Contact(
+        id=_CONTACT_ID,
+        email="lead@acme.com",
+        domain="acme.com",
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_workflow", return_value=workflow),
+        patch("mailpilot.database.get_contact", return_value=contact),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "workflow",
+                "run",
+                "--workflow-id",
+                _WORKFLOW_ID,
+                "--contact-id",
+                _CONTACT_ID,
+            ],
+        )
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "invalid_state"
+
+
+def test_workflow_run_contact_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    workflow = _make_workflow(status="active")
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_workflow", return_value=workflow),
+        patch("mailpilot.database.get_contact", return_value=None),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "workflow",
+                "run",
+                "--workflow-id",
+                _WORKFLOW_ID,
+                "--contact-id",
+                "nope",
+            ],
+        )
+    assert result.exit_code == 1
+    data = json.loads(result.output)
     assert data["error"] == "not_found"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -31,6 +31,7 @@ from mailpilot.database import (
     pause_workflow,
     search_companies,
     search_contacts,
+    search_workflows,
     update_account,
     update_company,
     update_contact,
@@ -365,6 +366,41 @@ def test_list_workflows_by_status(
     assert drafts[0].name == "W2"
     all_workflows = list_workflows(database_connection, account_id=account.id)
     assert len(all_workflows) == 2
+
+
+def test_search_workflows_by_name(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    make_test_workflow(database_connection, account_id=account.id, name="Demo outreach")
+    make_test_workflow(
+        database_connection, account_id=account.id, name="Support auto-reply"
+    )
+    results = search_workflows(database_connection, "demo")
+    assert len(results) == 1
+    assert results[0].name == "Demo outreach"
+
+
+def test_search_workflows_by_objective(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    w1 = make_test_workflow(database_connection, account_id=account.id, name="Alpha")
+    make_test_workflow(database_connection, account_id=account.id, name="Beta")
+    update_workflow(database_connection, w1.id, objective="Book discovery call")
+    results = search_workflows(database_connection, "discovery")
+    assert len(results) == 1
+    assert results[0].id == w1.id
+
+
+def test_search_workflows_respects_limit(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    for i in range(5):
+        make_test_workflow(database_connection, account_id=account.id, name=f"Flow {i}")
+    results = search_workflows(database_connection, "flow", limit=2)
+    assert len(results) == 2
 
 
 # -- Email ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements the full `workflow` CLI group per ADR-03 and ADR-06, and adds
`search_workflows()` to the database layer.

## Changes

- `workflow create --name N --type inbound|outbound --account-id ID [--objective O] [--instructions-file F]`
- `workflow update ID [--name N] [--objective O] [--instructions-file F]`
- `workflow search QUERY [--limit N]`
- `workflow list [--account-id ID]`
- `workflow view ID`
- `workflow activate ID` -- raises with clear JSON error if objective or instructions are empty
- `workflow pause ID`
- `workflow run --workflow-id ID --contact-id ID` -- validates active + outbound, delegates to `invoke_workflow_agent` stub
- `search_workflows(connection, query, limit)` added to `database.py` (name + objective LIKE search)
- 20 CLI tests + 3 database tests added; all 179 tests pass

Resolves #6