### PR TITLE
feat(sync): implement email routing module (ADR-04)

### DIFF
--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -1053,8 +1053,12 @@ def create_workflow_contact(
     connection: psycopg.Connection[dict[str, Any]],
     workflow_id: str,
     contact_id: str,
-) -> WorkflowContact:
+) -> WorkflowContact | None:
     """Add a contact to a workflow.
+
+    Uses ON CONFLICT DO NOTHING so callers can safely re-invoke without
+    catching unique-constraint errors. Returns None when the row already
+    exists (same pattern as ``create_email``).
 
     Args:
         connection: Open database connection.
@@ -1062,22 +1066,26 @@ def create_workflow_contact(
         contact_id: Contact FK.
 
     Returns:
-        Created workflow-contact link.
+        Created workflow-contact link, or None if it already existed.
     """
     with logfire.span(
         "db.workflow_contact.create",
         workflow_id=workflow_id,
         contact_id=contact_id,
-    ):
+    ) as span:
         row = connection.execute(
             """\
             INSERT INTO workflow_contact (workflow_id, contact_id)
             VALUES (%(workflow_id)s, %(contact_id)s)
+            ON CONFLICT (workflow_id, contact_id) DO NOTHING
             RETURNING *
             """,
             {"workflow_id": workflow_id, "contact_id": contact_id},
         ).fetchone()
         connection.commit()
+        span.set_attribute("created", row is not None)
+        if row is None:
+            return None
         return WorkflowContact.model_validate(row)
 
 

