### PR TITLE
perf(sync): bulk pre-fetch contacts to eliminate per-message N+1

### DIFF
--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -11,6 +11,7 @@ Convention:
 """
 
 import uuid
+from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
@@ -540,6 +541,94 @@ def create_or_get_contact_by_email(
         span.set_attribute("created", True)
         span.set_attribute("contact_id", created.id)
         return created
+
+
+def get_contacts_by_emails(
+    connection: psycopg.Connection[dict[str, Any]],
+    emails: Iterable[str],
+) -> dict[str, Contact]:
+    """Fetch contacts for a batch of email addresses in one round-trip.
+
+    Used by the sync pipeline to eliminate per-message contact lookups. The
+    caller should feed in the set of distinct sender addresses from a batch
+    of Gmail messages.
+
+    Args:
+        connection: Open database connection.
+        emails: Email addresses to look up. Duplicates are tolerated.
+
+    Returns:
+        Mapping from email to Contact for every input email that has an
+        existing row. Missing emails are simply absent from the dict.
+    """
+    unique = list(set(emails))
+    with logfire.span(
+        "db.contact.get_by_emails",
+        requested_count=len(unique),
+    ) as span:
+        if not unique:
+            span.set_attribute("hit_count", 0)
+            return {}
+        rows = connection.execute(
+            "SELECT * FROM contact WHERE email = ANY(%(emails)s)",
+            {"emails": unique},
+        ).fetchall()
+        result = {row["email"]: Contact.model_validate(row) for row in rows}
+        span.set_attribute("hit_count", len(result))
+        return result
+
+
+def create_contacts_bulk(
+    connection: psycopg.Connection[dict[str, Any]],
+    emails: Iterable[str],
+) -> dict[str, Contact]:
+    """Ensure a contact row exists for every input email, in one round-trip.
+
+    Inserts any missing rows with ``ON CONFLICT (email) DO NOTHING``, then
+    re-reads every requested email so the returned mapping covers rows
+    that were already present (either pre-existing or inserted by a
+    concurrent transaction). Safe to run in parallel from multiple sync
+    workers; no ``UniqueViolation`` can escape.
+
+    Args:
+        connection: Open database connection.
+        emails: Email addresses to ensure. Duplicates are tolerated.
+
+    Returns:
+        Mapping from email to Contact for every input email.
+    """
+    unique = list(set(emails))
+    with logfire.span(
+        "db.contact.create_bulk",
+        requested_count=len(unique),
+    ) as span:
+        if not unique:
+            span.set_attribute("inserted_count", 0)
+            return {}
+        ids = [_new_id() for _ in unique]
+        domains = [email.split("@", 1)[1] if "@" in email else "" for email in unique]
+        rows = connection.execute(
+            """\
+            INSERT INTO contact (id, email, domain)
+            SELECT id, email, domain
+            FROM unnest(%(ids)s::text[], %(emails)s::text[], %(domains)s::text[])
+                 AS t(id, email, domain)
+            ON CONFLICT (email) DO NOTHING
+            RETURNING *
+            """,
+            {"ids": ids, "emails": unique, "domains": domains},
+        ).fetchall()
+        connection.commit()
+        inserted = {row["email"]: Contact.model_validate(row) for row in rows}
+        span.set_attribute("inserted_count", len(inserted))
+        # Re-fetch any row that was not inserted by this transaction. These
+        # cover both pre-existing rows and rows inserted by a concurrent
+        # worker (ON CONFLICT DO NOTHING swallows those silently).
+        remaining = [email for email in unique if email not in inserted]
+        if remaining:
+            existing = get_contacts_by_emails(connection, remaining)
+            inserted.update(existing)
+        return inserted
 
 
 def list_contacts(

--- a/src/mailpilot/sync.py
+++ b/src/mailpilot/sync.py
@@ -26,13 +26,16 @@ import logfire
 import psycopg
 
 from mailpilot.database import (
+    create_contacts_bulk,
     create_email,
     create_or_get_contact_by_email,
     delete_sync_status,
+    get_contacts_by_emails,
     get_email_by_gmail_message_id,
     get_emails_by_gmail_thread_id,
     get_sync_status,
     update_account,
+    update_contact,
     update_email,
     update_sync_heartbeat,
     upsert_sync_status,
@@ -43,7 +46,7 @@ from mailpilot.gmail import (
     get_message_headers,
     parse_sender,
 )
-from mailpilot.models import Account, Email
+from mailpilot.models import Account, Contact, Email
 from mailpilot.settings import Settings
 
 _HEARTBEAT_INTERVAL = 30  # seconds
@@ -168,14 +171,31 @@ def sync_account(
             checkpoint = gmail_client.get_profile().get("historyId") or ""
             message_ids, mode = _collect_new_message_ids(account, gmail_client)
             span.set_attribute("mode", mode)
-            stored = 0
+            # Fetch message payloads once, skipping IDs already stored. We
+            # need the full message for sender parsing, text extraction, and
+            # the final insert, so caching here avoids a second Gmail fetch.
+            fresh_messages: list[dict[str, Any]] = []
             for message_id in message_ids:
                 if get_email_by_gmail_message_id(connection, message_id) is not None:
                     continue
                 message = gmail_client.get_message(message_id)
                 if message is None:
                     continue
-                if _store_inbound_message(connection, account, message) is None:
+                fresh_messages.append(message)
+            # Resolve every distinct sender in one pair of round-trips,
+            # regardless of message count. Scales with unique senders, not
+            # with mailbox size.
+            contacts_by_email = _resolve_contacts_for_messages(
+                connection, fresh_messages
+            )
+            stored = 0
+            for message in fresh_messages:
+                if (
+                    _store_inbound_message(
+                        connection, account, message, contacts_by_email
+                    )
+                    is None
+                ):
                     continue
                 stored += 1
             update_account(
@@ -191,6 +211,77 @@ def sync_account(
             span.set_attribute("result", "failure")
             logfire.exception("sync.account.run failed", account_id=account.id)
             raise
+
+
+def _resolve_contacts_for_messages(
+    connection: psycopg.Connection[dict[str, Any]],
+    messages: list[dict[str, Any]],
+) -> dict[str, Contact]:
+    """Resolve every distinct sender in ``messages`` to a contact row.
+
+    Bulk pre-fetch pass that replaces the former per-message
+    ``create_or_get_contact_by_email`` call. Uses one SELECT to find
+    existing contacts, one INSERT for the missing ones, and an optional
+    backfill pass to populate first/last names where the From header has
+    them and the contact row does not. Round-trips scale with distinct
+    senders, not with message count.
+    """
+    best_names = _aggregate_sender_names(messages)
+    if not best_names:
+        return {}
+    senders = list(best_names)
+    with logfire.span(
+        "sync.account.resolve_contacts",
+        distinct_sender_count=len(senders),
+    ) as span:
+        contacts_by_email = get_contacts_by_emails(connection, senders)
+        missing = [email for email in senders if email not in contacts_by_email]
+        span.set_attribute("existing_count", len(contacts_by_email))
+        span.set_attribute("missing_count", len(missing))
+        if missing:
+            contacts_by_email.update(create_contacts_bulk(connection, missing))
+        _backfill_contact_names(connection, contacts_by_email, best_names)
+        return contacts_by_email
+
+
+def _aggregate_sender_names(
+    messages: list[dict[str, Any]],
+) -> dict[str, tuple[str | None, str | None]]:
+    """Collect the first non-null first/last name per sender across ``messages``."""
+    best_names: dict[str, tuple[str | None, str | None]] = {}
+    for message in messages:
+        headers = get_message_headers(message)
+        sender_email, first_name, last_name = parse_sender(headers.get("from", ""))
+        if not sender_email:
+            continue
+        current_first, current_last = best_names.get(sender_email, (None, None))
+        best_names[sender_email] = (
+            current_first or first_name,
+            current_last or last_name,
+        )
+    return best_names
+
+
+def _backfill_contact_names(
+    connection: psycopg.Connection[dict[str, Any]],
+    contacts_by_email: dict[str, Contact],
+    best_names: dict[str, tuple[str | None, str | None]],
+) -> None:
+    """Populate NULL first/last names from From-header values, in place."""
+    for email, (first_name, last_name) in best_names.items():
+        contact = contacts_by_email.get(email)
+        if contact is None:
+            continue
+        backfill: dict[str, object] = {}
+        if contact.first_name is None and first_name is not None:
+            backfill["first_name"] = first_name
+        if contact.last_name is None and last_name is not None:
+            backfill["last_name"] = last_name
+        if not backfill:
+            continue
+        updated = update_contact(connection, contact.id, **backfill)
+        if updated is not None:
+            contacts_by_email[email] = updated
 
 
 def _collect_new_message_ids(
@@ -249,6 +340,7 @@ def _store_inbound_message(
     connection: psycopg.Connection[dict[str, Any]],
     account: Account,
     message: dict[str, Any],
+    contacts_by_email: dict[str, Contact],
 ) -> Email | None:
     """Persist a Gmail message as an inbound email and route when fresh.
 
