### PR TITLE
chore(e2e): add make e2e target and inbound sync smoke test

### DIFF
--- a/makefile
+++ b/makefile
@@ -17,6 +17,12 @@ lint: py-format py-lint py-types ## Lint Python code
 py-test: ## Run tests
 	uv run pytest -x
 
+e2e: ## Run end-to-end tests against the live Gmail API (mailpilot_e2e DB)
+	$(call header,Ensuring mailpilot_e2e database exists)
+	createdb mailpilot_e2e 2>/dev/null || true
+	$(call header,Running e2e tests)
+	uv run pytest -m e2e tests/e2e/ -v
+
 py-types:
 	$(call header,Running basedpyright typecheck)
 	uv run basedpyright

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,10 @@ known-first-party = ["mailpilot"]
 ]
 
 [tool.pytest.ini_options]
+addopts = "-m 'not e2e'"
+markers = [
+    "e2e: end-to-end tests that hit the live Gmail API and a dedicated e2e database (opt-in via 'make e2e' or 'pytest -m e2e')",
+]
 filterwarnings = [
     "ignore::DeprecationWarning",
     "ignore::PendingDeprecationWarning",

--- a/tests/e2e/test_sync_smoke.py
+++ b/tests/e2e/test_sync_smoke.py
@@ -1,0 +1,116 @@
+"""Smoke tests for the inbound sync pipeline against the live Gmail API.
+
+E2E tests are opt-in: ``pytest`` skips them by default via
+``addopts = -m 'not e2e'``. Invoke with ``make e2e`` or
+``uv run pytest -m e2e tests/e2e/``.
+
+Prerequisites:
+
+- ``mailpilot config set google_application_credentials /path/to/key.json``
+  (or ``GOOGLE_APPLICATION_CREDENTIALS`` env var)
+- ``createdb mailpilot_e2e`` (the Makefile target creates it if missing)
+- Service account delegated to ``inbound@lab5.ca``
+"""
+
+import os
+from collections.abc import Iterator
+from typing import Any, cast
+
+import psycopg
+import pytest
+from psycopg.rows import dict_row
+
+from mailpilot.database import create_account, initialize_database, list_accounts
+from mailpilot.gmail import GmailClient
+from mailpilot.models import Account
+from mailpilot.settings import Settings, get_settings
+from mailpilot.sync import sync_account
+
+pytestmark = pytest.mark.e2e
+
+E2E_DATABASE_URL = os.environ.get(
+    "E2E_DATABASE_URL", "postgresql://localhost/mailpilot_e2e"
+)
+INBOUND_EMAIL = "inbound@lab5.ca"
+
+
+def _require_service_account_credentials() -> None:
+    path = get_settings().google_application_credentials or os.environ.get(
+        "GOOGLE_APPLICATION_CREDENTIALS", ""
+    )
+    if not path or not os.path.isfile(path):
+        pytest.skip(
+            "Service account credentials not configured -- set via "
+            "'mailpilot config set google_application_credentials ...' "
+            "or GOOGLE_APPLICATION_CREDENTIALS"
+        )
+
+
+@pytest.fixture(scope="module")
+def e2e_settings() -> Settings:
+    _require_service_account_credentials()
+    return get_settings()
+
+
+@pytest.fixture
+def e2e_database_connection(
+    e2e_settings: Settings,
+) -> Iterator[psycopg.Connection[dict[str, Any]]]:
+    """Yield a connection to ``mailpilot_e2e``. Preserves state across runs."""
+    del e2e_settings  # force skip-on-missing-creds first
+    try:
+        initialize_database(E2E_DATABASE_URL).close()
+    except SystemExit as exc:
+        pytest.skip(f"e2e database unreachable: {exc}")
+    conn = cast(
+        psycopg.Connection[dict[str, Any]],
+        psycopg.connect(E2E_DATABASE_URL, row_factory=dict_row),  # type: ignore[arg-type]
+    )
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def e2e_inbound_account(
+    e2e_database_connection: psycopg.Connection[dict[str, Any]],
+) -> Account:
+    for account in list_accounts(e2e_database_connection):
+        if account.email == INBOUND_EMAIL:
+            return account
+    return create_account(
+        e2e_database_connection, email=INBOUND_EMAIL, display_name="E2E Inbound"
+    )
+
+
+@pytest.fixture
+def e2e_inbound_gmail_client(e2e_settings: Settings) -> GmailClient:
+    del e2e_settings
+    return GmailClient(INBOUND_EMAIL)
+
+
+def test_gmail_profile_reachable(e2e_inbound_gmail_client: GmailClient) -> None:
+    """Service account delegation + Gmail API connectivity for inbound@lab5.ca."""
+    profile = e2e_inbound_gmail_client.get_profile()
+    assert profile.get("emailAddress") == INBOUND_EMAIL
+    assert profile.get("historyId")
+
+
+def test_sync_account_inbound_does_not_raise(
+    e2e_database_connection: psycopg.Connection[dict[str, Any]],
+    e2e_inbound_account: Account,
+    e2e_inbound_gmail_client: GmailClient,
+    e2e_settings: Settings,
+) -> None:
+    """Full sync cycle against the live inbound mailbox: completes without error.
+
+    Regression guard for the pipeline end to end -- Gmail API auth,
+    history/full-sync dispatch, message fetch, and DB insertion. Does
+    not assert a specific row count because the inbox is live.
+    """
+    stored = sync_account(
+        e2e_database_connection,
+        e2e_inbound_account,
+        e2e_inbound_gmail_client,
+        e2e_settings,
+    )
+    assert stored >= 0


### PR DESCRIPTION
## Summary

Adds an opt-in end-to-end test harness that exercises the real Gmail API and a dedicated `mailpilot_e2e` PostgreSQL database, plus a `make e2e` target to run it. Unit/integration tests (`make check`, `make py-test`) remain fast and offline because the `e2e` marker is excluded by default.

## Motivation

Before this change, [PR #37](https://github.com/kborovik/mailpilot/pull/37) (the #24 race fix) was verified only with mock-backed tests. A real-Gmail smoke is a meaningful regression guard for the whole sync pipeline (service-account delegation, history/full-sync dispatch, message fetch, DB insertion) -- and it gives room to add a concurrency smoke against the live mailbox later, once Pub/Sub is wired in.

## What's here

- **Pytest config (`pyproject.toml`)**: register the `e2e` marker and exclude it from default runs via `addopts = -m 'not e2e'`.
- **`make e2e`**: creates `mailpilot_e2e` if missing, then runs `pytest -m e2e tests/e2e/ -v`.
- **`tests/e2e/test_sync_smoke.py`** -- two smokes against `inbound@lab5.ca`:
  1. `test_gmail_profile_reachable` -- verifies delegation + Gmail API connectivity.
  2. `test_sync_account_inbound_does_not_raise` -- full `sync_account` cycle against the live mailbox.
- **Graceful skips**: if `google_application_credentials` is unset or `mailpilot_e2e` is unreachable, e2e tests `pytest.skip` with a clear hint rather than erroring.

## Notes for reviewers

- E2E state is **not** truncated between runs so `gmail_history_id` stays current and syncs remain incremental (fast, cheap). If you want a clean slate: `dropdb mailpilot_e2e && make e2e`.
- Fixtures are inlined in the single smoke module rather than living in `tests/e2e/conftest.py`. A nested conftest collides with the existing `from conftest import ...` pattern used across `tests/`; keeping fixtures local avoids the shadowing until we have enough e2e files to justify reworking the import setup.
- No CI changes; this runs on-demand via `make e2e`. CI without GCP credentials will simply see the suite skip.

## Verification

```
make check   # 179 passed, 2 deselected (e2e filtered)
make e2e     # 2 passed in ~6s against live inbound@lab5.ca
```