### PR TITLE
feat(crm): implement activity table -- schema, model, database, CLI

### DIFF
--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -14,6 +14,19 @@ from typing import Any, NoReturn
 
 import click
 
+# Keep in sync with ActivityType in models.py and CHECK constraint in schema.sql.
+_ACTIVITY_TYPES = [
+    "email_sent",
+    "email_received",
+    "note_added",
+    "tag_added",
+    "tag_removed",
+    "status_changed",
+    "workflow_assigned",
+    "workflow_completed",
+    "workflow_failed",
+]
+
 
 def _database_url() -> str:
     """Resolve the database URL from settings at call time (not import time)."""
@@ -745,7 +758,13 @@ def activity() -> None:
 
 @activity.command("create")
 @click.option("--contact-id", required=True, help="Contact ID.")
-@click.option("--type", "activity_type", required=True, help="Activity type.")
+@click.option(
+    "--type",
+    "activity_type",
+    required=True,
+    type=click.Choice(_ACTIVITY_TYPES),
+    help="Activity type.",
+)
 @click.option("--summary", required=True, help="One-line description.")
 @click.option("--detail", default=None, help="JSON detail payload.")
 @click.option("--company-id", default=None, help="Optional company ID.")
@@ -778,7 +797,13 @@ def activity_create(
 @activity.command("list")
 @click.option("--contact-id", default=None, help="Filter by contact ID.")
 @click.option("--company-id", default=None, help="Filter by company ID.")
-@click.option("--type", "activity_type", default=None, help="Filter by activity type.")
+@click.option(
+    "--type",
+    "activity_type",
+    default=None,
+    type=click.Choice(_ACTIVITY_TYPES),
+    help="Filter by activity type.",
+)
 @click.option("--limit", default=100, help="Maximum results.")
 @click.option("--since", default=None, help="ISO datetime lower bound.")
 def activity_list(

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -735,6 +735,82 @@ def email_send(
         connection.close()
 
 
+# -- Activity commands ---------------------------------------------------------
+
+
+@main.group()
+def activity() -> None:
+    """Manage activity timeline events."""
+
+
+@activity.command("create")
+@click.option("--contact-id", required=True, help="Contact ID.")
+@click.option("--type", "activity_type", required=True, help="Activity type.")
+@click.option("--summary", required=True, help="One-line description.")
+@click.option("--detail", default=None, help="JSON detail payload.")
+@click.option("--company-id", default=None, help="Optional company ID.")
+def activity_create(
+    contact_id: str,
+    activity_type: str,
+    summary: str,
+    detail: str | None,
+    company_id: str | None,
+) -> None:
+    """Create an activity event."""
+    from mailpilot.database import create_activity, initialize_database
+
+    detail_dict: dict[str, object] = json.loads(detail) if detail else {}
+    connection = initialize_database(_database_url())
+    try:
+        created = create_activity(
+            connection,
+            contact_id=contact_id,
+            activity_type=activity_type,
+            summary=summary,
+            detail=detail_dict,
+            company_id=company_id,
+        )
+        output(created.model_dump(mode="json"))
+    finally:
+        connection.close()
+
+
+@activity.command("list")
+@click.option("--contact-id", default=None, help="Filter by contact ID.")
+@click.option("--company-id", default=None, help="Filter by company ID.")
+@click.option("--type", "activity_type", default=None, help="Filter by activity type.")
+@click.option("--limit", default=100, help="Maximum results.")
+@click.option("--since", default=None, help="ISO datetime lower bound.")
+def activity_list(
+    contact_id: str | None,
+    company_id: str | None,
+    activity_type: str | None,
+    limit: int,
+    since: str | None,
+) -> None:
+    """List activities (requires --contact-id or --company-id)."""
+    from mailpilot.database import initialize_database, list_activities
+
+    if contact_id is None and company_id is None:
+        output_error(
+            "at least one of --contact-id or --company-id is required",
+            "missing_filter",
+        )
+    connection = initialize_database(_database_url())
+    try:
+        activities = list_activities(
+            connection,
+            contact_id=contact_id,
+            company_id=company_id,
+            activity_type=activity_type,
+            limit=limit,
+            since=since,
+        )
+        output({"activities": [a.model_dump(mode="json") for a in activities]})
+    finally:
+        connection.close()
+
+
 # -- Workflow commands ---------------------------------------------------------
 
 

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -24,6 +24,7 @@ from psycopg.types.json import Json
 
 from mailpilot.models import (
     Account,
+    Activity,
     Company,
     Contact,
     Email,
@@ -118,7 +119,8 @@ def get_status_counts(
                 (SELECT COUNT(*) FROM company) AS companies,
                 (SELECT COUNT(*) FROM contact) AS contacts,
                 (SELECT COUNT(*) FROM workflow) AS workflows,
-                (SELECT COUNT(*) FROM email) AS emails
+                (SELECT COUNT(*) FROM email) AS emails,
+                (SELECT COUNT(*) FROM activity) AS activities
             FROM (SELECT 1) AS _dummy
             """
         ).fetchone()
@@ -128,6 +130,7 @@ def get_status_counts(
             "contacts": row["contacts"],  # type: ignore[index]
             "workflows": row["workflows"],  # type: ignore[index]
             "emails": row["emails"],  # type: ignore[index]
+            "activities": row["activities"],  # type: ignore[index]
         }
 
 
@@ -1739,6 +1742,116 @@ def cancel_task(
         if row is None:
             return None
         return Task.model_validate(row)
+
+
+# -- Activity ------------------------------------------------------------------
+
+
+def create_activity(
+    connection: psycopg.Connection[dict[str, Any]],
+    contact_id: str,
+    activity_type: str,
+    summary: str = "",
+    detail: dict[str, object] | None = None,
+    company_id: str | None = None,
+) -> Activity:
+    """Create an activity event in a contact's timeline.
+
+    Args:
+        connection: Open database connection.
+        contact_id: Contact FK (every activity relates to a contact).
+        activity_type: Activity type (email_sent, tag_added, etc.).
+        summary: One-line human-readable description.
+        detail: Type-specific JSON data (email_id, tag name, etc.).
+        company_id: Optional company FK for company-level views.
+
+    Returns:
+        Created activity.
+    """
+    with logfire.span(
+        "db.activity.create",
+        contact_id=contact_id,
+        activity_type=activity_type,
+    ) as span:
+        row = connection.execute(
+            """\
+            INSERT INTO activity (id, contact_id, company_id, type, summary, detail)
+            VALUES (%(id)s, %(contact_id)s, %(company_id)s, %(type)s,
+                    %(summary)s, %(detail)s)
+            RETURNING *
+            """,
+            {
+                "id": _new_id(),
+                "contact_id": contact_id,
+                "company_id": company_id,
+                "type": activity_type,
+                "summary": summary,
+                "detail": Json(detail or {}),
+            },
+        ).fetchone()
+        connection.commit()
+        activity = Activity.model_validate(row)
+        span.set_attribute("activity_id", activity.id)
+        return activity
+
+
+def list_activities(
+    connection: psycopg.Connection[dict[str, Any]],
+    contact_id: str | None = None,
+    company_id: str | None = None,
+    activity_type: str | None = None,
+    limit: int = 100,
+    since: str | None = None,
+) -> list[Activity]:
+    """List activities with required contact or company filter.
+
+    At least one of ``contact_id`` or ``company_id`` must be provided.
+
+    Args:
+        connection: Open database connection.
+        contact_id: Filter by contact ID.
+        company_id: Filter by company ID.
+        activity_type: Filter by activity type.
+        limit: Maximum number of results.
+        since: ISO datetime lower bound for created_at.
+
+    Returns:
+        Activities ordered by created_at descending.
+
+    Raises:
+        ValueError: If neither contact_id nor company_id is provided.
+    """
+    if contact_id is None and company_id is None:
+        raise ValueError("at least one of contact_id or company_id is required")
+    with logfire.span(
+        "db.activity.list",
+        contact_id=contact_id,
+        company_id=company_id,
+        activity_type=activity_type,
+        limit=limit,
+    ) as span:
+        conditions: list[SQL] = []
+        params: dict[str, object] = {"limit": limit}
+        if contact_id is not None:
+            conditions.append(SQL("contact_id = %(contact_id)s"))
+            params["contact_id"] = contact_id
+        if company_id is not None:
+            conditions.append(SQL("company_id = %(company_id)s"))
+            params["company_id"] = company_id
+        if activity_type is not None:
+            conditions.append(SQL("type = %(activity_type)s"))
+            params["activity_type"] = activity_type
+        if since is not None:
+            conditions.append(SQL("created_at >= %(since)s"))
+            params["since"] = since
+        where = SQL("WHERE ") + SQL(" AND ").join(conditions) if conditions else SQL("")
+        query = SQL(
+            "SELECT * FROM activity {} ORDER BY created_at DESC LIMIT %(limit)s"
+        ).format(where)
+        rows = connection.execute(query, params).fetchall()
+        activities = [Activity.model_validate(row) for row in rows]
+        span.set_attribute("activity_count", len(activities))
+        return activities
 
 
 # -- Sync Status ---------------------------------------------------------------

--- a/src/mailpilot/models.py
+++ b/src/mailpilot/models.py
@@ -136,6 +136,31 @@ class Task(BaseModel):
     created_at: datetime
 
 
+ActivityType = Literal[
+    "email_sent",
+    "email_received",
+    "note_added",
+    "tag_added",
+    "tag_removed",
+    "status_changed",
+    "workflow_assigned",
+    "workflow_completed",
+    "workflow_failed",
+]
+
+
+class Activity(BaseModel):
+    """Chronological event in a contact's relationship timeline."""
+
+    id: str
+    contact_id: str
+    company_id: str | None = None
+    type: ActivityType
+    summary: str = ""
+    detail: dict[str, object] = {}
+    created_at: datetime
+
+
 class SyncStatus(BaseModel):
     """Singleton row tracking the running sync process."""
 

--- a/src/mailpilot/schema.sql
+++ b/src/mailpilot/schema.sql
@@ -125,3 +125,24 @@ CREATE INDEX IF NOT EXISTS idx_email_account_id ON email(account_id);
 CREATE INDEX IF NOT EXISTS idx_email_contact_id ON email(contact_id);
 CREATE INDEX IF NOT EXISTS idx_email_workflow_id ON email(workflow_id);
 CREATE INDEX IF NOT EXISTS idx_email_gmail_thread_id ON email(gmail_thread_id);
+
+CREATE TABLE IF NOT EXISTS activity (
+    id              TEXT PRIMARY KEY,
+    contact_id      TEXT NOT NULL REFERENCES contact(id),
+    company_id      TEXT REFERENCES company(id),
+    type            TEXT NOT NULL
+                    CHECK (type IN (
+                        'email_sent', 'email_received',
+                        'note_added', 'tag_added', 'tag_removed',
+                        'status_changed', 'workflow_assigned',
+                        'workflow_completed', 'workflow_failed'
+                    )),
+    summary         TEXT NOT NULL DEFAULT '',
+    detail          JSONB NOT NULL DEFAULT '{}',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_activity_contact_id ON activity(contact_id);
+CREATE INDEX IF NOT EXISTS idx_activity_company_id ON activity(company_id);
+CREATE INDEX IF NOT EXISTS idx_activity_type ON activity(type);
+CREATE INDEX IF NOT EXISTS idx_activity_created_at ON activity(created_at);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,12 +13,13 @@ from psycopg.rows import dict_row
 
 from mailpilot.database import (
     create_account,
+    create_activity,
     create_company,
     create_contact,
     create_workflow,
     initialize_database,
 )
-from mailpilot.models import Account, Company, Contact, Workflow
+from mailpilot.models import Account, Activity, Company, Contact, Workflow
 from mailpilot.settings import Settings
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
@@ -61,7 +62,7 @@ def database_connection() -> Iterator[psycopg.Connection[dict[str, Any]]]:
         psycopg.connect(TEST_DATABASE_URL, row_factory=dict_row),  # type: ignore[arg-type]
     )
     conn.execute(
-        "TRUNCATE TABLE sync_status, task, email, workflow_contact, "
+        "TRUNCATE TABLE activity, sync_status, task, email, workflow_contact, "
         "workflow, contact, company, account CASCADE"
     )
     conn.commit()
@@ -120,4 +121,23 @@ def make_test_workflow(
         name=name,
         workflow_type=workflow_type,
         account_id=account_id,
+    )
+
+
+def make_test_activity(
+    connection: psycopg.Connection[dict[str, Any]],
+    contact_id: str,
+    activity_type: str = "email_sent",
+    summary: str = "Test activity",
+    detail: dict[str, object] | None = None,
+    company_id: str | None = None,
+) -> Activity:
+    """Create a test activity in the database."""
+    return create_activity(
+        connection,
+        contact_id=contact_id,
+        activity_type=activity_type,
+        summary=summary,
+        detail=detail or {},
+        company_id=company_id,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ from click.testing import CliRunner
 
 from conftest import make_test_settings
 from mailpilot.cli import main
-from mailpilot.models import Account, Company, Contact, Email, Workflow
+from mailpilot.models import Account, Activity, Company, Contact, Email, Workflow
 
 _NOW = datetime(2024, 1, 1, tzinfo=UTC)
 
@@ -1743,3 +1743,178 @@ def test_workflow_run_contact_not_found(
     assert result.exit_code == 1
     data = json.loads(result.output)
     assert data["error"] == "not_found"
+
+
+# -- Activity ------------------------------------------------------------------
+
+
+def _make_activity(**overrides: Any) -> Activity:
+    defaults: dict[str, Any] = {
+        "id": "01234567-0000-7000-0000-000000000010",
+        "contact_id": "01234567-0000-7000-0000-000000000003",
+        "type": "email_sent",
+        "summary": "Sent intro email",
+        "detail": {},
+        "created_at": _NOW,
+    }
+    return Activity(**{**defaults, **overrides})
+
+
+# -- activity create -----------------------------------------------------------
+
+
+def test_activity_create(runner: CliRunner, mock_connection: MagicMock) -> None:
+    activity = _make_activity()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch(
+            "mailpilot.database.create_activity", return_value=activity
+        ) as mock_create,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "activity",
+                "create",
+                "--contact-id",
+                "cid-1",
+                "--type",
+                "email_sent",
+                "--summary",
+                "Sent intro",
+            ],
+        )
+
+    assert result.exit_code == 0
+    mock_create.assert_called_once_with(
+        mock_connection,
+        contact_id="cid-1",
+        activity_type="email_sent",
+        summary="Sent intro",
+        detail={},
+        company_id=None,
+    )
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["type"] == "email_sent"
+
+
+def test_activity_create_with_detail(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    activity = _make_activity(detail={"email_id": "e-1"})
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch(
+            "mailpilot.database.create_activity", return_value=activity
+        ) as mock_create,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "activity",
+                "create",
+                "--contact-id",
+                "cid-1",
+                "--type",
+                "email_sent",
+                "--summary",
+                "Sent intro",
+                "--detail",
+                '{"email_id": "e-1"}',
+            ],
+        )
+
+    assert result.exit_code == 0
+    mock_create.assert_called_once_with(
+        mock_connection,
+        contact_id="cid-1",
+        activity_type="email_sent",
+        summary="Sent intro",
+        detail={"email_id": "e-1"},
+        company_id=None,
+    )
+
+
+# -- activity list -------------------------------------------------------------
+
+
+def test_activity_list(runner: CliRunner, mock_connection: MagicMock) -> None:
+    activities = [
+        _make_activity(id="id-1", summary="first"),
+        _make_activity(id="id-2", summary="second"),
+    ]
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_activities", return_value=activities),
+    ):
+        result = runner.invoke(main, ["activity", "list", "--contact-id", "cid-1"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert len(data["activities"]) == 2
+
+
+def test_activity_list_empty(runner: CliRunner, mock_connection: MagicMock) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_activities", return_value=[]),
+    ):
+        result = runner.invoke(main, ["activity", "list", "--contact-id", "cid-1"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["activities"] == []
+
+
+def test_activity_list_with_filters(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_activities", return_value=[]) as mock_list,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "activity",
+                "list",
+                "--contact-id",
+                "cid-1",
+                "--type",
+                "email_sent",
+                "--limit",
+                "5",
+                "--since",
+                "2024-01-01T00:00:00Z",
+            ],
+        )
+
+    assert result.exit_code == 0
+    mock_list.assert_called_once_with(
+        mock_connection,
+        contact_id="cid-1",
+        company_id=None,
+        activity_type="email_sent",
+        limit=5,
+        since="2024-01-01T00:00:00Z",
+    )
+
+
+def test_activity_list_no_filter(runner: CliRunner, mock_connection: MagicMock) -> None:
+    """activity list without --contact-id or --company-id should error."""
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+    ):
+        result = runner.invoke(main, ["activity", "list"])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "missing_filter"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,6 +1,7 @@
 """Integration tests for database CRUD operations (real DB)."""
 
 import threading
+from datetime import UTC
 from typing import Any, cast
 
 import psycopg
@@ -10,12 +11,14 @@ from psycopg.rows import dict_row
 from conftest import (
     TEST_DATABASE_URL,
     make_test_account,
+    make_test_activity,
     make_test_company,
     make_test_contact,
     make_test_workflow,
 )
 from mailpilot.database import (
     activate_workflow,
+    create_activity,
     create_contacts_bulk,
     create_email,
     create_or_get_contact_by_email,
@@ -29,8 +32,10 @@ from mailpilot.database import (
     get_email_by_gmail_message_id,
     get_emails_by_gmail_thread_id,
     get_last_cold_outbound,
+    get_status_counts,
     get_workflow,
     list_accounts,
+    list_activities,
     list_companies,
     list_contacts,
     list_emails,
@@ -945,3 +950,151 @@ def test_search_emails_filters_by_account_id(
     results = search_emails(database_connection, "pricing", account_id=a1.id)
     assert len(results) == 1
     assert results[0].account_id == a1.id
+
+
+# -- Activity ------------------------------------------------------------------
+
+
+def test_create_activity(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    activity = make_test_activity(database_connection, contact_id=contact.id)
+    assert activity.contact_id == contact.id
+    assert activity.type == "email_sent"
+    assert activity.summary == "Test activity"
+    assert activity.detail == {}
+    assert activity.company_id is None
+    assert activity.id
+
+
+def test_create_activity_with_company(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    company = make_test_company(database_connection)
+    contact = make_test_contact(database_connection, company_id=company.id)
+    activity = make_test_activity(
+        database_connection,
+        contact_id=contact.id,
+        company_id=company.id,
+        activity_type="tag_added",
+        summary="Tagged as prospect",
+        detail={"tag": "prospect"},
+    )
+    assert activity.company_id == company.id
+    assert activity.type == "tag_added"
+    assert activity.detail == {"tag": "prospect"}
+
+
+def test_create_activity_with_detail(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    activity = create_activity(
+        database_connection,
+        contact_id=contact.id,
+        activity_type="email_sent",
+        summary="Sent intro email",
+        detail={"email_id": "e-123", "subject": "Hello"},
+    )
+    assert activity.detail == {"email_id": "e-123", "subject": "Hello"}
+
+
+def test_list_activities_by_contact(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    c1 = make_test_contact(database_connection, email="a@test.com", domain="test.com")
+    c2 = make_test_contact(database_connection, email="b@test.com", domain="test.com")
+    make_test_activity(database_connection, contact_id=c1.id, summary="first")
+    make_test_activity(database_connection, contact_id=c1.id, summary="second")
+    make_test_activity(database_connection, contact_id=c2.id, summary="other")
+
+    results = list_activities(database_connection, contact_id=c1.id)
+    assert len(results) == 2
+    # Ordered by created_at DESC
+    assert results[0].summary == "second"
+    assert results[1].summary == "first"
+
+
+def test_list_activities_by_company(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    company = make_test_company(database_connection)
+    contact = make_test_contact(database_connection, company_id=company.id)
+    make_test_activity(
+        database_connection, contact_id=contact.id, company_id=company.id
+    )
+
+    results = list_activities(database_connection, company_id=company.id)
+    assert len(results) == 1
+    assert results[0].company_id == company.id
+
+
+def test_list_activities_by_type(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    make_test_activity(
+        database_connection, contact_id=contact.id, activity_type="email_sent"
+    )
+    make_test_activity(
+        database_connection, contact_id=contact.id, activity_type="tag_added"
+    )
+
+    results = list_activities(
+        database_connection, contact_id=contact.id, activity_type="tag_added"
+    )
+    assert len(results) == 1
+    assert results[0].type == "tag_added"
+
+
+def test_list_activities_since(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    from datetime import datetime, timedelta
+
+    contact = make_test_contact(database_connection)
+    make_test_activity(database_connection, contact_id=contact.id, summary="old")
+    # Set old activity's created_at to the past
+    database_connection.execute(
+        "UPDATE activity SET created_at = CURRENT_TIMESTAMP - interval '2 days' "
+        "WHERE summary = 'old'"
+    )
+    database_connection.commit()
+    make_test_activity(database_connection, contact_id=contact.id, summary="recent")
+
+    since = datetime.now(UTC) - timedelta(days=1)
+    results = list_activities(
+        database_connection, contact_id=contact.id, since=since.isoformat()
+    )
+    assert len(results) == 1
+    assert results[0].summary == "recent"
+
+
+def test_list_activities_with_limit(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    for i in range(5):
+        make_test_activity(
+            database_connection, contact_id=contact.id, summary=f"act-{i}"
+        )
+
+    results = list_activities(database_connection, contact_id=contact.id, limit=2)
+    assert len(results) == 2
+
+
+def test_list_activities_requires_filter(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    with pytest.raises(ValueError, match="contact_id or company_id"):
+        list_activities(database_connection)
+
+
+def test_status_counts_includes_activities(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    make_test_activity(database_connection, contact_id=contact.id)
+    counts = get_status_counts(database_connection)
+    assert counts["activities"] == 1


### PR DESCRIPTION
## Summary

Implements the `activity` table as the foundation for CRM evolution (ADR-08). The activity table is the unified per-contact timeline -- a chronological log of every significant event. Claude Code queries this table for relationship health, activity summaries, and reporting.

## Changes

- Add `activity` table schema with CHECK constraint on type and indexes on contact_id, company_id, type, created_at
- Add `Activity` model and `ActivityType` literal in models.py
- Add `create_activity` and `list_activities` database functions with logfire spans
- Add `activity create` and `activity list` CLI commands with `click.Choice` validation on `--type`
- Add `--contact-id` / `--company-id` required filter validation on `activity list`
- Update `get_status_counts` to include activity count
- Add test fixtures (`make_test_activity`), CLI unit tests, and database integration tests

Resolves #43