--- a/src/mailpilot/routing.py
+++ b/src/mailpilot/routing.py
@@ -1,0 +1,223 @@
+"""Email routing pipeline (ADR-04).
+
+Three-step pipeline that assigns inbound emails to the correct workflow:
+
+1. **Thread match** -- prior email in same Gmail thread has a workflow_id
+2. **LLM classification** -- single-turn call against active inbound workflows
+3. **Unrouted** -- store with is_routed=True, workflow_id=NULL
+
+Also handles bounce detection (mailer-daemon/postmaster senders and
+bounce-related Gmail labels) and creates ``workflow_contact`` entries
+on successful routing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import logfire
+import psycopg
+
+from mailpilot.agent.classify import classify_email
+from mailpilot.database import (
+    create_workflow_contact,
+    disable_contact,
+    get_emails_by_gmail_thread_id,
+    list_workflows,
+    update_email,
+)
+from mailpilot.models import Email
+from mailpilot.settings import Settings
+
+_BOUNCE_SENDERS = frozenset({"mailer-daemon", "postmaster"})
+
+
+def route_email(
+    connection: psycopg.Connection[dict[str, Any]],
+    email: Email,
+    sender_email: str,
+    settings: Settings,
+) -> Email:
+    """Route an inbound email through the ADR-04 pipeline.
+
+    Runs bounce detection, then the three-step routing pipeline
+    (thread match -> LLM classification -> unrouted). Creates a
+    ``workflow_contact`` entry when routing to a workflow.
+
+    Idempotent: emails with ``is_routed=True`` are returned unchanged.
+
+    Args:
+        connection: Open database connection.
+        email: Newly stored inbound email to route.
+        sender_email: Sender email address (parsed from From header).
+        settings: Application settings (for LLM classification).
+
+    Returns:
+        Updated email with routing decision applied.
+    """
+    with logfire.span(
+        "routing.route_email",
+        email_id=email.id,
+        account_id=email.account_id,
+    ) as span:
+        try:
+            if email.is_routed:
+                span.set_attribute("result", "skipped_already_routed")
+                return email
+
+            if _is_bounce(sender_email, email.labels):
+                span.set_attribute("result", "bounce")
+                return _handle_bounce(connection, email)
+
+            workflow_id = _try_thread_match(connection, email)
+            if workflow_id is not None:
+                span.set_attribute("result", "thread_match")
+                span.set_attribute("workflow_id", workflow_id)
+            else:
+                workflow_id = _try_classify(connection, email, sender_email, settings)
+                if workflow_id is not None:
+                    span.set_attribute("result", "classified")
+                    span.set_attribute("workflow_id", workflow_id)
+                else:
+                    span.set_attribute("result", "unrouted")
+
+            updated = update_email(
+                connection, email.id, workflow_id=workflow_id, is_routed=True
+            )
+            result = updated if updated is not None else email
+
+            if workflow_id is not None and result.contact_id is not None:
+                _ensure_workflow_contact(connection, workflow_id, result.contact_id)
+
+            return result
+        except Exception:
+            span.set_attribute("result", "failure")
+            logfire.exception("routing.route_email failed", email_id=email.id)
+            raise
+
+
+# -- Bounce detection ----------------------------------------------------------
+
+
+def _is_bounce(sender_email: str, labels: list[str]) -> bool:
+    """Check if the email is a bounce notification.
+
+    Detects bounces via two signals:
+    - Sender local part is ``mailer-daemon`` or ``postmaster`` (case-insensitive)
+    - Any Gmail label contains ``BOUNCE`` (case-insensitive substring)
+    """
+    local_part = sender_email.split("@", maxsplit=1)[0].lower() if sender_email else ""
+    if local_part in _BOUNCE_SENDERS:
+        return True
+    return any("BOUNCE" in label.upper() for label in labels)
+
+
+def _handle_bounce(
+    connection: psycopg.Connection[dict[str, Any]],
+    email: Email,
+) -> Email:
+    """Process a bounce notification.
+
+    Finds the original outbound email in the same thread, marks it as
+    bounced, and disables the original recipient contact. The bounce
+    notification itself is marked as routed.
+    """
+    with logfire.span(
+        "routing.handle_bounce",
+        email_id=email.id,
+        gmail_thread_id=email.gmail_thread_id,
+    ):
+        if email.gmail_thread_id:
+            thread_emails = get_emails_by_gmail_thread_id(
+                connection, email.gmail_thread_id
+            )
+            outbound = [
+                e
+                for e in thread_emails
+                if e.id != email.id
+                and e.account_id == email.account_id
+                and e.direction == "outbound"
+            ]
+            if outbound:
+                outbound.sort(key=lambda e: e.created_at, reverse=True)
+                original = outbound[0]
+                update_email(connection, original.id, status="bounced")
+                if original.contact_id is not None:
+                    disable_contact(
+                        connection,
+                        original.contact_id,
+                        status="bounced",
+                        status_reason=f"Bounce detected on email {original.id}",
+                    )
+            else:
+                logfire.warn(
+                    "routing.bounce.no_outbound_in_thread",
+                    email_id=email.id,
+                    gmail_thread_id=email.gmail_thread_id,
+                )
+        else:
+            logfire.warn(
+                "routing.bounce.no_thread_id",
+                email_id=email.id,
+            )
+
+        updated = update_email(connection, email.id, is_routed=True)
+        return updated if updated is not None else email
+
+
+# -- Three-step routing pipeline -----------------------------------------------
+
+
+def _try_thread_match(
+    connection: psycopg.Connection[dict[str, Any]],
+    email: Email,
+) -> str | None:
+    """Step 1: match via Gmail thread ID.
+
+    If a prior email in the same thread has a non-null ``workflow_id``,
+    return the most recent such workflow. Works regardless of workflow
+    status (active or paused) per the no-ghosting guarantee.
+    """
+    if not email.gmail_thread_id:
+        return None
+    thread_emails = get_emails_by_gmail_thread_id(connection, email.gmail_thread_id)
+    matches = [
+        prior
+        for prior in thread_emails
+        if prior.id != email.id
+        and prior.account_id == email.account_id
+        and prior.workflow_id is not None
+    ]
+    if not matches:
+        return None
+    matches.sort(key=lambda e: e.created_at, reverse=True)
+    return matches[0].workflow_id
+
+
+def _try_classify(
+    connection: psycopg.Connection[dict[str, Any]],
+    email: Email,
+    sender_email: str,
+    settings: Settings,
+) -> str | None:
+    """Step 2: LLM classification against active inbound workflows."""
+    workflows = list_workflows(connection, account_id=email.account_id, status="active")
+    inbound_workflows = [w for w in workflows if w.type == "inbound"]
+    if not inbound_workflows:
+        return None
+    return classify_email(
+        subject=email.subject,
+        body=email.body_text,
+        sender=sender_email,
+        active_workflows=inbound_workflows,
+        settings=settings,
+    )
+
+
+def _ensure_workflow_contact(
+    connection: psycopg.Connection[dict[str, Any]],
+    workflow_id: str,
+    contact_id: str,
+) -> None:
+    """Create a workflow_contact entry if not already present."""
+    create_workflow_contact(connection, workflow_id, contact_id)

--- a/src/mailpilot/sync.py
+++ b/src/mailpilot/sync.py
@@ -33,11 +33,9 @@ from mailpilot.database import (
     delete_sync_status,
     get_contacts_by_emails,
     get_email_by_gmail_message_id,
-    get_emails_by_gmail_thread_id,
     get_sync_status,
     update_account,
     update_contact,
-    update_email,
     update_sync_heartbeat,
     upsert_sync_status,
 )
@@ -48,6 +46,7 @@ from mailpilot.gmail import (
     parse_sender,
 )
 from mailpilot.models import Account, Contact, Email
+from mailpilot.routing import route_email
 from mailpilot.settings import Settings
 
 _HEARTBEAT_INTERVAL = 30  # seconds
@@ -159,7 +158,6 @@ def sync_account(
     Returns:
         Number of newly stored email rows.
     """