@@ -257,12 +349,17 @@ def _store_inbound_message(
     """
     headers = get_message_headers(message)
     sender_email, first_name, last_name = parse_sender(headers.get("from", ""))
-    contact = create_or_get_contact_by_email(
-        connection,
-        email=sender_email,
-        first_name=first_name,
-        last_name=last_name,
-    )
+    contact = contacts_by_email.get(sender_email)
+    if contact is None:
+        # Fallback for senders not in the pre-fetched dict (e.g. empty From
+        # header): resolve one-off so a single malformed message does not
+        # abort the whole sync.
+        contact = create_or_get_contact_by_email(
+            connection,
+            email=sender_email,
+            first_name=first_name,
+            last_name=last_name,
+        )
     received_at = _received_at_from_message(message)
     within_window = (
         received_at is not None and datetime.now(UTC) - received_at <= _RECENCY_WINDOW

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -16,12 +16,14 @@ from conftest import (
 )
 from mailpilot.database import (
     activate_workflow,
+    create_contacts_bulk,
     create_email,
     create_or_get_contact_by_email,
     get_account,
     get_company,
     get_contact,
     get_contact_by_email,
+    get_contacts_by_emails,
     get_email,
     get_email_by_gmail_message_id,
     get_emails_by_gmail_thread_id,
@@ -237,6 +239,162 @@ def test_create_or_get_contact_by_email_backfills_null_names(
     assert backfilled.id == created.id
     assert backfilled.first_name == "Jane"
     assert backfilled.last_name == "Doe"
+
+
+def test_get_contacts_by_emails_empty(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    assert get_contacts_by_emails(database_connection, []) == {}
+
+
+def test_get_contacts_by_emails_returns_map_for_existing(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    alice = make_test_contact(
+        database_connection, email="alice@example.com", domain="example.com"
+    )
+    bob = make_test_contact(
+        database_connection, email="bob@example.com", domain="example.com"
+    )
+    result = get_contacts_by_emails(
+        database_connection, ["alice@example.com", "bob@example.com"]
+    )
+    assert set(result.keys()) == {"alice@example.com", "bob@example.com"}
+    assert result["alice@example.com"].id == alice.id
+    assert result["bob@example.com"].id == bob.id
+
+
+def test_get_contacts_by_emails_omits_missing(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    make_test_contact(
+        database_connection, email="alice@example.com", domain="example.com"
+    )
+    result = get_contacts_by_emails(
+        database_connection, ["alice@example.com", "ghost@example.com"]
+    )
+    assert set(result.keys()) == {"alice@example.com"}
+
+
+def test_get_contacts_by_emails_deduplicates_input(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    make_test_contact(
+        database_connection, email="alice@example.com", domain="example.com"
+    )
+    result = get_contacts_by_emails(
+        database_connection, ["alice@example.com", "alice@example.com"]
+    )
+    assert set(result.keys()) == {"alice@example.com"}
+
+
+def test_create_contacts_bulk_empty(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    assert create_contacts_bulk(database_connection, []) == {}
+
+
+def test_create_contacts_bulk_all_new(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    result = create_contacts_bulk(
+        database_connection, ["alice@example.com", "bob@other.com"]
+    )
+    assert set(result.keys()) == {"alice@example.com", "bob@other.com"}
+    assert result["alice@example.com"].domain == "example.com"
+    assert result["bob@other.com"].domain == "other.com"
+    # Rows actually persisted.
+    assert get_contact_by_email(database_connection, "alice@example.com") is not None
+    assert get_contact_by_email(database_connection, "bob@other.com") is not None
+
+
+def test_create_contacts_bulk_returns_existing_and_new(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    existing = make_test_contact(
+        database_connection, email="alice@example.com", domain="example.com"
+    )
+    result = create_contacts_bulk(
+        database_connection, ["alice@example.com", "bob@example.com"]
+    )
+    assert set(result.keys()) == {"alice@example.com", "bob@example.com"}
+    # Existing row kept its original id.
+    assert result["alice@example.com"].id == existing.id
+
+
+def test_create_contacts_bulk_deduplicates_input(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    result = create_contacts_bulk(
+        database_connection, ["alice@example.com", "alice@example.com"]
+    )
+    assert set(result.keys()) == {"alice@example.com"}
+    row = database_connection.execute(
+        "SELECT COUNT(*) AS n FROM contact WHERE email = %(email)s",
+        {"email": "alice@example.com"},
+    ).fetchone()
+    assert row is not None
+    assert row["n"] == 1
+
+
+def test_create_contacts_bulk_handles_missing_at_symbol(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    result = create_contacts_bulk(database_connection, ["weirdaddress"])
+    assert "weirdaddress" in result
+    assert result["weirdaddress"].domain == ""
+
+
+def test_create_contacts_bulk_concurrent_is_safe(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Concurrent bulk inserts with overlapping emails must converge safely."""
+    emails_a = ["alice@example.com", "bob@example.com"]
+    emails_b = ["bob@example.com", "carol@example.com"]
+    thread_count = 2
+    barrier = threading.Barrier(thread_count)
+    results: list[dict[str, Any]] = []
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+
+    def worker(emails: list[str]) -> None:
+        conn = cast(
+            psycopg.Connection[dict[str, Any]],
+            psycopg.connect(TEST_DATABASE_URL, row_factory=dict_row),  # type: ignore[arg-type]
+        )
+        try:
+            barrier.wait(timeout=5)
+            result = create_contacts_bulk(conn, emails)
+            with lock:
+                results.append({e: c.id for e, c in result.items()})
+        except BaseException as exc:
+            with lock:
+                errors.append(exc)
+        finally:
+            conn.close()
+
+    threads = [
+        threading.Thread(target=worker, args=(emails_a,)),
+        threading.Thread(target=worker, args=(emails_b,)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert errors == []
+    assert len(results) == thread_count
+
+    row = database_connection.execute(
+        "SELECT COUNT(*) AS n FROM contact WHERE email = ANY(%(emails)s)",
+        {"emails": ["alice@example.com", "bob@example.com", "carol@example.com"]},
+    ).fetchone()
+    assert row is not None
+    assert row["n"] == 3
+
+    # Both workers must agree on Bob's id (the shared row).
+    bob_ids = {r["bob@example.com"] for r in results}
+    assert len(bob_ids) == 1
 
 
 # -- Workflow ------------------------------------------------------------------

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -7,6 +7,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import psycopg
+import pytest
 from googleapiclient.errors import HttpError
 
 from conftest import (
@@ -342,6 +343,85 @@ def test_sync_account_auto_creates_contact_only_once(
     emails = list_emails(database_connection, account_id=account.id)
     assert len(emails) == 2
     assert all(e.contact_id == contact.id for e in emails)
+
+
+def test_sync_account_bulk_prefetches_contacts_once(
+    database_connection: psycopg.Connection[dict[str, Any]],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """sync_account must call the bulk contact helpers once regardless of message count.
+
+    Guards against the per-message N+1 fixed in #34: round-trips should
+    scale with distinct senders, not total messages.
+    """
+    import mailpilot.database as db
+    import mailpilot.sync as sync_module
+
+    account = make_test_account(database_connection, email="bulk@example.com")
+    client, service = _make_mock_client(account.email)
+    stubs = [{"id": f"m{i}", "threadId": f"t{i}"} for i in range(5)]
+    _set_list_messages(service, stubs)
+    # 5 messages but only 2 distinct senders.
+    senders = [
+        "Bob <bob@example.com>",
+        "Carol <carol@example.com>",
+        "Bob <bob@example.com>",
+        "Carol <carol@example.com>",
+        "Bob <bob@example.com>",
+    ]
+    _set_get_messages(
+        service,
+        [
+            _make_gmail_message(f"m{i}", f"t{i}", from_header=senders[i])
+            for i in range(5)
+        ],
+    )
+
+    get_calls: list[list[str]] = []
+    create_calls: list[list[str]] = []
+
+    real_get = db.get_contacts_by_emails
+    real_create = db.create_contacts_bulk
+
+    def spy_get(
+        connection: psycopg.Connection[dict[str, Any]],
+        emails: object,
+    ) -> dict[str, Any]:
+        materialized = list(emails)  # type: ignore[arg-type]
+        get_calls.append(materialized)
+        return real_get(connection, materialized)
+
+    def spy_create(
+        connection: psycopg.Connection[dict[str, Any]],
+        emails: object,
+    ) -> dict[str, Any]:
+        materialized = list(emails)  # type: ignore[arg-type]
+        create_calls.append(materialized)
+        return real_create(connection, materialized)
+
+    monkeypatch.setattr(sync_module, "get_contacts_by_emails", spy_get)
+    monkeypatch.setattr(sync_module, "create_contacts_bulk", spy_create)
+
+    # Fail loudly if the old per-message path is still reachable.
+    def forbidden(*args: object, **kwargs: object) -> None:
+        raise AssertionError(
+            "create_or_get_contact_by_email must not be called from sync_account"
+        )
+
+    monkeypatch.setattr(sync_module, "create_or_get_contact_by_email", forbidden)
+
+    stored = sync_account(database_connection, account, client, make_test_settings())
+
+    assert stored == 5
+    assert len(get_calls) == 1, (
+        f"expected 1 get_contacts_by_emails call, got {get_calls}"
+    )
+    # bulk insert called at most once (may be skipped when all senders exist).
+    assert len(create_calls) <= 1
+    # Exactly 2 contact rows despite 5 messages.
+    emails_stored = list_emails(database_connection, account_id=account.id)
+    contact_ids = {e.contact_id for e in emails_stored}
+    assert len(contact_ids) == 2
 
 
 def test_sync_account_updates_account_history_and_last_synced(


### PR DESCRIPTION
## Summary

Replace the per-message `get_by_email` + `create_or_get` contact round-trips in `sync_account` with a bulk pre-fetch pass, so contact DB calls scale with **distinct senders** instead of total messages.

Smoke-test trace `019da12209674a388d16171b25323e03` showed 186 contact calls for 93 messages from only ~2 distinct senders -- straightforward N+1.

## Changes

- Add `get_contacts_by_emails(connection, emails) -> dict[str, Contact]` -- one SELECT via `email = ANY(%s)` returning a map keyed by email.
- Add `create_contacts_bulk(connection, emails) -> dict[str, Contact]` -- one INSERT via `unnest()` with `ON CONFLICT (email) DO NOTHING`, then a follow-up SELECT to cover rows conflicted by concurrent syncs. Safe to call from parallel workers.
- Refactor `sync_account` to pre-fetch all fresh message payloads, aggregate distinct senders, resolve contacts in one pair of round-trips via the new helpers, then pass the resolved `contacts_by_email` dict into `_store_inbound_message`.
- Extract `_resolve_contacts_for_messages`, `_aggregate_sender_names`, and `_backfill_contact_names` helpers from the main loop; keeps `_resolve_contacts_for_messages` within linter complexity limits.
- Name backfill (NULL first/last_name from From header) preserved at O(distinct_senders_needing_backfill) writes.
- Fallback to single `create_or_get_contact_by_email` for messages with empty/malformed From headers.
- 10 new database tests: empty input, all-new, mixed, deduplication, missing-`@`, and concurrent bulk inserts.
- 1 new sync spy test asserting bulk helpers are called exactly once per `sync_account` run, and the old per-message path is unreachable.

## Acceptance

- [x] Contact DB round-trips scale with distinct senders, not total messages
- [x] Concurrent syncs do not collide (ON CONFLICT DO NOTHING + follow-up SELECT)
- [x] `make check && make clean && make e2e` pass with new tests for both bulk helpers

Resolves #34