### PR TITLE
chore(sync): fix UNIQUE constraint race in sync_account() message dedupe

### DIFF
--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -1119,8 +1119,14 @@ def create_email(
     is_routed: bool = False,
     received_at: datetime | None = None,
     labels: list[str] | None = None,
-) -> Email:
-    """Create a new email record.
+) -> Email | None:
+    """Create a new email record, or return None on gmail_message_id conflict.
+
+    Insert is atomic via ``ON CONFLICT (gmail_message_id) DO NOTHING``, so two
+    concurrent workers attempting to store the same Gmail message will never
+    raise ``UniqueViolation``: one wins and returns the row, the other
+    returns ``None``. Outbound rows with ``gmail_message_id=NULL`` never
+    trigger the conflict (NULLs are distinct under a UNIQUE constraint).
 
     Args:
         connection: Open database connection.
@@ -1138,7 +1144,8 @@ def create_email(
         labels: Gmail label IDs attached to the message.
 
     Returns:
-        Created email.
+        Created email, or None if another worker already stored a row with
+        the same ``gmail_message_id``.
     """
     with logfire.span(
         "db.email.create",
@@ -1157,6 +1164,7 @@ def create_email(
                 %(subject)s, %(body_text)s, %(gmail_message_id)s,
                 %(gmail_thread_id)s, %(contact_id)s, %(workflow_id)s,
                 %(status)s, %(is_routed)s, %(received_at)s, %(labels)s)
+            ON CONFLICT (gmail_message_id) DO NOTHING
             RETURNING *
             """,
             {
@@ -1176,6 +1184,9 @@ def create_email(
             },
         ).fetchone()
         connection.commit()
+        if row is None:
+            span.set_attribute("result", "conflict_skipped")
+            return None
         email = Email.model_validate(row)
         span.set_attribute("email_id", email.id)
         return email

--- a/src/mailpilot/sync.py
+++ b/src/mailpilot/sync.py
@@ -175,7 +175,8 @@ def sync_account(
                 message = gmail_client.get_message(message_id)
                 if message is None:
                     continue
-                _store_inbound_message(connection, account, message)
+                if _store_inbound_message(connection, account, message) is None:
+                    continue
                 stored += 1
             update_account(
                 connection,
@@ -248,8 +249,12 @@ def _store_inbound_message(
     connection: psycopg.Connection[dict[str, Any]],
     account: Account,
     message: dict[str, Any],
-) -> Email:
-    """Persist a Gmail message as an inbound email and route when fresh."""
+) -> Email | None:
+    """Persist a Gmail message as an inbound email and route when fresh.
+
+    Returns None when a concurrent sync_account call for the same account
+    already stored the row (ON CONFLICT DO NOTHING in create_email).
+    """
     headers = get_message_headers(message)
     sender_email, first_name, last_name = parse_sender(headers.get("from", ""))
     contact = create_or_get_contact_by_email(
@@ -275,6 +280,13 @@ def _store_inbound_message(
         received_at=received_at,
         labels=list(message.get("labelIds", [])),
     )
+    if email is None:
+        logfire.debug(
+            "sync.account.message_skipped_conflict",
+            account_id=account.id,
+            gmail_message_id=message.get("id"),
+        )
+        return None
     logfire.debug(
         "sync.account.message_stored",
         account_id=account.id,

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,11 +1,14 @@
 """Integration tests for database CRUD operations (real DB)."""
 
-from typing import Any
+import threading
+from typing import Any, cast
 
 import psycopg
 import pytest
+from psycopg.rows import dict_row
 
 from conftest import (
+    TEST_DATABASE_URL,
     make_test_account,
     make_test_company,
     make_test_contact,
@@ -418,6 +421,7 @@ def test_create_and_list_emails(
         body_text="Hi there",
         gmail_message_id="msg_123",
     )
+    assert email is not None
     assert email.direction == "inbound"
     assert email.subject == "Hello"
     assert email.status == "received"
@@ -440,6 +444,7 @@ def test_create_email_with_explicit_status(
         status="sent",
         is_routed=True,
     )
+    assert email is not None
     assert email.status == "sent"
     assert email.is_routed is True
 
@@ -454,6 +459,7 @@ def test_get_email_by_gmail_message_id(
         direction="inbound",
         gmail_message_id="msg_abc",
     )
+    assert email is not None
     found = get_email_by_gmail_message_id(database_connection, "msg_abc")
     assert found is not None
     assert found.id == email.id
@@ -494,6 +500,8 @@ def test_get_emails_by_gmail_thread_id(
         gmail_thread_id="thread_other",
         subject="Unrelated",
     )
+    assert e1 is not None
+    assert e2 is not None
     results = get_emails_by_gmail_thread_id(database_connection, "thread_abc")
     assert len(results) == 2
     ids = {e.id for e in results}
@@ -516,6 +524,7 @@ def test_update_email(database_connection: psycopg.Connection[dict[str, Any]]):
         direction="inbound",
         gmail_message_id="msg_update",
     )
+    assert email is not None
     assert email.is_routed is False
     assert email.workflow_id is None
 
@@ -536,3 +545,64 @@ def test_update_email_not_found(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
     assert update_email(database_connection, "nonexistent", status="bounced") is None
+
+
+def test_create_email_concurrent_same_gmail_message_id_is_safe(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Concurrent inserts for the same gmail_message_id must not raise.
+
+    Regression guard for issue #24: two workers racing on the same Gmail
+    message must land exactly one row. ON CONFLICT DO NOTHING makes the
+    loser return None instead of raising UniqueViolation.
+    """
+    account = make_test_account(database_connection)
+    account_id = account.id
+    gmail_message_id = "race-msg"
+    thread_count = 2
+    barrier = threading.Barrier(thread_count)
+    results: list[object] = []
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+
+    def worker() -> None:
+        conn = cast(
+            psycopg.Connection[dict[str, Any]],
+            psycopg.connect(TEST_DATABASE_URL, row_factory=dict_row),  # type: ignore[arg-type]
+        )
+        try:
+            barrier.wait(timeout=5)
+            result = create_email(
+                conn,
+                account_id=account_id,
+                direction="inbound",
+                gmail_message_id=gmail_message_id,
+                gmail_thread_id="race-thread",
+            )
+            with lock:
+                results.append(result)
+        except BaseException as exc:
+            with lock:
+                errors.append(exc)
+        finally:
+            conn.close()
+
+    threads = [threading.Thread(target=worker) for _ in range(thread_count)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert errors == []
+    assert len(results) == thread_count
+    winners = [r for r in results if r is not None]
+    losers = [r for r in results if r is None]
+    assert len(winners) == 1
+    assert len(losers) == thread_count - 1
+
+    row = database_connection.execute(
+        "SELECT COUNT(*) AS n FROM email WHERE gmail_message_id = %(gmid)s",
+        {"gmid": gmail_message_id},
+    ).fetchone()
+    assert row is not None
+    assert row["n"] == 1

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -395,6 +395,7 @@ def test_route_email_thread_match_assigns_workflow(
         workflow_id=workflow.id,
         is_routed=True,
     )
+    assert prior is not None
     assert prior.workflow_id == workflow.id
 
     new_email = create_email(
@@ -404,6 +405,7 @@ def test_route_email_thread_match_assigns_workflow(
         subject="reply",
         gmail_thread_id="thread-xyz",
     )
+    assert new_email is not None
 
     routed = route_email(database_connection, new_email)
 
@@ -422,6 +424,7 @@ def test_route_email_no_thread_match_leaves_unrouted(
         subject="orphan",
         gmail_thread_id="thread-orphan",
     )
+    assert new_email is not None
 
     routed = route_email(database_connection, new_email)
 


### PR DESCRIPTION
## Summary

Fix the SELECT-then-INSERT race in `sync_account()` message dedupe by making insertion atomic via `ON CONFLICT DO NOTHING`. Two concurrent invocations for the same account can currently both pass the `get_email_by_gmail_message_id` existence check and race on `create_email`, with one call raising `UniqueViolation` and aborting the whole `sync.account.run` span.

Not urgent today (nothing invokes `sync_account` concurrently for a single account) but must land before #14 wires Pub/Sub notifications through a `ThreadPoolExecutor`.

## Approach

1. Make `create_email` (or an inbound variant) use `INSERT ... ON CONFLICT (gmail_message_id) DO NOTHING RETURNING *`. `None` return means "already stored by a concurrent worker, skip".
2. `sync_account` loop handles the `None` case.
3. Add a concurrency regression test (two threads, same account, same message IDs) asserting no exception and exactly one row.

Resolves #24