### PR TITLE
feat(agent): implement LLM email classification

### DIFF
--- a/src/mailpilot/agent/classify.py
+++ b/src/mailpilot/agent/classify.py
@@ -7,6 +7,8 @@ Architecturally separate from the agent to keep concerns distinct.
 
 from __future__ import annotations
 
+import json
+from functools import lru_cache
 from typing import TYPE_CHECKING
 
 import logfire
@@ -20,6 +22,9 @@ if TYPE_CHECKING:
     from mailpilot.settings import Settings
 
 
+_MAX_BODY_CHARS = 16384
+
+
 class ClassificationResult(BaseModel):
     """Structured output returned by the classifier LLM call."""
 
@@ -27,7 +32,7 @@ class ClassificationResult(BaseModel):
     reasoning: str = ""
 
 
-_SYSTEM_PROMPT = """\
+_INSTRUCTIONS = """\
 You route an inbound email to one of the candidate workflows by matching
 the email's content against each workflow's objective.
 
@@ -42,8 +47,14 @@ Candidate workflows will be provided in the user message.
 
 _AGENT: Agent[None, ClassificationResult] = Agent(
     output_type=ClassificationResult,
-    system_prompt=_SYSTEM_PROMPT,
+    instructions=_INSTRUCTIONS,
 )
