### PR TITLE
feat(agent): implement agent tools

### DIFF
--- a/src/mailpilot/agent/tools.py
+++ b/src/mailpilot/agent/tools.py
@@ -4,6 +4,10 @@ Each function is a Pydantic AI tool the agent can call. Tools are defined
 as standalone functions (not methods) so they can be unit-tested without
 spinning up a full agent.
 
+Dependency injection: each tool receives explicit dependency parameters
+(``connection``, ``account``, ``workflow_id``, etc.) that issue #12 will
+wire from ``RunContext[AgentDeps]``.
+
 Tools per ADR-03:
     - ``send_email`` -- send via Gmail API with contact status + cooldown guards
     - ``create_task`` -- schedule deferred work
@@ -18,10 +22,26 @@ Tools per ADR-03:
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
+import logfire
+import psycopg
 
-def send_email(
+from mailpilot import database
+from mailpilot.models import Account
+from mailpilot.settings import Settings
+from mailpilot.sync import send_email as sync_send_email
+
+_COOLDOWN_DAYS = 30
+
+
+def send_email(  # noqa: PLR0913
+    connection: psycopg.Connection[dict[str, Any]],
+    account: Account,
+    gmail_client: object,
+    settings: Settings,
+    workflow_id: str,
     to: str,
     subject: str,
     body: str,
@@ -37,18 +57,71 @@ def send_email(
          to this contact from this account was within cooldown period (30 days)
 
     Args:
+        connection: Open database connection.
+        account: Sending account.
+        gmail_client: Gmail client scoped to account.
+        settings: Application settings.
+        workflow_id: Current workflow FK.
         to: Recipient email address.
         subject: Email subject.
         body: Email body (plain text).
         thread_id: Gmail thread ID for threading replies.
 
     Returns:
-        Dict with sent message details (id, threadId).
+        Dict with sent message details (id, gmail_message_id, gmail_thread_id),
+        or error dict if blocked by guard.
     """
-    raise NotImplementedError
+    with logfire.span("agent.tool.send_email", to=to, workflow_id=workflow_id):
+        # Guard 1: contact status check.
+        contact = database.get_contact_by_email(connection, to)
+        contact_id: str | None = None
+        if contact is not None:
+            contact_id = contact.id
+            if contact.status != "active":
+                return {
+                    "error": "contact_disabled",
+                    "message": f"contact is {contact.status}: {contact.status_reason}",
+                }
+
+            # Guard 2: cooldown (new conversations only).
+            if thread_id is None:
+                last = database.get_last_cold_outbound(
+                    connection, account.id, contact.id
+                )
+                if last is not None and last.created_at > datetime.now(UTC) - timedelta(
+                    days=_COOLDOWN_DAYS
+                ):
+                    sent_at = last.created_at.isoformat()
+                    return {
+                        "error": "cooldown",
+                        "message": (
+                            f"last unsolicited email sent {sent_at}; "
+                            f"cooldown is {_COOLDOWN_DAYS} days"
+                        ),
+                    }
+
+        email = sync_send_email(
+            connection=connection,
+            account=account,
+            gmail_client=gmail_client,  # type: ignore[arg-type]
+            settings=settings,
+            to=to,
+            subject=subject,
+            body=body,
+            contact_id=contact_id,
+            workflow_id=workflow_id,
+            thread_id=thread_id,
+        )
+        return {
+            "id": email.id,
+            "gmail_message_id": email.gmail_message_id,
+            "gmail_thread_id": email.gmail_thread_id,
+        }
 
 
-def create_task(
+def create_task(  # noqa: PLR0913
+    connection: psycopg.Connection[dict[str, Any]],
+    workflow_id: str,
     contact_id: str,
     description: str,
     scheduled_at: str,
@@ -58,6 +131,8 @@ def create_task(
     """Schedule deferred work for later execution.
 
     Args:
+        connection: Open database connection.
+        workflow_id: Current workflow FK.
         contact_id: Contact this task targets (required).
         description: What the agent should do when the task runs.
         scheduled_at: When to execute (ISO 8601 timestamp).
@@ -67,10 +142,50 @@ def create_task(
     Returns:
         Dict with created task ID.
     """
-    raise NotImplementedError
+    with logfire.span(
+        "agent.tool.create_task", workflow_id=workflow_id, contact_id=contact_id
+    ):
+        task = database.create_task(
+            connection,
+            workflow_id=workflow_id,
+            contact_id=contact_id,
+            description=description,
+            scheduled_at=scheduled_at,
+            context=context,
+            email_id=email_id,
+        )
+        return {"id": task.id}
+
+
+def cancel_task(
+    connection: psycopg.Connection[dict[str, Any]],
+    task_id: str,
+) -> dict[str, str]:
+    """Cancel a pending task.
+
+    Use when a previously scheduled follow-up is no longer needed (e.g.,
+    the contact replied before the follow-up was due).
+
+    Args:
+        connection: Open database connection.
+        task_id: Task ID to cancel.
+
+    Returns:
+        Dict with cancelled task ID and status, or error if not found/not pending.
+    """
+    with logfire.span("agent.tool.cancel_task", task_id=task_id):
+        task = database.cancel_task(connection, task_id)
+        if task is None:
+            return {
+                "error": "not_found",
+                "message": f"task not found or not pending: {task_id}",
+            }
+        return {"id": task.id, "status": task.status}
 
 
 def update_contact_status(
+    connection: psycopg.Connection[dict[str, Any]],
+    workflow_id: str,
     contact_id: str,
     status: str,
     reason: str,
@@ -80,32 +195,34 @@ def update_contact_status(
     The agent -- not the system -- decides success or failure.
 
     Args:
+        connection: Open database connection.
+        workflow_id: Current workflow FK.
         contact_id: Contact ID.
         status: "active", "completed", or "failed".
         reason: Agent's explanation (e.g., "meeting booked", "no response").
 
     Returns:
-        Dict with updated status.
+        Dict with updated status, or error if workflow_contact not found.
     """
-    raise NotImplementedError
-
-
-def cancel_task(task_id: str) -> dict[str, str]:
-    """Cancel a pending task.
-
-    Use when a previously scheduled follow-up is no longer needed (e.g.,
-    the contact replied before the follow-up was due).
-
-    Args:
-        task_id: Task ID to cancel.
-
-    Returns:
-        Dict with cancelled task ID and status.
-    """
-    raise NotImplementedError
+    with logfire.span(
+        "agent.tool.update_contact_status",
+        workflow_id=workflow_id,
+        contact_id=contact_id,
+        status=status,
+    ):
+        wc = database.update_workflow_contact(
+            connection, workflow_id, contact_id, status=status, reason=reason
+        )
+        if wc is None:
+            return {
+                "error": "not_found",
+                "message": f"workflow_contact not found: {workflow_id}/{contact_id}",
+            }
+        return {"status": wc.status, "reason": wc.reason}
 
 
 def disable_contact(
+    connection: psycopg.Connection[dict[str, Any]],
     contact_id: str,
     status: str,
     reason: str,
@@ -116,62 +233,101 @@ def disable_contact(
     contact status before sending.
 
     Args:
+        connection: Open database connection.
         contact_id: Contact ID.
         status: "bounced" or "unsubscribed".
         reason: Explanation (e.g., "hard bounce", "replied: do not contact").
 
     Returns:
-        Dict with updated contact status.
+        Dict with updated contact status, or error if not found.
     """
-    raise NotImplementedError
+    with logfire.span(
+        "agent.tool.disable_contact", contact_id=contact_id, status=status
+    ):
+        updated = database.disable_contact(
+            connection, contact_id, status=status, status_reason=reason
+        )
+        if updated is None:
+            return {"error": "not_found", "message": f"contact not found: {contact_id}"}
+        return {"id": updated.id, "status": updated.status}
 
 
-def list_workflow_contacts(workflow_id: str) -> list[dict[str, Any]]:
+def list_workflow_contacts(
+    connection: psycopg.Connection[dict[str, Any]],
+    workflow_id: str,
+) -> list[dict[str, Any]]:
     """List contacts in a workflow with their outcome status.
 
     Lets the agent coordinate across contacts (e.g., skip person B if
     person A at the same company already completed the objective).
 
     Args:
+        connection: Open database connection.
         workflow_id: Workflow ID.
 
     Returns:
         List of workflow-contact records with status and reason.
     """
-    raise NotImplementedError
+    with logfire.span("agent.tool.list_workflow_contacts", workflow_id=workflow_id):
+        contacts = database.list_workflow_contacts(connection, workflow_id)
+        return [wc.model_dump() for wc in contacts]
 
 
-def search_emails(query: str) -> list[dict[str, Any]]:
-    """Search email history for the current account and contact.
+def search_emails(
+    connection: psycopg.Connection[dict[str, Any]],
+    account_id: str,
+    query: str,
+) -> list[dict[str, Any]]:
+    """Search email history for the current account.
 
     Args:
+        connection: Open database connection.
+        account_id: Account to scope search to.
         query: Search term matched against subject and body.
 
     Returns:
         List of matching email summaries.
     """
-    raise NotImplementedError
+    with logfire.span("agent.tool.search_emails", account_id=account_id, query=query):
+        emails = database.search_emails(connection, query, account_id=account_id)
+        return [e.model_dump() for e in emails]
 
 
-def read_contact(email: str) -> dict[str, Any] | None:
+def read_contact(
+    connection: psycopg.Connection[dict[str, Any]],
+    email: str,
+) -> dict[str, Any] | None:
     """Look up a contact by email address.
 
     Args:
+        connection: Open database connection.
         email: Contact email address.
 
     Returns:
         Contact details or None if not found.
     """
-    raise NotImplementedError
+    with logfire.span("agent.tool.read_contact", email=email):
+        contact = database.get_contact_by_email(connection, email)
+        if contact is None:
+            return None
+        return contact.model_dump()
 
 
-def read_company(domain: str) -> dict[str, Any] | None:
+def read_company(
+    connection: psycopg.Connection[dict[str, Any]],
+    domain: str,
+) -> dict[str, Any] | None:
     """Look up a company by domain.
 
     Args:
+        connection: Open database connection.
         domain: Company primary domain.
 
     Returns:
         Company details or None if not found.
     """
-    raise NotImplementedError
+    with logfire.span("agent.tool.read_company", domain=domain):
+        company = database.get_company_by_domain(connection, domain)
+        if company is None:
+            return None
+        return company.model_dump()

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -356,6 +356,30 @@ def search_companies(
         return companies
 
 
+def get_company_by_domain(
+    connection: psycopg.Connection[dict[str, Any]],
+    domain: str,
+) -> Company | None:
+    """Get a company by primary domain.
+
+    Args:
+        connection: Open database connection.
+        domain: Company domain (exact match on UNIQUE column).
+
+    Returns:
+        Company if found, None otherwise.
+    """
+    with logfire.span("db.company.get_by_domain", domain=domain) as span:
+        row = connection.execute(
+            "SELECT * FROM company WHERE domain = %(domain)s",
+            {"domain": domain},
+        ).fetchone()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return Company.model_validate(row)
+
+
 def update_company(
     connection: psycopg.Connection[dict[str, Any]],
     company_id: str,
@@ -1362,6 +1386,7 @@ def search_emails(
     connection: psycopg.Connection[dict[str, Any]],
     query: str,
     limit: int = 100,
+    account_id: str | None = None,
 ) -> list[Email]:
     """Search emails by subject or body text.
 
@@ -1369,22 +1394,29 @@ def search_emails(
         connection: Open database connection.
         query: Search term.
         limit: Maximum number of results.
+        account_id: Filter by account ID.
 
     Returns:
         Matching emails ordered by creation time descending.
     """
-    with logfire.span("db.email.search", query=query, limit=limit) as span:
+    with logfire.span(
+        "db.email.search", query=query, limit=limit, account_id=account_id
+    ) as span:
         pattern = f"%{query}%"
-        rows = connection.execute(
-            """\
-            SELECT * FROM email
-            WHERE LOWER(subject) LIKE LOWER(%(pattern)s)
-               OR LOWER(body_text) LIKE LOWER(%(pattern)s)
-            ORDER BY created_at DESC
-            LIMIT %(limit)s
-            """,
-            {"pattern": pattern, "limit": limit},
-        ).fetchall()
+        params: dict[str, object] = {"pattern": pattern, "limit": limit}
+        account_filter = SQL("")
+        if account_id is not None:
+            account_filter = SQL("AND account_id = %(account_id)s")
+            params["account_id"] = account_id
+        query_sql = SQL(
+            "SELECT * FROM email "
+            "WHERE (LOWER(subject) LIKE LOWER(%(pattern)s) "
+            "   OR LOWER(body_text) LIKE LOWER(%(pattern)s)) "
+            "{} "
+            "ORDER BY created_at DESC "
+            "LIMIT %(limit)s"
+        ).format(account_filter)
+        rows = connection.execute(query_sql, params).fetchall()
         emails = [Email.model_validate(row) for row in rows]
         span.set_attribute("email_count", len(emails))
         return emails
@@ -1445,6 +1477,57 @@ def get_emails_by_gmail_thread_id(
         emails = [Email.model_validate(row) for row in rows]
         span.set_attribute("email_count", len(emails))
         return emails
+
+
+def get_last_cold_outbound(
+    connection: psycopg.Connection[dict[str, Any]],
+    account_id: str,
+    contact_id: str,
+) -> Email | None:
+    """Get the most recent cold outbound email to a contact.
+
+    A cold outbound email is the first outbound message in its Gmail
+    thread (no prior outbound in the same thread). This distinguishes
+    initial outreach from follow-up replies within an existing
+    conversation. Used by the ``send_email`` agent tool for cooldown
+    enforcement.
+
+    Args:
+        connection: Open database connection.
+        account_id: Sending account.
+        contact_id: Recipient contact.
+
+    Returns:
+        Most recent cold outbound email, or None if none exists.
+    """
+    with logfire.span(
+        "db.email.get_last_cold_outbound",
+        account_id=account_id,
+        contact_id=contact_id,
+    ) as span:
+        row = connection.execute(
+            """\
+            SELECT e.* FROM email e
+            WHERE e.account_id = %(account_id)s
+              AND e.contact_id = %(contact_id)s
+              AND e.direction = 'outbound'
+              AND NOT EXISTS (
+                  SELECT 1 FROM email prior
+                  WHERE prior.gmail_thread_id = e.gmail_thread_id
+                    AND prior.gmail_thread_id IS NOT NULL
+                    AND prior.account_id = e.account_id
+                    AND prior.direction = 'outbound'
+                    AND prior.created_at < e.created_at
+              )
+            ORDER BY e.created_at DESC
+            LIMIT 1
+            """,
+            {"account_id": account_id, "contact_id": contact_id},
+        ).fetchone()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return Email.model_validate(row)
 
 
 def update_email(

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -1,0 +1,503 @@
+"""Tests for agent tool implementations."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import MagicMock
+
+import psycopg
+
+from conftest import (
+    make_test_account,
+    make_test_company,
+    make_test_contact,
+    make_test_settings,
+    make_test_workflow,
+)
+from mailpilot.agent.tools import (
+    cancel_task,
+    create_task,
+    disable_contact,
+    list_workflow_contacts,
+    read_company,
+    read_contact,
+    search_emails,
+    send_email,
+    update_contact_status,
+)
+from mailpilot.database import (
+    activate_workflow,
+    create_email,
+    create_workflow_contact,
+    get_contact,
+    get_task,
+    get_workflow_contact,
+    update_workflow,
+)
+from mailpilot.database import (
+    create_task as db_create_task,
+)
+from mailpilot.models import Account
+
+# -- Helpers -------------------------------------------------------------------
+
+
+def _activate(connection: psycopg.Connection[dict[str, Any]], workflow_id: str) -> None:
+    """Fill required fields and activate a workflow."""
+    update_workflow(
+        connection,
+        workflow_id,
+        objective="Test objective",
+        instructions="Test instructions",
+    )
+    activate_workflow(connection, workflow_id)
+
+
+def _make_gmail_client(
+    account: Account, send_result: dict[str, Any] | None = None
+) -> MagicMock:
+    """Build a mock GmailClient that returns a fixed send result."""
+    client = MagicMock()
+    client.send_message.return_value = send_result or {
+        "id": "gmail-msg-1",
+        "threadId": "gmail-thread-1",
+        "labelIds": ["SENT"],
+    }
+    return client
+
+
+# -- send_email ----------------------------------------------------------------
+
+
+def test_send_email_success(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    make_test_contact(
+        database_connection, email="recipient@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+    gmail_client = _make_gmail_client(account)
+
+    result = send_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        to="recipient@example.com",
+        subject="Hello",
+        body="Hi there",
+    )
+
+    assert result["gmail_message_id"] == "gmail-msg-1"
+    assert result["gmail_thread_id"] == "gmail-thread-1"
+    assert "id" in result
+    gmail_client.send_message.assert_called_once()
+
+
+def test_send_email_blocked_by_contact_status(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    from mailpilot.database import disable_contact as db_disable_contact
+
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="bounced@example.com", domain="example.com"
+    )
+    db_disable_contact(database_connection, contact.id, "bounced", "hard bounce")
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+    gmail_client = _make_gmail_client(account)
+
+    result = send_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        to="bounced@example.com",
+        subject="Hello",
+        body="Hi",
+    )
+
+    assert result["error"] == "contact_disabled"
+    assert "bounced" in result["message"]
+    gmail_client.send_message.assert_not_called()
+
+
+def test_send_email_blocked_by_cooldown(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="recent@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+
+    # Recent cold outbound (first in its thread, as Gmail always assigns one).
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="cold pitch",
+        contact_id=contact.id,
+        gmail_message_id="cold-msg",
+        gmail_thread_id="cold-thread",
+        status="sent",
+        sent_at=datetime.now(UTC) - timedelta(days=5),
+    )
+
+    gmail_client = _make_gmail_client(account)
+
+    result = send_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        to="recent@example.com",
+        subject="Follow up",
+        body="Hi again",
+    )
+
+    assert result["error"] == "cooldown"
+    gmail_client.send_message.assert_not_called()
+
+
+def test_send_email_reply_bypasses_cooldown(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="reply@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+
+    # Recent cold outbound (first in its thread).
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="cold pitch",
+        contact_id=contact.id,
+        gmail_message_id="cold-msg",
+        gmail_thread_id="cold-thread",
+        status="sent",
+        sent_at=datetime.now(UTC) - timedelta(days=5),
+    )
+
+    gmail_client = _make_gmail_client(account)
+
+    result = send_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        to="reply@example.com",
+        subject="Re: your question",
+        body="Here's the answer",
+        thread_id="existing-thread",
+    )
+
+    # Reply with thread_id should bypass cooldown.
+    assert "error" not in result
+    assert result["gmail_message_id"] == "gmail-msg-1"
+
+
+def test_send_email_unknown_contact_succeeds(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Sending to an email not in the contacts table should succeed."""
+    account = make_test_account(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+    gmail_client = _make_gmail_client(account)
+
+    result = send_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        to="unknown@example.com",
+        subject="Hello",
+        body="Hi",
+    )
+
+    assert "error" not in result
+    assert result["gmail_message_id"] == "gmail-msg-1"
+
+
+# -- create_task ---------------------------------------------------------------
+
+
+def test_create_task_success(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    contact = make_test_contact(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+
+    result = create_task(
+        connection=database_connection,
+        workflow_id=workflow.id,
+        contact_id=contact.id,
+        description="Follow up in 3 days",
+        scheduled_at="2026-04-22T10:00:00Z",
+    )
+
+    assert "id" in result
+    task = get_task(database_connection, result["id"])
+    assert task is not None
+    assert task.description == "Follow up in 3 days"
+    assert task.status == "pending"
+
+
+def test_create_task_with_context_and_email(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    contact = make_test_contact(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    email = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="question",
+    )
+    assert email is not None
+
+    result = create_task(
+        connection=database_connection,
+        workflow_id=workflow.id,
+        contact_id=contact.id,
+        description="Reply to question",
+        scheduled_at="2026-04-22T10:00:00Z",
+        context={"topic": "pricing"},
+        email_id=email.id,
+    )
+
+    task = get_task(database_connection, result["id"])
+    assert task is not None
+    assert task.context == {"topic": "pricing"}
+    assert task.email_id == email.id
+
+
+# -- cancel_task ---------------------------------------------------------------
+
+
+def test_cancel_task_success(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    contact = make_test_contact(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    task = db_create_task(
+        database_connection,
+        workflow_id=workflow.id,
+        contact_id=contact.id,
+        description="Follow up",
+        scheduled_at="2026-04-22T10:00:00Z",
+    )
+
+    result = cancel_task(connection=database_connection, task_id=task.id)
+
+    assert result["id"] == task.id
+    assert result["status"] == "cancelled"
+
+
+def test_cancel_task_not_found(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    result = cancel_task(connection=database_connection, task_id="nonexistent")
+    assert result["error"] == "not_found"
+
+
+# -- update_contact_status -----------------------------------------------------
+
+
+def test_update_contact_status_success(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    contact = make_test_contact(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    create_workflow_contact(database_connection, workflow.id, contact.id)
+
+    result = update_contact_status(
+        connection=database_connection,
+        workflow_id=workflow.id,
+        contact_id=contact.id,
+        status="completed",
+        reason="meeting booked",
+    )
+
+    assert result["status"] == "completed"
+    wc = get_workflow_contact(database_connection, workflow.id, contact.id)
+    assert wc is not None
+    assert wc.status == "completed"
+    assert wc.reason == "meeting booked"
+
+
+def test_update_contact_status_not_found(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    result = update_contact_status(
+        connection=database_connection,
+        workflow_id="nonexistent",
+        contact_id="nonexistent",
+        status="completed",
+        reason="done",
+    )
+
+    assert result["error"] == "not_found"
+
+
+# -- disable_contact -----------------------------------------------------------
+
+
+def test_disable_contact_success(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+
+    result = disable_contact(
+        connection=database_connection,
+        contact_id=contact.id,
+        status="unsubscribed",
+        reason="replied: do not contact",
+    )
+
+    assert result["status"] == "unsubscribed"
+    updated = get_contact(database_connection, contact.id)
+    assert updated is not None
+    assert updated.status == "unsubscribed"
+    assert updated.status_reason == "replied: do not contact"
+
+
+def test_disable_contact_not_found(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    result = disable_contact(
+        connection=database_connection,
+        contact_id="nonexistent",
+        status="bounced",
+        reason="hard bounce",
+    )
+
+    assert result["error"] == "not_found"
+
+
+# -- list_workflow_contacts ----------------------------------------------------
+
+
+def test_list_workflow_contacts_success(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    contact = make_test_contact(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    create_workflow_contact(database_connection, workflow.id, contact.id)
+
+    result = list_workflow_contacts(
+        connection=database_connection, workflow_id=workflow.id
+    )
+
+    assert len(result) == 1
+    assert result[0]["contact_id"] == contact.id
+    assert result[0]["status"] == "pending"
+
+
+def test_list_workflow_contacts_empty(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+
+    result = list_workflow_contacts(
+        connection=database_connection, workflow_id=workflow.id
+    )
+
+    assert result == []
+
+
+# -- search_emails -------------------------------------------------------------
+
+
+def test_search_emails_filters_by_account(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    a1 = make_test_account(database_connection, email="a1@test.com")
+    a2 = make_test_account(database_connection, email="a2@test.com")
+
+    create_email(
+        database_connection,
+        account_id=a1.id,
+        direction="inbound",
+        subject="pricing question",
+    )
+    create_email(
+        database_connection,
+        account_id=a2.id,
+        direction="inbound",
+        subject="pricing info",
+    )
+
+    result = search_emails(
+        connection=database_connection, account_id=a1.id, query="pricing"
+    )
+
+    assert len(result) == 1
+    assert result[0]["account_id"] == a1.id
+
+
+# -- read_contact --------------------------------------------------------------
+
+
+def test_read_contact_found(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(
+        database_connection, email="alice@example.com", domain="example.com"
+    )
+
+    result = read_contact(connection=database_connection, email="alice@example.com")
+
+    assert result is not None
+    assert result["id"] == contact.id
+    assert result["email"] == "alice@example.com"
+
+
+def test_read_contact_not_found(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    result = read_contact(connection=database_connection, email="nobody@example.com")
+    assert result is None
+
+
+# -- read_company --------------------------------------------------------------
+
+
+def test_read_company_found(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    company = make_test_company(database_connection, name="Acme", domain="acme.com")
+
+    result = read_company(connection=database_connection, domain="acme.com")
+
+    assert result is not None
+    assert result["id"] == company.id
+    assert result["domain"] == "acme.com"
+
+
+def test_read_company_not_found(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    result = read_company(connection=database_connection, domain="nonexistent.com")
+    assert result is None

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -21,12 +21,14 @@ from mailpilot.database import (
     create_or_get_contact_by_email,
     get_account,
     get_company,
+    get_company_by_domain,
     get_contact,
     get_contact_by_email,
     get_contacts_by_emails,
     get_email,
     get_email_by_gmail_message_id,
     get_emails_by_gmail_thread_id,
+    get_last_cold_outbound,
     get_workflow,
     list_accounts,
     list_companies,
@@ -36,6 +38,7 @@ from mailpilot.database import (
     pause_workflow,
     search_companies,
     search_contacts,
+    search_emails,
     search_workflows,
     update_account,
     update_company,
@@ -784,3 +787,161 @@ def test_create_email_concurrent_same_gmail_message_id_is_safe(
     ).fetchone()
     assert row is not None
     assert row["n"] == 1
+
+
+# -- get_company_by_domain ----------------------------------------------------
+
+
+def test_get_company_by_domain(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    company = make_test_company(database_connection, name="Acme", domain="acme.com")
+    fetched = get_company_by_domain(database_connection, "acme.com")
+    assert fetched is not None
+    assert fetched.id == company.id
+    assert fetched.domain == "acme.com"
+
+
+def test_get_company_by_domain_not_found(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    assert get_company_by_domain(database_connection, "nonexistent.com") is None
+
+
+# -- get_last_cold_outbound ----------------------------------------------------
+
+
+def test_get_last_cold_outbound_returns_newest(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="r@example.com", domain="example.com"
+    )
+
+    # Older cold outbound (first in its thread).
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="old pitch",
+        contact_id=contact.id,
+        gmail_message_id="old-msg",
+        gmail_thread_id="thread-old",
+        status="sent",
+    )
+    # Newer cold outbound (first in a different thread).
+    newer = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="new pitch",
+        contact_id=contact.id,
+        gmail_message_id="new-msg",
+        gmail_thread_id="thread-new",
+        status="sent",
+    )
+    assert newer is not None
+
+    result = get_last_cold_outbound(database_connection, account.id, contact.id)
+    assert result is not None
+    assert result.id == newer.id
+
+
+def test_get_last_cold_outbound_excludes_follow_ups(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """A second outbound in the same thread is a follow-up, not cold outreach."""
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="r@example.com", domain="example.com"
+    )
+
+    # First outbound in thread (cold).
+    cold = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="initial pitch",
+        contact_id=contact.id,
+        gmail_message_id="cold-msg",
+        gmail_thread_id="thread-1",
+        status="sent",
+    )
+    assert cold is not None
+
+    # Second outbound in same thread (follow-up reply, not cold).
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="follow up",
+        contact_id=contact.id,
+        gmail_message_id="followup-msg",
+        gmail_thread_id="thread-1",
+        status="sent",
+    )
+
+    result = get_last_cold_outbound(database_connection, account.id, contact.id)
+    assert result is not None
+    # Should return the cold email, not the follow-up.
+    assert result.id == cold.id
+
+
+def test_get_last_cold_outbound_ignores_inbound(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="r@example.com", domain="example.com"
+    )
+
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="hello",
+        contact_id=contact.id,
+    )
+
+    result = get_last_cold_outbound(database_connection, account.id, contact.id)
+    assert result is None
+
+
+def test_get_last_cold_outbound_none_when_no_emails(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="r@example.com", domain="example.com"
+    )
+
+    result = get_last_cold_outbound(database_connection, account.id, contact.id)
+    assert result is None
+
+
+# -- search_emails with account_id filter --------------------------------------
+
+
+def test_search_emails_filters_by_account_id(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    a1 = make_test_account(database_connection, email="a1@example.com")
+    a2 = make_test_account(database_connection, email="a2@example.com")
+
+    create_email(
+        database_connection,
+        account_id=a1.id,
+        direction="inbound",
+        subject="pricing question",
+    )
+    create_email(
+        database_connection,
+        account_id=a2.id,
+        direction="inbound",
+        subject="pricing info",
+    )
+
+    results = search_emails(database_connection, "pricing", account_id=a1.id)
+    assert len(results) == 1
+    assert results[0].account_id == a1.id


### PR DESCRIPTION
## Summary

Implement all nine agent tools in `src/mailpilot/agent/tools.py` as standalone functions with explicit dependency parameters. Each tool wraps database/sync functions and adds business logic (guards, cooldowns). Issue #12 will wire these into Pydantic AI `RunContext[AgentDeps]`.

## Tools

1. `send_email` -- contact status guard + 30-day cold outreach cooldown, delegates to `sync.send_email()`
2. `create_task` -- schedule deferred work (follow-ups)
3. `cancel_task` -- cancel a pending task; returns error dict if not found/not pending
4. `update_contact_status` -- update `workflow_contact` status and reason
5. `disable_contact` -- global hard block across all workflows
6. `list_workflow_contacts` -- read pipeline state for a workflow
7. `search_emails` -- search email history scoped to account
8. `read_contact` -- CRM lookup by email address
9. `read_company` -- CRM lookup by domain (new `get_company_by_domain()`)

## Database additions

- `get_company_by_domain(connection, domain)` -- exact match on UNIQUE column
- `get_last_cold_outbound(connection, account_id, contact_id)` -- first outbound in its thread, used for cooldown
- `search_emails` updated with optional `account_id` filter

## Test plan

- [x] All nine tools implemented with correct guards and database calls
- [x] `send_email` enforces contact status guard (bounced/unsubscribed)
- [x] `send_email` enforces 30-day cold outreach cooldown; replies bypass cooldown
- [x] Cooldown detection uses thread-based query (not `gmail_thread_id IS NULL`) to match production Gmail behavior
- [x] `create_task` stores task with `scheduled_at` timestamp
- [x] `read_company` uses new `get_company_by_domain()`
- [x] All tools use explicit dependency params, not global state
- [x] `send_email` mocks `GmailClient`; all other tools use real DB
- [x] `make check` + `make clean` + `make e2e` pass

Resolves #11