### PR TITLE
feat(crm): implement tag table -- schema, model, database, CLI (#44)

### DIFF
--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -864,6 +864,7 @@ def tag_add(contact_id: str | None, company_id: str | None, name: str) -> None:
     from mailpilot.database import (
         create_activity,
         create_tag,
+        get_company,
         get_contact,
         initialize_database,
     )
@@ -871,6 +872,21 @@ def tag_add(contact_id: str | None, company_id: str | None, name: str) -> None:
     entity_type, entity_id = _resolve_entity(contact_id, company_id)
     connection = initialize_database(_database_url())
     try:
+        # Validate entity exists before creating tag
+        if entity_type == "contact":
+            contact = get_contact(connection, entity_id)
+            if contact is None:
+                output_error(
+                    f"contact {entity_id} not found",
+                    "not_found",
+                )
+        else:
+            company = get_company(connection, entity_id)
+            if company is None:
+                output_error(
+                    f"company {entity_id} not found",
+                    "not_found",
+                )
         created = create_tag(
             connection,
             entity_type=entity_type,

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -836,6 +836,151 @@ def activity_list(
         connection.close()
 
 
+# -- Tag commands --------------------------------------------------------------
+
+
+@main.group()
+def tag() -> None:
+    """Manage tags on contacts and companies."""
+
+
+def _resolve_entity(contact_id: str | None, company_id: str | None) -> tuple[str, str]:
+    """Return (entity_type, entity_id) or call output_error."""
+    if contact_id and company_id:
+        output_error("specify only one of --contact-id or --company-id", "invalid_args")
+    if contact_id:
+        return ("contact", contact_id)
+    if company_id:
+        return ("company", company_id)
+    output_error("one of --contact-id or --company-id is required", "missing_filter")
+
+
+@tag.command("add")
+@click.option("--contact-id", default=None, help="Contact ID.")
+@click.option("--company-id", default=None, help="Company ID.")
+@click.argument("name")
+def tag_add(contact_id: str | None, company_id: str | None, name: str) -> None:
+    """Add a tag to a contact or company."""
+    from mailpilot.database import (
+        create_activity,
+        create_tag,
+        get_contact,
+        initialize_database,
+    )
+
+    entity_type, entity_id = _resolve_entity(contact_id, company_id)
+    connection = initialize_database(_database_url())
+    try:
+        created = create_tag(
+            connection,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            name=name,
+        )
+        if created is None:
+            normalized = name.strip().lower()
+            output_error(
+                f"tag '{normalized}' already exists on {entity_type} {entity_id}",
+                "already_exists",
+            )
+        # Create tag_added activity when tagging a contact
+        if entity_type == "contact":
+            contact = get_contact(connection, entity_id)
+            create_activity(
+                connection,
+                contact_id=entity_id,
+                activity_type="tag_added",
+                summary=f"Tagged as {created.name}",
+                detail={"tag": created.name},
+                company_id=contact.company_id if contact else None,
+            )
+        output(created.model_dump(mode="json"))
+    finally:
+        connection.close()
+
+
+@tag.command("remove")
+@click.option("--contact-id", default=None, help="Contact ID.")
+@click.option("--company-id", default=None, help="Company ID.")
+@click.argument("name")
+def tag_remove(contact_id: str | None, company_id: str | None, name: str) -> None:
+    """Remove a tag from a contact or company."""
+    from mailpilot.database import (
+        create_activity,
+        delete_tag,
+        get_contact,
+        initialize_database,
+    )
+
+    entity_type, entity_id = _resolve_entity(contact_id, company_id)
+    connection = initialize_database(_database_url())
+    try:
+        deleted = delete_tag(
+            connection,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            name=name,
+        )
+        normalized = name.strip().lower()
+        if not deleted:
+            output_error(
+                f"tag '{normalized}' not found on {entity_type} {entity_id}",
+                "not_found",
+            )
+        # Create tag_removed activity when untagging a contact
+        if entity_type == "contact":
+            contact = get_contact(connection, entity_id)
+            create_activity(
+                connection,
+                contact_id=entity_id,
+                activity_type="tag_removed",
+                summary=f"Removed tag {normalized}",
+                detail={"tag": normalized},
+                company_id=contact.company_id if contact else None,
+            )
+        output({"removed": True, "tag": normalized, "entity_type": entity_type})
+    finally:
+        connection.close()
+
+
+@tag.command("list")
+@click.option("--contact-id", default=None, help="Contact ID.")
+@click.option("--company-id", default=None, help="Company ID.")
+def tag_list(contact_id: str | None, company_id: str | None) -> None:
+    """List tags on a contact or company."""
+    from mailpilot.database import initialize_database, list_tags
+
+    entity_type, entity_id = _resolve_entity(contact_id, company_id)
+    connection = initialize_database(_database_url())
+    try:
+        tags = list_tags(connection, entity_type=entity_type, entity_id=entity_id)
+        output({"tags": [t.model_dump(mode="json") for t in tags]})
+    finally:
+        connection.close()
+
+
+@tag.command("search")
+@click.argument("name")
+@click.option(
+    "--type",
+    "entity_type",
+    default=None,
+    type=click.Choice(["contact", "company"]),
+    help="Filter by entity type.",
+)
+@click.option("--limit", default=100, help="Maximum results.")
+def tag_search(name: str, entity_type: str | None, limit: int) -> None:
+    """Search tags by name."""
+    from mailpilot.database import initialize_database, search_tags
+
+    connection = initialize_database(_database_url())
+    try:
+        tags = search_tags(connection, name=name, entity_type=entity_type, limit=limit)
+        output({"tags": [t.model_dump(mode="json") for t in tags]})
+    finally:
+        connection.close()
+
+
 # -- Workflow commands ---------------------------------------------------------
 
 

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -29,6 +29,7 @@ from mailpilot.models import (
     Contact,
     Email,
     SyncStatus,
+    Tag,
     Task,
     Workflow,
     WorkflowContact,
@@ -120,7 +121,8 @@ def get_status_counts(
                 (SELECT COUNT(*) FROM contact) AS contacts,
                 (SELECT COUNT(*) FROM workflow) AS workflows,
                 (SELECT COUNT(*) FROM email) AS emails,
-                (SELECT COUNT(*) FROM activity) AS activities
+                (SELECT COUNT(*) FROM activity) AS activities,
+                (SELECT COUNT(*) FROM tag) AS tags
             FROM (SELECT 1) AS _dummy
             """
         ).fetchone()
@@ -131,6 +133,7 @@ def get_status_counts(
             "workflows": row["workflows"],  # type: ignore[index]
             "emails": row["emails"],  # type: ignore[index]
             "activities": row["activities"],  # type: ignore[index]
+            "tags": row["tags"],  # type: ignore[index]
         }
 
 
@@ -1852,6 +1855,215 @@ def list_activities(
         activities = [Activity.model_validate(row) for row in rows]
         span.set_attribute("activity_count", len(activities))
         return activities
+
+
+# -- Tag -----------------------------------------------------------------------
+
+
+def create_tag(
+    connection: psycopg.Connection[dict[str, Any]],
+    entity_type: str,
+    entity_id: str,
+    name: str,
+) -> Tag | None:
+    """Create a tag on a contact or company.
+
+    Normalizes the tag name to lowercase with leading/trailing whitespace
+    stripped. Uses ON CONFLICT DO NOTHING so duplicate tags are silently
+    ignored.
+
+    Args:
+        connection: Open database connection.
+        entity_type: "contact" or "company".
+        entity_id: ID of the tagged entity.
+        name: Tag name (normalized to lowercase).
+
+    Returns:
+        Created tag, or None if the tag already exists.
+    """
+    normalized = name.strip().lower()
+    with logfire.span(
+        "db.tag.create",
+        entity_type=entity_type,
+        entity_id=entity_id,
+        name=normalized,
+    ) as span:
+        row = connection.execute(
+            """\
+            INSERT INTO tag (id, entity_type, entity_id, name)
+            VALUES (%(id)s, %(entity_type)s, %(entity_id)s, %(name)s)
+            ON CONFLICT (entity_type, entity_id, name) DO NOTHING
+            RETURNING *
+            """,
+            {
+                "id": _new_id(),
+                "entity_type": entity_type,
+                "entity_id": entity_id,
+                "name": normalized,
+            },
+        ).fetchone()
+        connection.commit()
+        if row is None:
+            span.set_attribute("result", "already_exists")
+            return None
+        tag = Tag.model_validate(row)
+        span.set_attribute("tag_id", tag.id)
+        return tag
+
+
+def delete_tag(
+    connection: psycopg.Connection[dict[str, Any]],
+    entity_type: str,
+    entity_id: str,
+    name: str,
+) -> bool:
+    """Remove a tag from a contact or company.
+
+    Args:
+        connection: Open database connection.
+        entity_type: "contact" or "company".
+        entity_id: ID of the tagged entity.
+        name: Tag name (normalized to lowercase for matching).
+
+    Returns:
+        True if the tag was deleted, False if it was not found.
+    """
+    normalized = name.strip().lower()
+    with logfire.span(
+        "db.tag.delete",
+        entity_type=entity_type,
+        entity_id=entity_id,
+        name=normalized,
+    ) as span:
+        cursor = connection.execute(
+            """\
+            DELETE FROM tag
+            WHERE entity_type = %(entity_type)s
+              AND entity_id = %(entity_id)s
+              AND name = %(name)s
+            """,
+            {
+                "entity_type": entity_type,
+                "entity_id": entity_id,
+                "name": normalized,
+            },
+        )
+        connection.commit()
+        deleted = cursor.rowcount > 0
+        span.set_attribute("deleted", deleted)
+        return deleted
+
+
+def list_tags(
+    connection: psycopg.Connection[dict[str, Any]],
+    entity_type: str,
+    entity_id: str,
+) -> list[Tag]:
+    """List all tags on a contact or company.
+
+    Args:
+        connection: Open database connection.
+        entity_type: "contact" or "company".
+        entity_id: ID of the tagged entity.
+
+    Returns:
+        Tags ordered by name.
+    """
+    with logfire.span(
+        "db.tag.list",
+        entity_type=entity_type,
+        entity_id=entity_id,
+    ) as span:
+        rows = connection.execute(
+            """\
+            SELECT * FROM tag
+            WHERE entity_type = %(entity_type)s AND entity_id = %(entity_id)s
+            ORDER BY name
+            """,
+            {"entity_type": entity_type, "entity_id": entity_id},
+        ).fetchall()
+        tags = [Tag.model_validate(row) for row in rows]
+        span.set_attribute("tag_count", len(tags))
+        return tags
+
+
+def list_entities_by_tag(
+    connection: psycopg.Connection[dict[str, Any]],
+    entity_type: str,
+    name: str,
+    limit: int = 100,
+) -> list[str]:
+    """Find all entities with a given tag.
+
+    Args:
+        connection: Open database connection.
+        entity_type: "contact" or "company".
+        name: Tag name to search for.
+        limit: Maximum number of entity IDs to return.
+
+    Returns:
+        Entity IDs matching the tag.
+    """
+    normalized = name.strip().lower()
+    with logfire.span(
+        "db.tag.list_entities",
+        entity_type=entity_type,
+        name=normalized,
+        limit=limit,
+    ) as span:
+        rows = connection.execute(
+            """\
+            SELECT entity_id FROM tag
+            WHERE entity_type = %(entity_type)s AND name = %(name)s
+            ORDER BY created_at
+            LIMIT %(limit)s
+            """,
+            {"entity_type": entity_type, "name": normalized, "limit": limit},
+        ).fetchall()
+        entity_ids = [row["entity_id"] for row in rows]
+        span.set_attribute("entity_count", len(entity_ids))
+        return entity_ids
+
+
+def search_tags(
+    connection: psycopg.Connection[dict[str, Any]],
+    name: str,
+    entity_type: str | None = None,
+    limit: int = 100,
+) -> list[Tag]:
+    """Search tags by name with optional entity type filter.
+
+    Args:
+        connection: Open database connection.
+        name: Tag name pattern (LIKE match).
+        entity_type: Optional filter by "contact" or "company".
+        limit: Maximum number of results.
+
+    Returns:
+        Matching tags ordered by name.
+    """
+    with logfire.span(
+        "db.tag.search",
+        name=name,
+        entity_type=entity_type,
+        limit=limit,
+    ) as span:
+        pattern = f"%{name.strip().lower()}%"
+        params: dict[str, object] = {"pattern": pattern, "limit": limit}
+        type_filter = SQL("")
+        if entity_type is not None:
+            type_filter = SQL("AND entity_type = %(entity_type)s")
+            params["entity_type"] = entity_type
+        query = SQL(
+            "SELECT * FROM tag "
+            "WHERE name LIKE %(pattern)s {} "
+            "ORDER BY name "
+            "LIMIT %(limit)s"
+        ).format(type_filter)
+        rows = connection.execute(query, params).fetchall()
+        tags = [Tag.model_validate(row) for row in rows]
+        span.set_attribute("tag_count", len(tags))
+        return tags
 
 
 # -- Sync Status ---------------------------------------------------------------

--- a/src/mailpilot/models.py
+++ b/src/mailpilot/models.py
@@ -161,6 +161,19 @@ class Activity(BaseModel):
     created_at: datetime
 
 
+TagEntityType = Literal["contact", "company"]
+
+
+class Tag(BaseModel):
+    """Flexible label on a contact or company for segmentation."""
+
+    id: str
+    entity_type: TagEntityType
+    entity_id: str
+    name: str
+    created_at: datetime
+
+
 class SyncStatus(BaseModel):
     """Singleton row tracking the running sync process."""
 

--- a/src/mailpilot/schema.sql
+++ b/src/mailpilot/schema.sql
@@ -146,3 +146,16 @@ CREATE INDEX IF NOT EXISTS idx_activity_contact_id ON activity(contact_id);
 CREATE INDEX IF NOT EXISTS idx_activity_company_id ON activity(company_id);
 CREATE INDEX IF NOT EXISTS idx_activity_type ON activity(type);
 CREATE INDEX IF NOT EXISTS idx_activity_created_at ON activity(created_at);
+
+CREATE TABLE IF NOT EXISTS tag (
+    id              TEXT PRIMARY KEY,
+    entity_type     TEXT NOT NULL
+                    CHECK (entity_type IN ('contact', 'company')),
+    entity_id       TEXT NOT NULL,
+    name            TEXT NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (entity_type, entity_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tag_entity ON tag(entity_type, entity_id);
+CREATE INDEX IF NOT EXISTS idx_tag_name ON tag(name);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,10 +16,11 @@ from mailpilot.database import (
     create_activity,
     create_company,
     create_contact,
+    create_tag,
     create_workflow,
     initialize_database,
 )
-from mailpilot.models import Account, Activity, Company, Contact, Workflow
+from mailpilot.models import Account, Activity, Company, Contact, Tag, Workflow
 from mailpilot.settings import Settings
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
@@ -62,7 +63,7 @@ def database_connection() -> Iterator[psycopg.Connection[dict[str, Any]]]:
         psycopg.connect(TEST_DATABASE_URL, row_factory=dict_row),  # type: ignore[arg-type]
     )
     conn.execute(
-        "TRUNCATE TABLE activity, sync_status, task, email, workflow_contact, "
+        "TRUNCATE TABLE tag, activity, sync_status, task, email, workflow_contact, "
         "workflow, contact, company, account CASCADE"
     )
     conn.commit()
@@ -141,3 +142,20 @@ def make_test_activity(
         detail=detail or {},
         company_id=company_id,
     )
+
+
+def make_test_tag(
+    connection: psycopg.Connection[dict[str, Any]],
+    entity_type: str = "contact",
+    entity_id: str = "",
+    name: str = "prospect",
+) -> Tag:
+    """Create a test tag in the database."""
+    tag = create_tag(
+        connection,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        name=name,
+    )
+    assert tag is not None, f"tag '{name}' already exists"
+    return tag

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1992,9 +1992,11 @@ def test_tag_add_creates_activity(
 
 
 def test_tag_add_already_exists(runner: CliRunner, mock_connection: MagicMock) -> None:
+    contact = _make_contact(id="cid-1")
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=contact),
         patch("mailpilot.database.create_tag", return_value=None),
     ):
         result = runner.invoke(
@@ -2005,6 +2007,44 @@ def test_tag_add_already_exists(runner: CliRunner, mock_connection: MagicMock) -
     assert result.exit_code == 1
     data = json.loads(result.output)
     assert data["error"] == "already_exists"
+
+
+def test_tag_add_contact_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=None),
+    ):
+        result = runner.invoke(
+            main,
+            ["tag", "add", "--contact-id", "cid-missing", "prospect"],
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "contact" in data["message"]
+
+
+def test_tag_add_company_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_company", return_value=None),
+    ):
+        result = runner.invoke(
+            main,
+            ["tag", "add", "--company-id", "cid-missing", "prospect"],
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "company" in data["message"]
 
 
 def test_tag_add_no_entity(runner: CliRunner, mock_connection: MagicMock) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ from click.testing import CliRunner
 
 from conftest import make_test_settings
 from mailpilot.cli import main
-from mailpilot.models import Account, Activity, Company, Contact, Email, Workflow
+from mailpilot.models import Account, Activity, Company, Contact, Email, Tag, Workflow
 
 _NOW = datetime(2024, 1, 1, tzinfo=UTC)
 
@@ -1918,3 +1918,245 @@ def test_activity_list_no_filter(runner: CliRunner, mock_connection: MagicMock) 
     assert result.exit_code == 1
     data = json.loads(result.output)
     assert data["error"] == "missing_filter"
+
+
+# -- Tag -----------------------------------------------------------------------
+
+
+def _make_tag(**overrides: Any) -> Tag:
+    defaults: dict[str, Any] = {
+        "id": "01234567-0000-7000-0000-000000000011",
+        "entity_type": "contact",
+        "entity_id": "01234567-0000-7000-0000-000000000003",
+        "name": "prospect",
+        "created_at": _NOW,
+    }
+    return Tag(**{**defaults, **overrides})
+
+
+# -- tag add -------------------------------------------------------------------
+
+
+def test_tag_add(runner: CliRunner, mock_connection: MagicMock) -> None:
+    tag = _make_tag()
+    contact = _make_contact()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.create_tag", return_value=tag) as mock_create,
+        patch("mailpilot.database.get_contact", return_value=contact),
+        patch("mailpilot.database.create_activity"),
+    ):
+        result = runner.invoke(
+            main,
+            ["tag", "add", "--contact-id", "cid-1", "prospect"],
+        )
+
+    assert result.exit_code == 0
+    mock_create.assert_called_once_with(
+        mock_connection,
+        entity_type="contact",
+        entity_id="cid-1",
+        name="prospect",
+    )
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["name"] == "prospect"
+
+
+def test_tag_add_creates_activity(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    tag = _make_tag()
+    contact = _make_contact()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.create_tag", return_value=tag),
+        patch("mailpilot.database.get_contact", return_value=contact),
+        patch("mailpilot.database.create_activity") as mock_activity,
+    ):
+        runner.invoke(
+            main,
+            ["tag", "add", "--contact-id", "cid-1", "prospect"],
+        )
+
+    mock_activity.assert_called_once_with(
+        mock_connection,
+        contact_id="cid-1",
+        activity_type="tag_added",
+        summary="Tagged as prospect",
+        detail={"tag": "prospect"},
+        company_id=None,
+    )
+
+
+def test_tag_add_already_exists(runner: CliRunner, mock_connection: MagicMock) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.create_tag", return_value=None),
+    ):
+        result = runner.invoke(
+            main,
+            ["tag", "add", "--contact-id", "cid-1", "prospect"],
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "already_exists"
+
+
+def test_tag_add_no_entity(runner: CliRunner, mock_connection: MagicMock) -> None:
+    """tag add without --contact-id or --company-id should error."""
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+    ):
+        result = runner.invoke(main, ["tag", "add", "prospect"])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "missing_filter"
+
+
+# -- tag remove ----------------------------------------------------------------
+
+
+def test_tag_remove(runner: CliRunner, mock_connection: MagicMock) -> None:
+    contact = _make_contact()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.delete_tag", return_value=True) as mock_delete,
+        patch("mailpilot.database.get_contact", return_value=contact),
+        patch("mailpilot.database.create_activity"),
+    ):
+        result = runner.invoke(
+            main,
+            ["tag", "remove", "--contact-id", "cid-1", "prospect"],
+        )
+
+    assert result.exit_code == 0
+    mock_delete.assert_called_once_with(
+        mock_connection,
+        entity_type="contact",
+        entity_id="cid-1",
+        name="prospect",
+    )
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["removed"] is True
+
+
+def test_tag_remove_creates_activity(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    contact = _make_contact()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.delete_tag", return_value=True),
+        patch("mailpilot.database.get_contact", return_value=contact),
+        patch("mailpilot.database.create_activity") as mock_activity,
+    ):
+        runner.invoke(
+            main,
+            ["tag", "remove", "--contact-id", "cid-1", "prospect"],
+        )
+
+    mock_activity.assert_called_once_with(
+        mock_connection,
+        contact_id="cid-1",
+        activity_type="tag_removed",
+        summary="Removed tag prospect",
+        detail={"tag": "prospect"},
+        company_id=None,
+    )
+
+
+def test_tag_remove_not_found(runner: CliRunner, mock_connection: MagicMock) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.delete_tag", return_value=False),
+    ):
+        result = runner.invoke(
+            main,
+            ["tag", "remove", "--contact-id", "cid-1", "prospect"],
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+
+
+# -- tag list ------------------------------------------------------------------
+
+
+def test_tag_list(runner: CliRunner, mock_connection: MagicMock) -> None:
+    tags = [
+        _make_tag(id="id-1", name="cold"),
+        _make_tag(id="id-2", name="prospect"),
+    ]
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_tags", return_value=tags),
+    ):
+        result = runner.invoke(main, ["tag", "list", "--contact-id", "cid-1"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert len(data["tags"]) == 2
+
+
+def test_tag_list_no_entity(runner: CliRunner, mock_connection: MagicMock) -> None:
+    """tag list without --contact-id or --company-id should error."""
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+    ):
+        result = runner.invoke(main, ["tag", "list"])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "missing_filter"
+
+
+# -- tag search ----------------------------------------------------------------
+
+
+def test_tag_search(runner: CliRunner, mock_connection: MagicMock) -> None:
+    tags = [_make_tag(name="prospect")]
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.search_tags", return_value=tags) as mock_search,
+    ):
+        result = runner.invoke(main, ["tag", "search", "prospect"])
+
+    assert result.exit_code == 0
+    mock_search.assert_called_once_with(
+        mock_connection, name="prospect", entity_type=None, limit=100
+    )
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert len(data["tags"]) == 1
+
+
+def test_tag_search_with_type(runner: CliRunner, mock_connection: MagicMock) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.search_tags", return_value=[]) as mock_search,
+    ):
+        result = runner.invoke(
+            main, ["tag", "search", "prospect", "--type", "contact", "--limit", "5"]
+        )
+
+    assert result.exit_code == 0
+    mock_search.assert_called_once_with(
+        mock_connection, name="prospect", entity_type="contact", limit=5
+    )

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -14,6 +14,7 @@ from conftest import (
     make_test_activity,
     make_test_company,
     make_test_contact,
+    make_test_tag,
     make_test_workflow,
 )
 from mailpilot.database import (
@@ -22,6 +23,8 @@ from mailpilot.database import (
     create_contacts_bulk,
     create_email,
     create_or_get_contact_by_email,
+    create_tag,
+    delete_tag,
     get_account,
     get_company,
     get_company_by_domain,
@@ -39,11 +42,14 @@ from mailpilot.database import (
     list_companies,
     list_contacts,
     list_emails,
+    list_entities_by_tag,
+    list_tags,
     list_workflows,
     pause_workflow,
     search_companies,
     search_contacts,
     search_emails,
+    search_tags,
     search_workflows,
     update_account,
     update_company,
@@ -1098,3 +1104,214 @@ def test_status_counts_includes_activities(
     make_test_activity(database_connection, contact_id=contact.id)
     counts = get_status_counts(database_connection)
     assert counts["activities"] == 1
+
+
+# -- Tag -----------------------------------------------------------------------
+
+
+def test_create_tag(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    tag = make_test_tag(
+        database_connection, entity_type="contact", entity_id=contact.id
+    )
+    assert tag.entity_type == "contact"
+    assert tag.entity_id == contact.id
+    assert tag.name == "prospect"
+    assert tag.id
+
+
+def test_create_tag_normalizes_name(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    tag = make_test_tag(
+        database_connection,
+        entity_type="contact",
+        entity_id=contact.id,
+        name="  PROSPECT  ",
+    )
+    assert tag.name == "prospect"
+
+
+def test_create_tag_idempotent(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    first = create_tag(
+        database_connection,
+        entity_type="contact",
+        entity_id=contact.id,
+        name="prospect",
+    )
+    assert first is not None
+    second = create_tag(
+        database_connection,
+        entity_type="contact",
+        entity_id=contact.id,
+        name="prospect",
+    )
+    assert second is None
+
+
+def test_create_tag_on_company(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    company = make_test_company(database_connection)
+    tag = make_test_tag(
+        database_connection,
+        entity_type="company",
+        entity_id=company.id,
+        name="logistics",
+    )
+    assert tag.entity_type == "company"
+    assert tag.name == "logistics"
+
+
+def test_delete_tag(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    make_test_tag(database_connection, entity_type="contact", entity_id=contact.id)
+    deleted = delete_tag(
+        database_connection,
+        entity_type="contact",
+        entity_id=contact.id,
+        name="prospect",
+    )
+    assert deleted is True
+
+
+def test_delete_tag_not_found(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    deleted = delete_tag(
+        database_connection,
+        entity_type="contact",
+        entity_id=contact.id,
+        name="nonexistent",
+    )
+    assert deleted is False
+
+
+def test_list_tags(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    make_test_tag(
+        database_connection, entity_type="contact", entity_id=contact.id, name="cold"
+    )
+    make_test_tag(
+        database_connection,
+        entity_type="contact",
+        entity_id=contact.id,
+        name="prospect",
+    )
+    tags = list_tags(database_connection, entity_type="contact", entity_id=contact.id)
+    assert len(tags) == 2
+    # Ordered by name
+    assert tags[0].name == "cold"
+    assert tags[1].name == "prospect"
+
+
+def test_list_tags_empty(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    tags = list_tags(database_connection, entity_type="contact", entity_id=contact.id)
+    assert tags == []
+
+
+def test_list_entities_by_tag(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    c1 = make_test_contact(database_connection, email="a@test.com", domain="test.com")
+    c2 = make_test_contact(database_connection, email="b@test.com", domain="test.com")
+    c3 = make_test_contact(database_connection, email="c@test.com", domain="test.com")
+    make_test_tag(
+        database_connection, entity_type="contact", entity_id=c1.id, name="prospect"
+    )
+    make_test_tag(
+        database_connection, entity_type="contact", entity_id=c2.id, name="prospect"
+    )
+    make_test_tag(
+        database_connection, entity_type="contact", entity_id=c3.id, name="client"
+    )
+
+    ids = list_entities_by_tag(
+        database_connection, entity_type="contact", name="prospect"
+    )
+    assert len(ids) == 2
+    assert c1.id in ids
+    assert c2.id in ids
+
+
+def test_list_entities_by_tag_with_limit(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    c1 = make_test_contact(database_connection, email="a@test.com", domain="test.com")
+    c2 = make_test_contact(database_connection, email="b@test.com", domain="test.com")
+    make_test_tag(
+        database_connection, entity_type="contact", entity_id=c1.id, name="prospect"
+    )
+    make_test_tag(
+        database_connection, entity_type="contact", entity_id=c2.id, name="prospect"
+    )
+
+    ids = list_entities_by_tag(
+        database_connection, entity_type="contact", name="prospect", limit=1
+    )
+    assert len(ids) == 1
+
+
+def test_search_tags(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    make_test_tag(
+        database_connection,
+        entity_type="contact",
+        entity_id=contact.id,
+        name="prospect",
+    )
+    make_test_tag(
+        database_connection, entity_type="contact", entity_id=contact.id, name="cold"
+    )
+
+    results = search_tags(database_connection, name="pro")
+    assert len(results) == 1
+    assert results[0].name == "prospect"
+
+
+def test_search_tags_with_entity_type(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    company = make_test_company(database_connection)
+    make_test_tag(
+        database_connection,
+        entity_type="contact",
+        entity_id=contact.id,
+        name="prospect",
+    )
+    make_test_tag(
+        database_connection,
+        entity_type="company",
+        entity_id=company.id,
+        name="prospect",
+    )
+
+    results = search_tags(database_connection, name="prospect", entity_type="contact")
+    assert len(results) == 1
+    assert results[0].entity_type == "contact"
+
+
+def test_status_counts_includes_tags(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    make_test_tag(database_connection, entity_type="contact", entity_id=contact.id)
+    counts = get_status_counts(database_connection)
+    assert counts["tags"] == 1


### PR DESCRIPTION
## Summary

Implements the `tag` CRM entity -- schema, model, database layer, and CLI commands. Tags are flexible labels on contacts or companies for segmentation (e.g., `prospect`, `logistics`, `cold`).

Resolves #44

## Changes

- Add `tag` table with polymorphic `entity_type`/`entity_id` and UNIQUE constraint
- Add `Tag` model and `TagEntityType` literal to `models.py`
- Implement `create_tag` (ON CONFLICT DO NOTHING), `delete_tag`, `list_tags`, `list_entities_by_tag`, `search_tags` in `database.py`
- Add CLI `tag add|remove|list|search` commands with entity existence validation
- Tag operations on contacts create corresponding activities (`tag_added`, `tag_removed`)
- Add tag count to `get_status_counts`