+
+
+@lru_cache(maxsize=4)
+def _get_model(api_key: str, model_name: str) -> AnthropicModel:
+    """Cache the AnthropicModel/AnthropicProvider pair by (api_key, model_name)."""
+    return AnthropicModel(model_name, provider=AnthropicProvider(api_key=api_key))
 
 
 def classify_email(
@@ -94,13 +105,11 @@ def classify_email(
                 "set it via `mailpilot config set anthropic_api_key ...`",
             )
 
-        model = AnthropicModel(
-            settings.anthropic_model,
-            provider=AnthropicProvider(api_key=settings.anthropic_api_key),
-        )
+        model = _get_model(settings.anthropic_api_key, settings.anthropic_model)
         prompt = _format_prompt(subject, body, sender, active_workflows)
         result = _AGENT.run_sync(prompt, model=model)
         output = result.output
+        span.set_attribute("reasoning", output.reasoning)
         candidate_ids = {workflow.id for workflow in active_workflows}
         if output.workflow_id is None or output.workflow_id not in candidate_ids:
             span.set_attribute("result", "no_match")
@@ -117,14 +126,22 @@ def _format_prompt(
     active_workflows: list[Workflow],
 ) -> str:
     """Render the user prompt for the classifier LLM call."""
-    workflow_lines = "\n".join(
-        f"- id={workflow.id} | name={workflow.name} | objective={workflow.objective}"
-        for workflow in active_workflows
+    workflows_json = json.dumps(
+        [
+            {
+                "id": workflow.id,
+                "name": workflow.name,
+                "objective": workflow.objective,
+            }
+            for workflow in active_workflows
+        ],
+        indent=2,
     )
+    truncated_body = body[:_MAX_BODY_CHARS]
     return (
-        f"Candidate workflows:\n{workflow_lines}\n\n"
+        f"Candidate workflows (JSON):\n{workflows_json}\n\n"
         f"Email:\n"
         f"From: {sender}\n"
         f"Subject: {subject}\n\n"
-        f"{body}"
+        f"{truncated_body}"
     )

--- a/src/mailpilot/agent/classify.py
+++ b/src/mailpilot/agent/classify.py
@@ -9,8 +9,41 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import logfire
+from pydantic import BaseModel
+from pydantic_ai import Agent
+from pydantic_ai.models.anthropic import AnthropicModel
+from pydantic_ai.providers.anthropic import AnthropicProvider
+
 if TYPE_CHECKING:
     from mailpilot.models import Workflow
+    from mailpilot.settings import Settings
+
+
+class ClassificationResult(BaseModel):
+    """Structured output returned by the classifier LLM call."""
+
+    workflow_id: str | None = None
+    reasoning: str = ""
+
+
+_SYSTEM_PROMPT = """\
+You route an inbound email to one of the candidate workflows by matching
+the email's content against each workflow's objective.
+
+Rules:
+- Pick the workflow whose objective is the best semantic match for the email.
+- Return the workflow's exact id in the `workflow_id` field.
+- If no workflow is a clear match, set `workflow_id` to null -- do not guess.
+- Populate `reasoning` with one short sentence explaining the decision.
+
+Candidate workflows will be provided in the user message.
+"""
+
+_AGENT: Agent[None, ClassificationResult] = Agent(
+    output_type=ClassificationResult,
+    system_prompt=_SYSTEM_PROMPT,
+)
 
 
 def classify_email(
@@ -18,6 +51,7 @@ def classify_email(
     body: str,
     sender: str,
     active_workflows: list[Workflow],
+    settings: Settings,
 ) -> str | None:
     """Classify an inbound email to a workflow.
 
@@ -27,14 +61,70 @@ def classify_email(
     - Output: workflow_id or None (unrouted)
     - No tools, no agent -- pure routing decision
 
+    When ``active_workflows`` is empty, the LLM is not invoked and None is
+    returned. If the model hallucinates a ``workflow_id`` not in the
+    candidate set, the result is also coerced to None.
+
     Args:
         subject: Email subject line.
         body: Email body (plain text).
         sender: Sender email address.
-        active_workflows: Active workflows for the account
-            (name, objective).
+        active_workflows: Active workflows for the account (name, objective).
+        settings: Application settings; supplies ``anthropic_api_key`` and
+            ``anthropic_model``.
 
     Returns:
         Workflow ID if classified, None if unrouted.
+
+    Raises:
+        ValueError: If ``settings.anthropic_api_key`` is empty.
     """
-    raise NotImplementedError
+    with logfire.span(
+        "agent.classify_email",
+        sender=sender,
+        candidate_count=len(active_workflows),
+    ) as span:
+        if not active_workflows:
+            span.set_attribute("result", "no_candidates")
+            return None
+
+        if not settings.anthropic_api_key:
+            raise ValueError(
+                "anthropic_api_key is required for classification; "
+                "set it via `mailpilot config set anthropic_api_key ...`",
+            )
+
+        model = AnthropicModel(
+            settings.anthropic_model,
+            provider=AnthropicProvider(api_key=settings.anthropic_api_key),
+        )
+        prompt = _format_prompt(subject, body, sender, active_workflows)
+        result = _AGENT.run_sync(prompt, model=model)
+        output = result.output
+        candidate_ids = {workflow.id for workflow in active_workflows}
+        if output.workflow_id is None or output.workflow_id not in candidate_ids:
+            span.set_attribute("result", "no_match")
+            return None
+        span.set_attribute("result", "match")
+        span.set_attribute("workflow_id", output.workflow_id)
+        return output.workflow_id
+
+
+def _format_prompt(
+    subject: str,
+    body: str,
+    sender: str,
+    active_workflows: list[Workflow],
+) -> str:
+    """Render the user prompt for the classifier LLM call."""
+    workflow_lines = "\n".join(
+        f"- id={workflow.id} | name={workflow.name} | objective={workflow.objective}"
+        for workflow in active_workflows
+    )
+    return (
+        f"Candidate workflows:\n{workflow_lines}\n\n"
+        f"Email:\n"
+        f"From: {sender}\n"
+        f"Subject: {subject}\n\n"
+        f"{body}"
+    )

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -1,0 +1,183 @@
+"""Tests for the LLM-based email classifier (ADR-04 step 2)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from conftest import make_test_settings
+from mailpilot.agent import classify as classify_module
+from mailpilot.agent.classify import classify_email
+from mailpilot.models import Workflow
+
+
+def make_workflow(
+    workflow_id: str,
+    name: str,
+    objective: str,
+    workflow_type: str = "inbound",
+) -> Workflow:
+    now = datetime.now(UTC)
+    return Workflow(
+        id=workflow_id,
+        name=name,
+        type=workflow_type,  # pyright: ignore[reportArgumentType]
+        account_id="account-1",
+        status="active",
+        objective=objective,
+        instructions="",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def function_model_returning(
+    workflow_id: str | None,
+    reasoning: str = "",
+) -> FunctionModel:
+    """Build a FunctionModel that yields a fixed structured-output result.
+
+    Pydantic AI routes structured output through a synthetic
+    ``final_result`` tool call, so tests return a ``ToolCallPart`` the
+    same way the real model would.
+    """
+
+    def _respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        del messages, info
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="final_result",
+                    args={"workflow_id": workflow_id, "reasoning": reasoning},
+                ),
+            ],
+        )
+
+    return FunctionModel(_respond)
+
+
+def run_classify(
+    workflows: list[Workflow],
+    function_model: FunctionModel,
+    subject: str = "Question about pricing",
+    body: str = "Hi, I'd like to know more about your plans.",
+    sender: str = "alice@example.com",
+) -> str | None:
+    """Invoke ``classify_email`` with the agent overridden to a FunctionModel."""
+    settings = make_test_settings(
+        anthropic_api_key="sk-test",
+        anthropic_model="claude-sonnet-4-6",
+    )
+    with classify_module._AGENT.override(model=function_model):  # pyright: ignore[reportPrivateUsage]
+        return classify_email(
+            subject=subject,
+            body=body,
+            sender=sender,
+            active_workflows=workflows,
+            settings=settings,
+        )
+
+
+def test_single_match_returns_workflow_id() -> None:
+    workflow = make_workflow(
+        "wf-sales-1",
+        "Sales inbound",
+        "Handle inbound pricing and demo requests",
+    )
+    result = run_classify(
+        [workflow],
+        function_model_returning(workflow_id="wf-sales-1", reasoning="pricing intent"),
+    )
+    assert result == "wf-sales-1"
+
+
+def test_no_match_returns_none() -> None:
+    workflow = make_workflow(
+        "wf-support-1",
+        "Support",
+        "Answer customer product questions",
+    )
+    result = run_classify(
+        [workflow],
+        function_model_returning(workflow_id=None, reasoning="no topic match"),
+        subject="Interested in partnership",
+        body="We'd like to explore a reseller agreement.",
+    )
+    assert result is None
+
+
+def test_multiple_workflows_clear_winner() -> None:
+    sales = make_workflow(
+        "wf-sales-1",
+        "Sales inbound",
+        "Handle inbound pricing and demo requests",
+    )
+    support = make_workflow(
+        "wf-support-1",
+        "Support",
+        "Answer customer product questions",
+    )
+    partnerships = make_workflow(
+        "wf-partner-1",
+        "Partnerships",
+        "Evaluate reseller and integration partner requests",
+    )
+    result = run_classify(
+        [sales, support, partnerships],
+        function_model_returning(
+            workflow_id="wf-partner-1",
+            reasoning="partnership inquiry",
+        ),
+        subject="Partner proposal",
+        body="We build an analytics tool and want to integrate.",
+    )
+    assert result == "wf-partner-1"
+
+
+def test_empty_workflows_skips_llm_call() -> None:
+    def _should_not_be_called(
+        messages: list[ModelMessage],
+        info: AgentInfo,
+    ) -> ModelResponse:
+        del messages, info
+        raise AssertionError("LLM must not be called when no candidates exist")
+
+    result = run_classify(
+        [],
+        FunctionModel(_should_not_be_called),
+    )
+    assert result is None
+
+
+def test_model_returning_unknown_id_treated_as_no_match() -> None:
+    """A hallucinated workflow_id (not in candidate set) must return None."""
+    workflow = make_workflow(
+        "wf-sales-1",
+        "Sales",
+        "Pricing questions",
+    )
+    result = run_classify(
+        [workflow],
+        function_model_returning(workflow_id="wf-does-not-exist"),
+    )
+    assert result is None
+
+
+def test_missing_api_key_raises(
+    database_connection: Any,  # ensures schema is applied
+) -> None:
+    """Without an Anthropic API key, classification must fail fast."""
+    workflow = make_workflow("wf-1", "Sales", "Pricing")
+    settings = make_test_settings(anthropic_api_key="")
+    with pytest.raises(ValueError, match="anthropic_api_key"):
+        classify_email(
+            subject="hi",
+            body="hello",
+            sender="x@example.com",
+            active_workflows=[workflow],
+            settings=settings,
+        )

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
 
 import pytest
 from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart
@@ -167,9 +166,7 @@ def test_model_returning_unknown_id_treated_as_no_match() -> None:
     assert result is None
 
 
-def test_missing_api_key_raises(
-    database_connection: Any,  # ensures schema is applied
-) -> None:
+def test_missing_api_key_raises() -> None:
     """Without an Anthropic API key, classification must fail fast."""
     workflow = make_workflow("wf-1", "Sales", "Pricing")
     settings = make_test_settings(anthropic_api_key="")


### PR DESCRIPTION
## Summary

Implements the LLM-based email classifier that matches inbound emails to active inbound workflows (step 2 of the ADR-04 routing pipeline, invoked when thread matching fails).

## Scope

- `src/mailpilot/agent/classify.py` -- replace `NotImplementedError` stub with a real `classify_email(subject, body, sender, active_workflows, settings) -> str | None` implementation using Pydantic AI structured output.
- System prompt instructs the model to pick a single best-matching workflow (by objective) or return no match.
- Model selection driven by `settings.anthropic_model` for cost control.
- `tests/test_classify.py` -- new test file covering single match, no match, and multiple workflows with a clear winner; uses `FunctionModel` + `Agent.override()` for deterministic tests without hitting the network.

Landing this unblocks step 2/3 completion of [#9](https://github.com/kborovik/mailpilot/issues/9) (routing pipeline) and keeps the inbound flow on the critical path.

## Test plan

- [x] New `tests/test_classify.py` passes (single match, no match, multi-workflow tie-breaker, hallucination guard, empty candidate short-circuit, missing API key)
- [x] `make check` green (207 passed)
- [ ] `make clean && make e2e` green

Resolves #10