-    del settings  # reserved for future tuning (recency window, etc.)
     with logfire.span(
         "sync.account.run",
         account_id=account.id,
@@ -193,7 +191,7 @@ def sync_account(
             for message in fresh_messages:
                 if (
                     _store_inbound_message(
-                        connection, account, message, contacts_by_email
+                        connection, account, message, contacts_by_email, settings
                     )
                     is None
                 ):
@@ -342,6 +340,7 @@ def _store_inbound_message(
     account: Account,
     message: dict[str, Any],
     contacts_by_email: dict[str, Contact],
+    settings: Settings,
 ) -> Email | None:
     """Persist a Gmail message as an inbound email and route when fresh.
 
@@ -393,7 +392,9 @@ def _store_inbound_message(
         within_recency_window=within_window,
     )
     if within_window:
-        email = route_email(connection, email)
+        email = route_email(
+            connection, email, sender_email=sender_email, settings=settings
+        )
     return email
 
 
@@ -409,7 +410,7 @@ def _received_at_from_message(message: dict[str, Any]) -> datetime | None:
     return datetime.fromtimestamp(ms / 1000, tz=UTC)
 
 
-# -- Routing ------------------------------------------------------------------
+# -- Send email ----------------------------------------------------------------
 
 
 def send_email(  # noqa: PLR0913
@@ -513,57 +514,3 @@ def send_email(  # noqa: PLR0913
         span.set_attribute("email_id", email.id)
         span.set_attribute("gmail_message_id", gmail_message_id)
         return email
-
-
-def route_email(
-    connection: psycopg.Connection[dict[str, Any]],
-    email: Email,
-) -> Email:
-    """Route an inbound email to a workflow via thread matching.
-
-    Implements step 1 of the ADR-04 routing pipeline. If a prior email
-    in the same Gmail thread has a non-null ``workflow_id``, assign the
-    most recent such workflow and mark the email ``is_routed``. If no
-    thread match exists, the email is left unchanged -- a future
-    classification pass (see ``mailpilot.agent.classify.classify_email``)
-    resolves it.
-
-    Args:
-        connection: Open database connection.
-        email: Newly stored inbound email to route.
-
-    Returns:
-        Possibly updated email (unchanged on no thread match).
-    """
-    with logfire.span(
-        "sync.route_email",
-        email_id=email.id,
-        account_id=email.account_id,
-    ) as span:
-        try:
-            if not email.gmail_thread_id:
-                span.set_attribute("result", "skipped")
-                return email
-            thread_emails = get_emails_by_gmail_thread_id(
-                connection, email.gmail_thread_id
-            )
-            matches = [
-                prior
-                for prior in thread_emails
-                if prior.id != email.id and prior.workflow_id is not None
-            ]
-            if not matches:
-                span.set_attribute("result", "no_match")
-                return email
-            matches.sort(key=lambda e: e.created_at, reverse=True)
-            workflow_id = matches[0].workflow_id
-            updated = update_email(
-                connection, email.id, workflow_id=workflow_id, is_routed=True
-            )
-            span.set_attribute("result", "thread_match")
-            span.set_attribute("workflow_id", workflow_id)
-            return updated if updated is not None else email
-        except Exception:
-            span.set_attribute("result", "failure")
-            logfire.exception("sync.route_email failed", email_id=email.id)
-            raise

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,0 +1,625 @@
+"""Tests for the email routing pipeline (ADR-04)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg
+from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from conftest import (
+    make_test_account,
+    make_test_contact,
+    make_test_settings,
+    make_test_workflow,
+)
+from mailpilot.agent import classify as classify_module
+from mailpilot.database import (
+    activate_workflow,
+    create_email,
+    get_email,
+    get_workflow_contact,
+    update_workflow,
+)
+from mailpilot.routing import (
+    _is_bounce,  # pyright: ignore[reportPrivateUsage]
+    route_email,
+)
+
+# -- Helpers -------------------------------------------------------------------
+
+
+def _activate_workflow(
+    connection: psycopg.Connection[dict[str, Any]],
+    workflow_id: str,
+) -> None:
+    """Fill required fields and activate a workflow."""
+    update_workflow(
+        connection,
+        workflow_id,
+        objective="Handle inbound inquiries",
+        instructions="Reply helpfully",
+    )
+    activate_workflow(connection, workflow_id)
+
+
+def _function_model_returning(
+    workflow_id: str | None,
+    reasoning: str = "",
+) -> FunctionModel:
+    """Build a FunctionModel that yields a fixed classification result."""
+
+    def _respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        del messages, info
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="final_result",
+                    args={"workflow_id": workflow_id, "reasoning": reasoning},
+                ),
+            ],
+        )
+
+    return FunctionModel(_respond)
+
+
+# -- Bounce detection (_is_bounce) ---------------------------------------------
+
+
+def test_is_bounce_detects_mailer_daemon_sender() -> None:
+    assert _is_bounce("mailer-daemon@gmail.com", []) is True
+
+
+def test_is_bounce_detects_postmaster_sender() -> None:
+    assert _is_bounce("postmaster@example.com", []) is True
+
+
+def test_is_bounce_case_insensitive_sender() -> None:
+    assert _is_bounce("MAILER-DAEMON@gmail.com", []) is True
+    assert _is_bounce("Postmaster@example.com", []) is True
+
+
+def test_is_bounce_detects_bounce_label() -> None:
+    assert _is_bounce("noreply@example.com", ["CATEGORY_BOUNCED"]) is True
+    assert _is_bounce("noreply@example.com", ["INBOX", "bounce-notification"]) is True
+
+
+def test_is_bounce_returns_false_for_normal_email() -> None:
+    assert _is_bounce("alice@example.com", ["INBOX"]) is False
+    assert _is_bounce("alice@example.com", []) is False
+
+
+# -- Idempotency ---------------------------------------------------------------
+
+
+def test_route_email_skips_already_routed(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    account = make_test_account(database_connection, email="idem@example.com")
+    email = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="already routed",
+        gmail_thread_id="t-idem",
+        is_routed=True,
+    )
+    assert email is not None
+
+    result = route_email(
+        database_connection, email, "alice@example.com", make_test_settings()
+    )
+
+    assert result.is_routed is True
+    assert result.workflow_id is None
+
+
+# -- Thread match ---------------------------------------------------------------
+
+
+def test_route_email_thread_match_assigns_workflow(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    account = make_test_account(database_connection, email="route@example.com")
+    workflow = make_test_workflow(
+        database_connection, account_id=account.id, workflow_type="inbound"
+    )
+    _activate_workflow(database_connection, workflow.id)
+
+    prior = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="prior",
+        gmail_thread_id="thread-xyz",
+        workflow_id=workflow.id,
+        is_routed=True,
+    )
+    assert prior is not None
+
+    new_email = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="reply",
+        gmail_thread_id="thread-xyz",
+    )
+    assert new_email is not None
+
+    routed = route_email(
+        database_connection, new_email, "alice@example.com", make_test_settings()
+    )
+
+    assert routed.workflow_id == workflow.id
+    assert routed.is_routed is True
+
+
+def test_route_email_thread_match_uses_most_recent_workflow(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    account = make_test_account(database_connection, email="recent@example.com")
+    wf_old = make_test_workflow(
+        database_connection,
+        account_id=account.id,
+        name="Old Workflow",
+        workflow_type="inbound",
+    )
+    wf_new = make_test_workflow(
+        database_connection,
+        account_id=account.id,
+        name="New Workflow",
+        workflow_type="inbound",
+    )
+
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="first",
+        gmail_thread_id="thread-multi",
+        workflow_id=wf_old.id,
+        is_routed=True,
+    )
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="second",
+        gmail_thread_id="thread-multi",
+        workflow_id=wf_new.id,
+        is_routed=True,
+    )
+
+    new_email = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="reply",
+        gmail_thread_id="thread-multi",
+    )
+    assert new_email is not None
+
+    routed = route_email(
+        database_connection, new_email, "alice@example.com", make_test_settings()
+    )
+
+    assert routed.workflow_id == wf_new.id
+
+
+def test_route_email_no_gmail_thread_id_goes_to_classification(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """An email without a thread ID skips thread match, goes to classification."""
+    account = make_test_account(database_connection, email="nothreadid@example.com")
+    new_email = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="no thread",
+    )
+    assert new_email is not None
+
+    routed = route_email(
+        database_connection, new_email, "alice@example.com", make_test_settings()
+    )
+
+    # No active workflows -> unrouted.
+    assert routed.is_routed is True
+    assert routed.workflow_id is None
+
+
+# -- LLM classification --------------------------------------------------------
+
+
+def test_route_email_classifies_when_no_thread_match(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    account = make_test_account(database_connection, email="classify@example.com")
+    workflow = make_test_workflow(
+        database_connection, account_id=account.id, workflow_type="inbound"
+    )
+    _activate_workflow(database_connection, workflow.id)
+
+    new_email = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Pricing question",
+        body_text="How much does your product cost?",
+        gmail_thread_id="t-classify",
+    )
+    assert new_email is not None
+
+    settings = make_test_settings(
+        anthropic_api_key="sk-test",
+        anthropic_model="claude-sonnet-4-6",
+    )
+    model = _function_model_returning(
+        workflow_id=workflow.id,
+        reasoning="pricing inquiry matches inbound workflow",
+    )
+
+    with classify_module._AGENT.override(model=model):  # pyright: ignore[reportPrivateUsage]
+        routed = route_email(
+            database_connection, new_email, "alice@example.com", settings
+        )
+
+    assert routed.workflow_id == workflow.id
+    assert routed.is_routed is True
+
+
+def test_route_email_classification_no_match_stores_unrouted(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    account = make_test_account(database_connection, email="unrouted@example.com")
+    workflow = make_test_workflow(
+        database_connection, account_id=account.id, workflow_type="inbound"
+    )
+    _activate_workflow(database_connection, workflow.id)
+
+    new_email = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Random spam",
+        body_text="You won a prize!",
+        gmail_thread_id="t-unrouted",
+    )
+    assert new_email is not None
+
+    settings = make_test_settings(
+        anthropic_api_key="sk-test",
+        anthropic_model="claude-sonnet-4-6",
+    )
+    model = _function_model_returning(workflow_id=None, reasoning="no match")
+
+    with classify_module._AGENT.override(model=model):  # pyright: ignore[reportPrivateUsage]
+        routed = route_email(
+            database_connection, new_email, "alice@example.com", settings
+        )
+
+    assert routed.workflow_id is None
+    assert routed.is_routed is True
+
+
+def test_route_email_classification_skips_outbound_workflows(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """Only inbound workflows are classification candidates."""
+    account = make_test_account(database_connection, email="obfilter@example.com")
+    outbound_wf = make_test_workflow(
+        database_connection,
+        account_id=account.id,
+        name="Outbound Campaign",
+        workflow_type="outbound",
+    )
+    update_workflow(
+        database_connection,
+        outbound_wf.id,
+        objective="Cold outreach",
+        instructions="Send cold emails",
+    )
+    activate_workflow(database_connection, outbound_wf.id)
+
+    new_email = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Hi there",
+        gmail_thread_id="t-obfilter",
+    )
+    assert new_email is not None
+
+    # No inbound workflows -> unrouted, LLM never called.
+    routed = route_email(
+        database_connection, new_email, "alice@example.com", make_test_settings()
+    )
+
+    assert routed.workflow_id is None
+    assert routed.is_routed is True
+
+
+# -- Unrouted fallback ----------------------------------------------------------
+
+
+def test_route_email_no_match_sets_routed_true_workflow_null(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """No thread match, no active inbound workflows -> deliberately unrouted."""
+    account = make_test_account(database_connection, email="noworkflows@example.com")
+    new_email = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="orphan",
+        gmail_thread_id="t-orphan",
+    )
+    assert new_email is not None
+
+    routed = route_email(
+        database_connection, new_email, "alice@example.com", make_test_settings()
+    )
+
+    assert routed.is_routed is True
+    assert routed.workflow_id is None
+    stored = get_email(database_connection, new_email.id)
+    assert stored is not None
+    assert stored.is_routed is True
+    assert stored.workflow_id is None
+
+
+# -- Bounce detection -----------------------------------------------------------
+
+
+def test_route_email_bounce_marks_original_outbound_bounced(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    account = make_test_account(database_connection, email="bounce@example.com")
+    contact = make_test_contact(
+        database_connection, email="recipient@example.com", domain="example.com"
+    )
+
+    outbound = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="Hello",
+        gmail_thread_id="t-bounce",
+        contact_id=contact.id,
+        status="sent",
+        is_routed=True,
+    )
+    assert outbound is not None
+
+    bounce_notification = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Delivery Status Notification (Failure)",
+        gmail_thread_id="t-bounce",
+    )
+    assert bounce_notification is not None
+
+    routed = route_email(
+        database_connection,
+        bounce_notification,
+        "mailer-daemon@gmail.com",
+        make_test_settings(),
+    )
+
+    assert routed.is_routed is True
+    # Original outbound email should be marked bounced.
+    original = get_email(database_connection, outbound.id)
+    assert original is not None
+    assert original.status == "bounced"
+
+
+def test_route_email_bounce_disables_original_contact(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    from mailpilot.database import get_contact
+
+    account = make_test_account(database_connection, email="bdisable@example.com")
+    contact = make_test_contact(
+        database_connection, email="bounced@example.com", domain="example.com"
+    )
+
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="Hello",
+        gmail_thread_id="t-bdisable",
+        contact_id=contact.id,
+        status="sent",
+        is_routed=True,
+    )
+
+    bounce = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Bounce",
+        gmail_thread_id="t-bdisable",
+    )
+    assert bounce is not None
+
+    route_email(
+        database_connection,
+        bounce,
+        "POSTMASTER@example.com",
+        make_test_settings(),
+    )
+
+    updated_contact = get_contact(database_connection, contact.id)
+    assert updated_contact is not None
+    assert updated_contact.status == "bounced"
+    assert updated_contact.status_reason != ""
+
+
+def test_route_email_bounce_via_label(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """Bounce detected via Gmail label even if sender is not mailer-daemon."""
+    account = make_test_account(database_connection, email="blabel@example.com")
+    contact = make_test_contact(
+        database_connection, email="labelrecip@example.com", domain="example.com"
+    )
+
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="Hello",
+        gmail_thread_id="t-blabel",
+        contact_id=contact.id,
+        status="sent",
+        is_routed=True,
+    )
+
+    bounce = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Bounce",
+        gmail_thread_id="t-blabel",
+        labels=["INBOX", "CATEGORY_BOUNCED"],
+    )
+    assert bounce is not None
+
+    routed = route_email(
+        database_connection,
+        bounce,
+        "noreply@google.com",
+        make_test_settings(),
+    )
+
+    assert routed.is_routed is True
+    original = get_email(database_connection, bounce.id)
+    assert original is not None
+    assert original.is_routed is True
+
+
+def test_route_email_bounce_no_outbound_in_thread_still_marks_routed(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """Bounce notification without a matching outbound is still marked routed."""
+    account = make_test_account(database_connection, email="noob@example.com")
+
+    bounce = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Bounce",
+        gmail_thread_id="t-noob",
+    )
+    assert bounce is not None
+
+    routed = route_email(
+        database_connection,
+        bounce,
+        "mailer-daemon@gmail.com",
+        make_test_settings(),
+    )
+
+    assert routed.is_routed is True
+
+
+# -- workflow_contact creation --------------------------------------------------
+
+
+def test_route_email_creates_workflow_contact_on_route(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    account = make_test_account(database_connection, email="wcreate@example.com")
+    contact = make_test_contact(
+        database_connection, email="sender@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(
+        database_connection, account_id=account.id, workflow_type="inbound"
+    )
+    _activate_workflow(database_connection, workflow.id)
+
+    # Thread match path -> routes to workflow -> should create workflow_contact.
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="prior",
+        gmail_thread_id="t-wcreate",
+        workflow_id=workflow.id,
+        is_routed=True,
+    )
+
+    new_email = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="reply",
+        gmail_thread_id="t-wcreate",
+        contact_id=contact.id,
+    )
+    assert new_email is not None
+
+    route_email(
+        database_connection, new_email, "sender@example.com", make_test_settings()
+    )
+
+    wc = get_workflow_contact(database_connection, workflow.id, contact.id)
+    assert wc is not None
+    assert wc.status == "pending"
+
+
+def test_route_email_workflow_contact_idempotent(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """Routing a second email in the same thread doesn't fail on duplicate workflow_contact."""
+    account = make_test_account(database_connection, email="wcidem@example.com")
+    contact = make_test_contact(
+        database_connection, email="repeat@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(
+        database_connection, account_id=account.id, workflow_type="inbound"
+    )
+    _activate_workflow(database_connection, workflow.id)
+
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="prior",
+        gmail_thread_id="t-wcidem",
+        workflow_id=workflow.id,
+        is_routed=True,
+    )
+
+    # First inbound -> creates workflow_contact.
+    email1 = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="reply 1",
+        gmail_thread_id="t-wcidem",
+        contact_id=contact.id,
+    )
+    assert email1 is not None
+    route_email(database_connection, email1, "repeat@example.com", make_test_settings())
+
+    # Second inbound -> should NOT raise on duplicate workflow_contact.
+    email2 = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="reply 2",
+        gmail_thread_id="t-wcidem",
+        gmail_message_id="msg-wcidem-2",
+        contact_id=contact.id,
+    )
+    assert email2 is not None
+    routed = route_email(
+        database_connection, email2, "repeat@example.com", make_test_settings()
+    )
+
+    assert routed.workflow_id == workflow.id
+    assert routed.is_routed is True

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -16,7 +16,6 @@ from conftest import (
     make_test_workflow,
 )
 from mailpilot.database import (
-    activate_workflow,
     create_email,
     delete_sync_status,
     get_contact_by_email,
@@ -26,11 +25,10 @@ from mailpilot.database import (
     list_emails,
     update_account,
     update_sync_heartbeat,
-    update_workflow,
     upsert_sync_status,
 )
 from mailpilot.gmail import GmailClient
-from mailpilot.sync import is_pid_alive, route_email, send_email, sync_account
+from mailpilot.sync import is_pid_alive, send_email, sync_account
 
 
 def test_upsert_and_get_sync_status(
@@ -300,7 +298,7 @@ def test_sync_account_recency_gate_marks_old_messages_routed(
     assert email.workflow_id is None
 
 
-def test_sync_account_fresh_message_stays_unrouted_without_thread(
+def test_sync_account_fresh_message_routed_as_unrouted_without_workflows(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
     account = make_test_account(database_connection, email="fresh@example.com")
@@ -312,8 +310,8 @@ def test_sync_account_fresh_message_stays_unrouted_without_thread(
 
     email = get_email_by_gmail_message_id(database_connection, "fresh")
     assert email is not None
-    # No prior thread emails, classify not wired up -> deferred.
-    assert email.is_routed is False
+    # No prior thread emails, no active inbound workflows -> deliberately unrouted.
+    assert email.is_routed is True
     assert email.workflow_id is None
 
 
@@ -445,74 +443,6 @@ def test_sync_account_updates_account_history_and_last_synced(
     assert refreshed.gmail_history_id == "12345"
     assert refreshed.last_synced_at is not None
     assert refreshed.last_synced_at >= before
-
-
-# -- route_email ---------------------------------------------------------------
-
-
-def test_route_email_thread_match_assigns_workflow(
-    database_connection: psycopg.Connection[dict[str, Any]],
-):
-    account = make_test_account(database_connection, email="route@example.com")
-    workflow = make_test_workflow(
-        database_connection, account_id=account.id, workflow_type="inbound"
-    )
-    # Make workflow active so it has a workflow_id we can reuse.
-    update_workflow(
-        database_connection,
-        workflow.id,
-        objective="o",
-        instructions="i",
-    )
-    activate_workflow(database_connection, workflow.id)
-
-    prior = create_email(
-        database_connection,
-        account_id=account.id,
-        direction="outbound",
-        subject="prior",
-        gmail_thread_id="thread-xyz",
-        workflow_id=workflow.id,
-        is_routed=True,
-    )
-    assert prior is not None
-    assert prior.workflow_id == workflow.id
-
-    new_email = create_email(
-        database_connection,
-        account_id=account.id,
-        direction="inbound",
-        subject="reply",
-        gmail_thread_id="thread-xyz",
-    )
-    assert new_email is not None
-
-    routed = route_email(database_connection, new_email)
-
-    assert routed.workflow_id == workflow.id
-    assert routed.is_routed is True
-
-
-def test_route_email_no_thread_match_leaves_unrouted(
-    database_connection: psycopg.Connection[dict[str, Any]],
-):
-    account = make_test_account(database_connection, email="noroute@example.com")
-    new_email = create_email(
-        database_connection,
-        account_id=account.id,
-        direction="inbound",
-        subject="orphan",
-        gmail_thread_id="thread-orphan",
-    )
-    assert new_email is not None
-
-    routed = route_email(database_connection, new_email)
-
-    assert routed.workflow_id is None
-    assert routed.is_routed is False
-    stored = get_email(database_connection, new_email.id)
-    assert stored is not None
-    assert stored.is_routed is False
 
 
 # -- send_email ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implement the three-step email routing pipeline that assigns inbound emails to the correct workflow:

1. **Thread match** -- if the email's Gmail thread already has a routed email, assign to the same workflow
2. **LLM classification** -- call `classify_email()` to match against active inbound workflows
3. **Store as unrouted** -- if no match, set `is_routed = true` with `workflow_id = NULL`

Also includes bounce detection (mailer-daemon/postmaster -> contact status `bounced`) and `workflow_contact` creation on successful routing.

Resolves #9