### PR TITLE
feat(crm): implement note table -- schema, model, database, CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,13 @@ The CLI must be LLM Agent friendly: JSON output only. Exit codes must be meaning
 
 **Convention: GitHub CLI (`gh`) as reference.** Standard verbs: `list` (summary), `view ID` (full record), `get` (fetch from external API), `set` (update config). All IDs are UUIDv7.
 
+**Input validation in CLI commands.** All commands validate before touching the database:
+
+1. Required text fields reject empty/whitespace-only values: `output_error("X cannot be empty", "validation_error")` -- checked before `initialize_database()`.
+2. FK references (`--contact-id`, `--company-id`, `--account-id`) are validated with `get_X()` after connection, before the main operation. Return `not_found` if the entity doesn't exist.
+3. List commands with optional FK filters (`email list --contact-id`, `contact list --company-id`, etc.) validate entity existence when the filter is provided. This prevents silent empty results from typos.
+4. Use `if x is not None and get_y(...) is None:` (single `if`) to avoid ruff SIM102.
+
 ```
 mailpilot --version
 mailpilot --debug COMMAND
@@ -98,8 +105,9 @@ mailpilot tag list --contact-id ID
 mailpilot tag list --company-id ID
 mailpilot tag search NAME [--type contact|company] [--limit N]
 
-mailpilot note add --contact-id ID BODY
-mailpilot note add --company-id ID BODY
+mailpilot note add --contact-id ID --body TEXT
+mailpilot note add --company-id ID --body TEXT
+mailpilot note view ID
 mailpilot note list --contact-id ID [--limit N]
 mailpilot note list --company-id ID [--limit N]
 
@@ -225,6 +233,8 @@ If a GitHub operation isn't covered by a skill (e.g. reviewing comments, closing
 3. Run: `uv run ruff check --fix` then `uv run basedpyright`
 
 Tests use a separate database: `postgresql://localhost/mailpilot_test` (override with `DATABASE_URL` env var). The `database_connection` fixture truncates all tables before each test. Use `make_test_settings()` for Settings instances and `load_fixture()` for JSON fixtures -- all in `conftest.py`. HTTP mocking uses `pytest-httpx`. Span-contract tests use the `capfire: CaptureLogfire` fixture (see `tests/test_database_telemetry.py`). The `e2e` pytest marker is excluded from default runs (`addopts = "-m 'not e2e'"`); live-Gmail tests live under `tests/e2e/` and run via `make e2e` against `mailpilot_e2e`.
+
+**Patching gotcha for entity validation.** When a CLI command calls `get_contact()`, `get_company()`, or `get_account()` for FK validation, every test for that command must patch the `get_*` function with a valid return value. Adding FK validation to an existing command will break its tests until the patches are added.
 
 ## Observability
 

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -973,8 +973,10 @@ def tag_remove(contact_id: str | None, company_id: str | None, name: str) -> Non
     entity_type, entity_id = _resolve_entity(contact_id, company_id)
     connection = initialize_database(_database_url())
     try:
+        contact = None
         if entity_type == "contact":
-            if get_contact(connection, entity_id) is None:
+            contact = get_contact(connection, entity_id)
+            if contact is None:
                 output_error(f"contact {entity_id} not found", "not_found")
         elif get_company(connection, entity_id) is None:
             output_error(f"company {entity_id} not found", "not_found")
@@ -990,16 +992,14 @@ def tag_remove(contact_id: str | None, company_id: str | None, name: str) -> Non
                 f"tag '{normalized}' not found on {entity_type} {entity_id}",
                 "not_found",
             )
-        # Create tag_removed activity when untagging a contact
-        if entity_type == "contact":
-            contact = get_contact(connection, entity_id)
+        if entity_type == "contact" and contact is not None:
             create_activity(
                 connection,
                 contact_id=entity_id,
                 activity_type="tag_removed",
                 summary=f"Removed tag {normalized}",
                 detail={"tag": normalized},
-                company_id=contact.company_id if contact else None,
+                company_id=contact.company_id,
             )
         output({"removed": True, "tag": normalized, "entity_type": entity_type})
     finally:

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -229,6 +229,8 @@ def account_create(email: str, display_name: str) -> None:
     """Create a new Gmail account."""
     from mailpilot.database import create_account, initialize_database
 
+    if not email.strip():
+        output_error("email cannot be empty", "validation_error")
     connection = initialize_database(_database_url())
     try:
         created = create_account(connection, email=email, display_name=display_name)
@@ -353,6 +355,8 @@ def company_create(domain: str, name: str) -> None:
     """Create a new company."""
     from mailpilot.database import create_company, initialize_database
 
+    if not domain.strip():
+        output_error("domain cannot be empty", "validation_error")
     connection = initialize_database(_database_url())
     try:
         created = create_company(connection, name=name, domain=domain)
@@ -484,11 +488,17 @@ def contact_create(
     company_id: str | None,
 ) -> None:
     """Create a new contact."""
-    from mailpilot.database import create_contact, initialize_database
+    from mailpilot.database import (
+        create_contact,
+        get_company,
+        initialize_database,
+    )
 
     domain = email.rsplit("@", maxsplit=1)[-1]
     connection = initialize_database(_database_url())
     try:
+        if company_id is not None and get_company(connection, company_id) is None:
+            output_error(f"company not found: {company_id}", "not_found")
         created = create_contact(
             connection,
             email=email,
@@ -559,10 +569,12 @@ def contact_search(query: str, limit: int) -> None:
 @click.option("--company-id", default=None, help="Filter by company ID.")
 def contact_list(limit: int, domain: str | None, company_id: str | None) -> None:
     """List contacts."""
-    from mailpilot.database import initialize_database, list_contacts
+    from mailpilot.database import get_company, initialize_database, list_contacts
 
     connection = initialize_database(_database_url())
     try:
+        if company_id is not None and get_company(connection, company_id) is None:
+            output_error(f"company not found: {company_id}", "not_found")
         contacts = list_contacts(
             connection, limit=limit, domain=domain, company_id=company_id
         )
@@ -663,10 +675,19 @@ def email_search(query: str, limit: int) -> None:
 @click.option("--account-id", default=None, help="Filter by account ID.")
 def email_list(limit: int, contact_id: str | None, account_id: str | None) -> None:
     """List emails with optional filters."""
-    from mailpilot.database import initialize_database, list_emails
+    from mailpilot.database import (
+        get_account,
+        get_contact,
+        initialize_database,
+        list_emails,
+    )
 
     connection = initialize_database(_database_url())
     try:
+        if contact_id is not None and get_contact(connection, contact_id) is None:
+            output_error(f"contact not found: {contact_id}", "not_found")
+        if account_id is not None and get_account(connection, account_id) is None:
+            output_error(f"account not found: {account_id}", "not_found")
         emails = list_emails(
             connection, limit=limit, contact_id=contact_id, account_id=account_id
         )
@@ -776,11 +797,22 @@ def activity_create(
     company_id: str | None,
 ) -> None:
     """Create an activity event."""
-    from mailpilot.database import create_activity, initialize_database
+    from mailpilot.database import (
+        create_activity,
+        get_company,
+        get_contact,
+        initialize_database,
+    )
 
+    if not summary.strip():
+        output_error("summary cannot be empty", "validation_error")
     detail_dict: dict[str, object] = json.loads(detail) if detail else {}
     connection = initialize_database(_database_url())
     try:
+        if get_contact(connection, contact_id) is None:
+            output_error(f"contact not found: {contact_id}", "not_found")
+        if company_id is not None and get_company(connection, company_id) is None:
+            output_error(f"company not found: {company_id}", "not_found")
         created = create_activity(
             connection,
             contact_id=contact_id,
@@ -814,7 +846,12 @@ def activity_list(
     since: str | None,
 ) -> None:
     """List activities (requires --contact-id or --company-id)."""
-    from mailpilot.database import initialize_database, list_activities
+    from mailpilot.database import (
+        get_company,
+        get_contact,
+        initialize_database,
+        list_activities,
+    )
 
     if contact_id is None and company_id is None:
         output_error(
@@ -823,6 +860,10 @@ def activity_list(
         )
     connection = initialize_database(_database_url())
     try:
+        if contact_id is not None and get_contact(connection, contact_id) is None:
+            output_error(f"contact not found: {contact_id}", "not_found")
+        if company_id is not None and get_company(connection, company_id) is None:
+            output_error(f"company not found: {company_id}", "not_found")
         activities = list_activities(
             connection,
             contact_id=contact_id,
@@ -869,6 +910,8 @@ def tag_add(contact_id: str | None, company_id: str | None, name: str) -> None:
         initialize_database,
     )
 
+    if not name.strip():
+        output_error("tag name cannot be empty", "validation_error")
     entity_type, entity_id = _resolve_entity(contact_id, company_id)
     connection = initialize_database(_database_url())
     try:
@@ -922,6 +965,7 @@ def tag_remove(contact_id: str | None, company_id: str | None, name: str) -> Non
     from mailpilot.database import (
         create_activity,
         delete_tag,
+        get_company,
         get_contact,
         initialize_database,
     )
@@ -929,6 +973,11 @@ def tag_remove(contact_id: str | None, company_id: str | None, name: str) -> Non
     entity_type, entity_id = _resolve_entity(contact_id, company_id)
     connection = initialize_database(_database_url())
     try:
+        if entity_type == "contact":
+            if get_contact(connection, entity_id) is None:
+                output_error(f"contact {entity_id} not found", "not_found")
+        elif get_company(connection, entity_id) is None:
+            output_error(f"company {entity_id} not found", "not_found")
         deleted = delete_tag(
             connection,
             entity_type=entity_type,
@@ -962,11 +1011,21 @@ def tag_remove(contact_id: str | None, company_id: str | None, name: str) -> Non
 @click.option("--company-id", default=None, help="Company ID.")
 def tag_list(contact_id: str | None, company_id: str | None) -> None:
     """List tags on a contact or company."""
-    from mailpilot.database import initialize_database, list_tags
+    from mailpilot.database import (
+        get_company,
+        get_contact,
+        initialize_database,
+        list_tags,
+    )
 
     entity_type, entity_id = _resolve_entity(contact_id, company_id)
     connection = initialize_database(_database_url())
     try:
+        if entity_type == "contact":
+            if get_contact(connection, entity_id) is None:
+                output_error(f"contact {entity_id} not found", "not_found")
+        elif get_company(connection, entity_id) is None:
+            output_error(f"company {entity_id} not found", "not_found")
         tags = list_tags(connection, entity_type=entity_type, entity_id=entity_id)
         output({"tags": [t.model_dump(mode="json") for t in tags]})
     finally:
@@ -1006,7 +1065,7 @@ def note() -> None:
 @note.command("add")
 @click.option("--contact-id", default=None, help="Contact ID.")
 @click.option("--company-id", default=None, help="Company ID.")
-@click.argument("body")
+@click.option("--body", required=True, help="Note text.")
 def note_add(contact_id: str | None, company_id: str | None, body: str) -> None:
     """Add a note to a contact or company."""
     from mailpilot.database import (
@@ -1017,6 +1076,8 @@ def note_add(contact_id: str | None, company_id: str | None, body: str) -> None:
         initialize_database,
     )
 
+    if not body.strip():
+        output_error("note body cannot be empty", "validation_error")
     entity_type, entity_id = _resolve_entity(contact_id, company_id)
     connection = initialize_database(_database_url())
     try:
@@ -1061,15 +1122,41 @@ def note_add(contact_id: str | None, company_id: str | None, body: str) -> None:
 @click.option("--limit", default=100, help="Maximum results.")
 def note_list(contact_id: str | None, company_id: str | None, limit: int) -> None:
     """List notes on a contact or company."""
-    from mailpilot.database import initialize_database, list_notes
+    from mailpilot.database import (
+        get_company,
+        get_contact,
+        initialize_database,
+        list_notes,
+    )
 
     entity_type, entity_id = _resolve_entity(contact_id, company_id)
     connection = initialize_database(_database_url())
     try:
+        if entity_type == "contact":
+            if get_contact(connection, entity_id) is None:
+                output_error(f"contact {entity_id} not found", "not_found")
+        elif get_company(connection, entity_id) is None:
+            output_error(f"company {entity_id} not found", "not_found")
         notes = list_notes(
             connection, entity_type=entity_type, entity_id=entity_id, limit=limit
         )
         output({"notes": [n.model_dump(mode="json") for n in notes]})
+    finally:
+        connection.close()
+
+
+@note.command("view")
+@click.argument("note_id")
+def note_view(note_id: str) -> None:
+    """View a note by ID."""
+    from mailpilot.database import get_note, initialize_database
+
+    connection = initialize_database(_database_url())
+    try:
+        found = get_note(connection, note_id)
+        if found is None:
+            output_error(f"note {note_id} not found", "not_found")
+        output(found.model_dump(mode="json"))
     finally:
         connection.close()
 
@@ -1111,12 +1198,17 @@ def workflow_create(
 
     from mailpilot.database import (
         create_workflow,
+        get_account,
         initialize_database,
         update_workflow,
     )
 
+    if not name.strip():
+        output_error("workflow name cannot be empty", "validation_error")
     connection = initialize_database(_database_url())
     try:
+        if get_account(connection, account_id) is None:
+            output_error(f"account not found: {account_id}", "not_found")
         created = create_workflow(
             connection,
             name=name,
@@ -1194,10 +1286,12 @@ def workflow_search(query: str, limit: int) -> None:
 @click.option("--account-id", default=None, help="Filter by account ID.")
 def workflow_list(account_id: str | None) -> None:
     """List workflows."""
-    from mailpilot.database import initialize_database, list_workflows
+    from mailpilot.database import get_account, initialize_database, list_workflows
 
     connection = initialize_database(_database_url())
     try:
+        if account_id is not None and get_account(connection, account_id) is None:
+            output_error(f"account not found: {account_id}", "not_found")
         workflows = list_workflows(connection, account_id=account_id)
         output({"workflows": [w.model_dump(mode="json") for w in workflows]})
     finally:

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -872,7 +872,7 @@ def tag_add(contact_id: str | None, company_id: str | None, name: str) -> None:
     entity_type, entity_id = _resolve_entity(contact_id, company_id)
     connection = initialize_database(_database_url())
     try:
-        # Validate entity exists before creating tag
+        contact = None
         if entity_type == "contact":
             contact = get_contact(connection, entity_id)
             if contact is None:
@@ -899,16 +899,14 @@ def tag_add(contact_id: str | None, company_id: str | None, name: str) -> None:
                 f"tag '{normalized}' already exists on {entity_type} {entity_id}",
                 "already_exists",
             )
-        # Create tag_added activity when tagging a contact
-        if entity_type == "contact":
-            contact = get_contact(connection, entity_id)
+        if entity_type == "contact" and contact is not None:
             create_activity(
                 connection,
                 contact_id=entity_id,
                 activity_type="tag_added",
                 summary=f"Tagged as {created.name}",
                 detail={"tag": created.name},
-                company_id=contact.company_id if contact else None,
+                company_id=contact.company_id,
             )
         output(created.model_dump(mode="json"))
     finally:
@@ -993,6 +991,85 @@ def tag_search(name: str, entity_type: str | None, limit: int) -> None:
     try:
         tags = search_tags(connection, name=name, entity_type=entity_type, limit=limit)
         output({"tags": [t.model_dump(mode="json") for t in tags]})
+    finally:
+        connection.close()
+
+
+# -- Note commands -------------------------------------------------------------
+
+
+@main.group()
+def note() -> None:
+    """Manage notes on contacts and companies."""
+
+
+@note.command("add")
+@click.option("--contact-id", default=None, help="Contact ID.")
+@click.option("--company-id", default=None, help="Company ID.")
+@click.argument("body")
+def note_add(contact_id: str | None, company_id: str | None, body: str) -> None:
+    """Add a note to a contact or company."""
+    from mailpilot.database import (
+        create_activity,
+        create_note,
+        get_company,
+        get_contact,
+        initialize_database,
+    )
+
+    entity_type, entity_id = _resolve_entity(contact_id, company_id)
+    connection = initialize_database(_database_url())
+    try:
+        contact = None
+        if entity_type == "contact":
+            contact = get_contact(connection, entity_id)
+            if contact is None:
+                output_error(
+                    f"contact {entity_id} not found",
+                    "not_found",
+                )
+        else:
+            company = get_company(connection, entity_id)
+            if company is None:
+                output_error(
+                    f"company {entity_id} not found",
+                    "not_found",
+                )
+        created = create_note(
+            connection,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            body=body,
+        )
+        if entity_type == "contact" and contact is not None:
+            create_activity(
+                connection,
+                contact_id=entity_id,
+                activity_type="note_added",
+                summary="Note added",
+                detail={"note_id": created.id},
+                company_id=contact.company_id,
+            )
+        output(created.model_dump(mode="json"))
+    finally:
+        connection.close()
+
+
+@note.command("list")
+@click.option("--contact-id", default=None, help="Contact ID.")
+@click.option("--company-id", default=None, help="Company ID.")
+@click.option("--limit", default=100, help="Maximum results.")
+def note_list(contact_id: str | None, company_id: str | None, limit: int) -> None:
+    """List notes on a contact or company."""
+    from mailpilot.database import initialize_database, list_notes
+
+    entity_type, entity_id = _resolve_entity(contact_id, company_id)
+    connection = initialize_database(_database_url())
+    try:
+        notes = list_notes(
+            connection, entity_type=entity_type, entity_id=entity_id, limit=limit
+        )
+        output({"notes": [n.model_dump(mode="json") for n in notes]})
     finally:
         connection.close()
 

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -28,6 +28,7 @@ from mailpilot.models import (
     Company,
     Contact,
     Email,
+    Note,
     SyncStatus,
     Tag,
     Task,
@@ -122,7 +123,8 @@ def get_status_counts(
                 (SELECT COUNT(*) FROM workflow) AS workflows,
                 (SELECT COUNT(*) FROM email) AS emails,
                 (SELECT COUNT(*) FROM activity) AS activities,
-                (SELECT COUNT(*) FROM tag) AS tags
+                (SELECT COUNT(*) FROM tag) AS tags,
+                (SELECT COUNT(*) FROM note) AS notes
             FROM (SELECT 1) AS _dummy
             """
         ).fetchone()
@@ -134,6 +136,7 @@ def get_status_counts(
             "emails": row["emails"],  # type: ignore[index]
             "activities": row["activities"],  # type: ignore[index]
             "tags": row["tags"],  # type: ignore[index]
+            "notes": row["notes"],  # type: ignore[index]
         }
 
 
@@ -2064,6 +2067,111 @@ def search_tags(
         tags = [Tag.model_validate(row) for row in rows]
         span.set_attribute("tag_count", len(tags))
         return tags
+
+
+# -- Note ----------------------------------------------------------------------
+
+
+def create_note(
+    connection: psycopg.Connection[dict[str, Any]],
+    entity_type: str,
+    entity_id: str,
+    body: str,
+) -> Note:
+    """Create a freeform text note on a contact or company.
+
+    Args:
+        connection: Open database connection.
+        entity_type: "contact" or "company".
+        entity_id: ID of the annotated entity.
+        body: Note text.
+
+    Returns:
+        Created note.
+    """
+    with logfire.span(
+        "db.note.create",
+        entity_type=entity_type,
+        entity_id=entity_id,
+    ) as span:
+        row = connection.execute(
+            """\
+            INSERT INTO note (id, entity_type, entity_id, body)
+            VALUES (%(id)s, %(entity_type)s, %(entity_id)s, %(body)s)
+            RETURNING *
+            """,
+            {
+                "id": _new_id(),
+                "entity_type": entity_type,
+                "entity_id": entity_id,
+                "body": body,
+            },
+        ).fetchone()
+        connection.commit()
+        note = Note.model_validate(row)
+        span.set_attribute("note_id", note.id)
+        return note
+
+
+def list_notes(
+    connection: psycopg.Connection[dict[str, Any]],
+    entity_type: str,
+    entity_id: str,
+    limit: int = 100,
+) -> list[Note]:
+    """List notes on a contact or company.
+
+    Args:
+        connection: Open database connection.
+        entity_type: "contact" or "company".
+        entity_id: ID of the annotated entity.
+        limit: Maximum number of notes to return.
+
+    Returns:
+        Notes ordered by created_at descending.
+    """
+    with logfire.span(
+        "db.note.list",
+        entity_type=entity_type,
+        entity_id=entity_id,
+        limit=limit,
+    ) as span:
+        rows = connection.execute(
+            """\
+            SELECT * FROM note
+            WHERE entity_type = %(entity_type)s AND entity_id = %(entity_id)s
+            ORDER BY created_at DESC
+            LIMIT %(limit)s
+            """,
+            {"entity_type": entity_type, "entity_id": entity_id, "limit": limit},
+        ).fetchall()
+        notes = [Note.model_validate(row) for row in rows]
+        span.set_attribute("note_count", len(notes))
+        return notes
+
+
+def get_note(
+    connection: psycopg.Connection[dict[str, Any]],
+    note_id: str,
+) -> Note | None:
+    """Get a note by ID.
+
+    Args:
+        connection: Open database connection.
+        note_id: Note ID.
+
+    Returns:
+        Note if found, None otherwise.
+    """
+    with logfire.span("db.note.get", note_id=note_id) as span:
+        row = connection.execute(
+            "SELECT * FROM note WHERE id = %(id)s",
+            {"id": note_id},
+        ).fetchone()
+        span.set_attribute("hit", row is not None)
+        if row is None:
+            return None
+        return Note.model_validate(row)
 
 
 # -- Sync Status ---------------------------------------------------------------

--- a/src/mailpilot/models.py
+++ b/src/mailpilot/models.py
@@ -161,16 +161,26 @@ class Activity(BaseModel):
     created_at: datetime
 
 
-TagEntityType = Literal["contact", "company"]
+EntityType = Literal["contact", "company"]
 
 
 class Tag(BaseModel):
     """Flexible label on a contact or company for segmentation."""
 
     id: str
-    entity_type: TagEntityType
+    entity_type: EntityType
     entity_id: str
     name: str
+    created_at: datetime
+
+
+class Note(BaseModel):
+    """Freeform text annotation on a contact or company."""
+
+    id: str
+    entity_type: EntityType
+    entity_id: str
+    body: str
     created_at: datetime
 
 

--- a/src/mailpilot/schema.sql
+++ b/src/mailpilot/schema.sql
@@ -159,3 +159,14 @@ CREATE TABLE IF NOT EXISTS tag (
 
 CREATE INDEX IF NOT EXISTS idx_tag_entity ON tag(entity_type, entity_id);
 CREATE INDEX IF NOT EXISTS idx_tag_name ON tag(name);
+
+CREATE TABLE IF NOT EXISTS note (
+    id              TEXT PRIMARY KEY,
+    entity_type     TEXT NOT NULL
+                    CHECK (entity_type IN ('contact', 'company')),
+    entity_id       TEXT NOT NULL,
+    body            TEXT NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_note_entity ON note(entity_type, entity_id);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,11 +16,12 @@ from mailpilot.database import (
     create_activity,
     create_company,
     create_contact,
+    create_note,
     create_tag,
     create_workflow,
     initialize_database,
 )
-from mailpilot.models import Account, Activity, Company, Contact, Tag, Workflow
+from mailpilot.models import Account, Activity, Company, Contact, Note, Tag, Workflow
 from mailpilot.settings import Settings
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
@@ -63,8 +64,8 @@ def database_connection() -> Iterator[psycopg.Connection[dict[str, Any]]]:
         psycopg.connect(TEST_DATABASE_URL, row_factory=dict_row),  # type: ignore[arg-type]
     )
     conn.execute(
-        "TRUNCATE TABLE tag, activity, sync_status, task, email, workflow_contact, "
-        "workflow, contact, company, account CASCADE"
+        "TRUNCATE TABLE note, tag, activity, sync_status, task, email, "
+        "workflow_contact, workflow, contact, company, account CASCADE"
     )
     conn.commit()
     yield conn
@@ -159,3 +160,18 @@ def make_test_tag(
     )
     assert tag is not None, f"tag '{name}' already exists"
     return tag
+
+
+def make_test_note(
+    connection: psycopg.Connection[dict[str, Any]],
+    entity_type: str = "contact",
+    entity_id: str = "",
+    body: str = "Test note body",
+) -> Note:
+    """Create a test note in the database."""
+    return create_note(
+        connection,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        body=body,
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,16 @@ from click.testing import CliRunner
 
 from conftest import make_test_settings
 from mailpilot.cli import main
-from mailpilot.models import Account, Activity, Company, Contact, Email, Tag, Workflow
+from mailpilot.models import (
+    Account,
+    Activity,
+    Company,
+    Contact,
+    Email,
+    Note,
+    Tag,
+    Workflow,
+)
 
 _NOW = datetime(2024, 1, 1, tzinfo=UTC)
 
@@ -2200,3 +2209,194 @@ def test_tag_search_with_type(runner: CliRunner, mock_connection: MagicMock) -> 
     mock_search.assert_called_once_with(
         mock_connection, name="prospect", entity_type="contact", limit=5
     )
+
+
+# -- note helpers --------------------------------------------------------------
+
+
+def _make_note(**overrides: Any) -> Note:
+    defaults: dict[str, Any] = {
+        "id": "01234567-0000-7000-0000-000000000012",
+        "entity_type": "contact",
+        "entity_id": "01234567-0000-7000-0000-000000000003",
+        "body": "Test note body",
+        "created_at": _NOW,
+    }
+    return Note(**{**defaults, **overrides})
+
+
+# -- note add ------------------------------------------------------------------
+
+
+def test_note_add(runner: CliRunner, mock_connection: MagicMock) -> None:
+    note = _make_note()
+    contact = _make_contact()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.create_note", return_value=note) as mock_create,
+        patch("mailpilot.database.get_contact", return_value=contact),
+        patch("mailpilot.database.create_activity"),
+    ):
+        result = runner.invoke(
+            main,
+            ["note", "add", "--contact-id", "cid-1", "Test note body"],
+        )
+
+    assert result.exit_code == 0
+    mock_create.assert_called_once_with(
+        mock_connection,
+        entity_type="contact",
+        entity_id="cid-1",
+        body="Test note body",
+    )
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["body"] == "Test note body"
+
+
+def test_note_add_on_company(runner: CliRunner, mock_connection: MagicMock) -> None:
+    note = _make_note(entity_type="company", entity_id="comp-1")
+    company = _make_company(id="comp-1")
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.create_note", return_value=note),
+        patch("mailpilot.database.get_company", return_value=company),
+    ):
+        result = runner.invoke(
+            main,
+            ["note", "add", "--company-id", "comp-1", "Company note"],
+        )
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["ok"] is True
+
+
+def test_note_add_creates_activity(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    note = _make_note()
+    contact = _make_contact()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.create_note", return_value=note),
+        patch("mailpilot.database.get_contact", return_value=contact),
+        patch("mailpilot.database.create_activity") as mock_activity,
+    ):
+        runner.invoke(
+            main,
+            ["note", "add", "--contact-id", "cid-1", "Test note body"],
+        )
+
+    mock_activity.assert_called_once_with(
+        mock_connection,
+        contact_id="cid-1",
+        activity_type="note_added",
+        summary="Note added",
+        detail={"note_id": note.id},
+        company_id=None,
+    )
+
+
+def test_note_add_contact_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=None),
+    ):
+        result = runner.invoke(
+            main,
+            ["note", "add", "--contact-id", "cid-missing", "Some note"],
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "contact" in data["message"]
+
+
+def test_note_add_company_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_company", return_value=None),
+    ):
+        result = runner.invoke(
+            main,
+            ["note", "add", "--company-id", "comp-missing", "Some note"],
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "company" in data["message"]
+
+
+def test_note_add_no_entity(runner: CliRunner, mock_connection: MagicMock) -> None:
+    """note add without --contact-id or --company-id should error."""
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+    ):
+        result = runner.invoke(main, ["note", "add", "Some note"])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "missing_filter"
+
+
+# -- note list -----------------------------------------------------------------
+
+
+def test_note_list(runner: CliRunner, mock_connection: MagicMock) -> None:
+    notes = [
+        _make_note(id="id-1", body="First note"),
+        _make_note(id="id-2", body="Second note"),
+    ]
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_notes", return_value=notes),
+    ):
+        result = runner.invoke(main, ["note", "list", "--contact-id", "cid-1"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert len(data["notes"]) == 2
+
+
+def test_note_list_with_limit(runner: CliRunner, mock_connection: MagicMock) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_notes", return_value=[]) as mock_list,
+    ):
+        result = runner.invoke(
+            main, ["note", "list", "--contact-id", "cid-1", "--limit", "5"]
+        )
+
+    assert result.exit_code == 0
+    mock_list.assert_called_once_with(
+        mock_connection, entity_type="contact", entity_id="cid-1", limit=5
+    )
+
+
+def test_note_list_no_entity(runner: CliRunner, mock_connection: MagicMock) -> None:
+    """note list without --contact-id or --company-id should error."""
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+    ):
+        result = runner.invoke(main, ["note", "list"])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "missing_filter"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -120,6 +120,21 @@ def test_account_create_email_only(
     )
 
 
+def test_account_create_empty_email(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+    ):
+        result = runner.invoke(main, ["account", "create", "--email", ""])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "validation_error"
+    assert "email" in data["message"]
+
+
 # -- account list --------------------------------------------------------------
 
 
@@ -516,6 +531,21 @@ def test_company_search_with_limit(
     mock_search.assert_called_once_with(mock_connection, "acme", limit=10)
 
 
+def test_company_create_empty_domain(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+    ):
+        result = runner.invoke(main, ["company", "create", "--domain", ""])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "validation_error"
+    assert "domain" in data["message"]
+
+
 # -- company update ------------------------------------------------------------
 
 
@@ -704,6 +734,32 @@ def test_contact_create_email_only(
     )
 
 
+def test_contact_create_company_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_company", return_value=None),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "contact",
+                "create",
+                "--email",
+                "a@example.com",
+                "--company-id",
+                "comp-missing",
+            ],
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "company" in data["message"]
+
+
 # -- contact update ------------------------------------------------------------
 
 
@@ -834,9 +890,11 @@ def test_contact_list_empty(runner: CliRunner, mock_connection: MagicMock) -> No
 def test_contact_list_with_filters(
     runner: CliRunner, mock_connection: MagicMock
 ) -> None:
+    company = _make_company()
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_company", return_value=company),
         patch("mailpilot.database.list_contacts", return_value=[]) as mock_list,
     ):
         result = runner.invoke(
@@ -857,6 +915,24 @@ def test_contact_list_with_filters(
     mock_list.assert_called_once_with(
         mock_connection, limit=5, domain="example.com", company_id="cid-1"
     )
+
+
+def test_contact_list_company_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_company", return_value=None),
+    ):
+        result = runner.invoke(
+            main, ["contact", "list", "--company-id", "comp-missing"]
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "company" in data["message"]
 
 
 # -- contact view --------------------------------------------------------------
@@ -1033,9 +1109,13 @@ def test_email_list_empty(runner: CliRunner, mock_connection: MagicMock) -> None
 
 
 def test_email_list_with_filters(runner: CliRunner, mock_connection: MagicMock) -> None:
+    contact = _make_contact()
+    account = _make_account()
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=contact),
+        patch("mailpilot.database.get_account", return_value=account),
         patch("mailpilot.database.list_emails", return_value=[]) as mock_list,
     ):
         result = runner.invoke(
@@ -1082,6 +1162,38 @@ def test_email_view_not_found(runner: CliRunner, mock_connection: MagicMock) -> 
     data = json.loads(result.output)
     assert data["ok"] is False
     assert data["error"] == "not_found"
+
+
+def test_email_list_contact_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=None),
+    ):
+        result = runner.invoke(main, ["email", "list", "--contact-id", "cid-missing"])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "contact" in data["message"]
+
+
+def test_email_list_account_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_account", return_value=None),
+    ):
+        result = runner.invoke(main, ["email", "list", "--account-id", "acc-missing"])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "account" in data["message"]
 
 
 # -- email send ----------------------------------------------------------------
@@ -1279,9 +1391,11 @@ def _make_workflow(**overrides: Any) -> Workflow:
 
 def test_workflow_create(runner: CliRunner, mock_connection: MagicMock) -> None:
     workflow = _make_workflow()
+    account = _make_account()
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_account", return_value=account),
         patch(
             "mailpilot.database.create_workflow", return_value=workflow
         ) as mock_create,
@@ -1321,9 +1435,11 @@ def test_workflow_create_with_objective_and_instructions(
     )
     instructions_file = tmp_path / "instructions.md"
     instructions_file.write_text("You are a sales rep.")
+    account = _make_account()
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_account", return_value=account),
         patch("mailpilot.database.create_workflow", return_value=_make_workflow()),
         patch(
             "mailpilot.database.update_workflow", return_value=workflow
@@ -1376,6 +1492,61 @@ def test_workflow_create_rejects_invalid_type(
         ],
     )
     assert result.exit_code != 0
+
+
+def test_workflow_create_empty_name(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "workflow",
+                "create",
+                "--name",
+                "",
+                "--type",
+                "outbound",
+                "--account-id",
+                "acc-1",
+            ],
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "validation_error"
+    assert "name" in data["message"]
+
+
+def test_workflow_create_account_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_account", return_value=None),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "workflow",
+                "create",
+                "--name",
+                "Test",
+                "--type",
+                "outbound",
+                "--account-id",
+                "acc-missing",
+            ],
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "account" in data["message"]
 
 
 # -- workflow update -----------------------------------------------------------
@@ -1465,15 +1636,35 @@ def test_workflow_list(runner: CliRunner, mock_connection: MagicMock) -> None:
 def test_workflow_list_by_account(
     runner: CliRunner, mock_connection: MagicMock
 ) -> None:
+    account = _make_account()
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_account", return_value=account),
         patch("mailpilot.database.list_workflows", return_value=[]) as mock_list,
     ):
         result = runner.invoke(main, ["workflow", "list", "--account-id", _ACCOUNT_ID])
 
     assert result.exit_code == 0
     mock_list.assert_called_once_with(mock_connection, account_id=_ACCOUNT_ID)
+
+
+def test_workflow_list_account_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_account", return_value=None),
+    ):
+        result = runner.invoke(
+            main, ["workflow", "list", "--account-id", "acc-missing"]
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "account" in data["message"]
 
 
 def test_workflow_view(runner: CliRunner, mock_connection: MagicMock) -> None:
@@ -1774,9 +1965,11 @@ def _make_activity(**overrides: Any) -> Activity:
 
 def test_activity_create(runner: CliRunner, mock_connection: MagicMock) -> None:
     activity = _make_activity()
+    contact = _make_contact()
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=contact),
         patch(
             "mailpilot.database.create_activity", return_value=activity
         ) as mock_create,
@@ -1813,9 +2006,11 @@ def test_activity_create_with_detail(
     runner: CliRunner, mock_connection: MagicMock
 ) -> None:
     activity = _make_activity(detail={"email_id": "e-1"})
+    contact = _make_contact()
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=contact),
         patch(
             "mailpilot.database.create_activity", return_value=activity
         ) as mock_create,
@@ -1847,6 +2042,93 @@ def test_activity_create_with_detail(
     )
 
 
+def test_activity_create_empty_summary(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "activity",
+                "create",
+                "--contact-id",
+                "cid-1",
+                "--type",
+                "note_added",
+                "--summary",
+                "",
+            ],
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "validation_error"
+    assert "summary" in data["message"]
+
+
+def test_activity_create_contact_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=None),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "activity",
+                "create",
+                "--contact-id",
+                "cid-missing",
+                "--type",
+                "note_added",
+                "--summary",
+                "Test",
+            ],
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "contact" in data["message"]
+
+
+def test_activity_create_company_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    contact = _make_contact()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=contact),
+        patch("mailpilot.database.get_company", return_value=None),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "activity",
+                "create",
+                "--contact-id",
+                "cid-1",
+                "--type",
+                "note_added",
+                "--summary",
+                "Test",
+                "--company-id",
+                "comp-missing",
+            ],
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "company" in data["message"]
+
+
 # -- activity list -------------------------------------------------------------
 
 
@@ -1855,9 +2137,11 @@ def test_activity_list(runner: CliRunner, mock_connection: MagicMock) -> None:
         _make_activity(id="id-1", summary="first"),
         _make_activity(id="id-2", summary="second"),
     ]
+    contact = _make_contact()
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=contact),
         patch("mailpilot.database.list_activities", return_value=activities),
     ):
         result = runner.invoke(main, ["activity", "list", "--contact-id", "cid-1"])
@@ -1869,9 +2153,11 @@ def test_activity_list(runner: CliRunner, mock_connection: MagicMock) -> None:
 
 
 def test_activity_list_empty(runner: CliRunner, mock_connection: MagicMock) -> None:
+    contact = _make_contact()
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=contact),
         patch("mailpilot.database.list_activities", return_value=[]),
     ):
         result = runner.invoke(main, ["activity", "list", "--contact-id", "cid-1"])
@@ -1884,9 +2170,11 @@ def test_activity_list_empty(runner: CliRunner, mock_connection: MagicMock) -> N
 def test_activity_list_with_filters(
     runner: CliRunner, mock_connection: MagicMock
 ) -> None:
+    contact = _make_contact()
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=contact),
         patch("mailpilot.database.list_activities", return_value=[]) as mock_list,
     ):
         result = runner.invoke(
@@ -1927,6 +2215,42 @@ def test_activity_list_no_filter(runner: CliRunner, mock_connection: MagicMock) 
     assert result.exit_code == 1
     data = json.loads(result.output)
     assert data["error"] == "missing_filter"
+
+
+def test_activity_list_contact_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=None),
+    ):
+        result = runner.invoke(
+            main, ["activity", "list", "--contact-id", "cid-missing"]
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "contact" in data["message"]
+
+
+def test_activity_list_company_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_company", return_value=None),
+    ):
+        result = runner.invoke(
+            main, ["activity", "list", "--company-id", "comp-missing"]
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "company" in data["message"]
 
 
 # -- Tag -----------------------------------------------------------------------
@@ -2069,6 +2393,19 @@ def test_tag_add_no_entity(runner: CliRunner, mock_connection: MagicMock) -> Non
     assert data["error"] == "missing_filter"
 
 
+def test_tag_add_empty_name(runner: CliRunner, mock_connection: MagicMock) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+    ):
+        result = runner.invoke(main, ["tag", "add", "--contact-id", "cid-1", ""])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "validation_error"
+    assert "name" in data["message"]
+
+
 # -- tag remove ----------------------------------------------------------------
 
 
@@ -2125,9 +2462,11 @@ def test_tag_remove_creates_activity(
 
 
 def test_tag_remove_not_found(runner: CliRunner, mock_connection: MagicMock) -> None:
+    contact = _make_contact()
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=contact),
         patch("mailpilot.database.delete_tag", return_value=False),
     ):
         result = runner.invoke(
@@ -2140,6 +2479,42 @@ def test_tag_remove_not_found(runner: CliRunner, mock_connection: MagicMock) -> 
     assert data["error"] == "not_found"
 
 
+def test_tag_remove_contact_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=None),
+    ):
+        result = runner.invoke(
+            main, ["tag", "remove", "--contact-id", "cid-missing", "prospect"]
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "contact" in data["message"]
+
+
+def test_tag_remove_company_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_company", return_value=None),
+    ):
+        result = runner.invoke(
+            main, ["tag", "remove", "--company-id", "comp-missing", "prospect"]
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "company" in data["message"]
+
+
 # -- tag list ------------------------------------------------------------------
 
 
@@ -2148,9 +2523,11 @@ def test_tag_list(runner: CliRunner, mock_connection: MagicMock) -> None:
         _make_tag(id="id-1", name="cold"),
         _make_tag(id="id-2", name="prospect"),
     ]
+    contact = _make_contact()
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=contact),
         patch("mailpilot.database.list_tags", return_value=tags),
     ):
         result = runner.invoke(main, ["tag", "list", "--contact-id", "cid-1"])
@@ -2172,6 +2549,38 @@ def test_tag_list_no_entity(runner: CliRunner, mock_connection: MagicMock) -> No
     assert result.exit_code == 1
     data = json.loads(result.output)
     assert data["error"] == "missing_filter"
+
+
+def test_tag_list_contact_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=None),
+    ):
+        result = runner.invoke(main, ["tag", "list", "--contact-id", "cid-missing"])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "contact" in data["message"]
+
+
+def test_tag_list_company_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_company", return_value=None),
+    ):
+        result = runner.invoke(main, ["tag", "list", "--company-id", "comp-missing"])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "company" in data["message"]
 
 
 # -- tag search ----------------------------------------------------------------
@@ -2240,7 +2649,7 @@ def test_note_add(runner: CliRunner, mock_connection: MagicMock) -> None:
     ):
         result = runner.invoke(
             main,
-            ["note", "add", "--contact-id", "cid-1", "Test note body"],
+            ["note", "add", "--contact-id", "cid-1", "--body", "Test note body"],
         )
 
     assert result.exit_code == 0
@@ -2266,7 +2675,7 @@ def test_note_add_on_company(runner: CliRunner, mock_connection: MagicMock) -> N
     ):
         result = runner.invoke(
             main,
-            ["note", "add", "--company-id", "comp-1", "Company note"],
+            ["note", "add", "--company-id", "comp-1", "--body", "Company note"],
         )
 
     assert result.exit_code == 0
@@ -2288,7 +2697,7 @@ def test_note_add_creates_activity(
     ):
         runner.invoke(
             main,
-            ["note", "add", "--contact-id", "cid-1", "Test note body"],
+            ["note", "add", "--contact-id", "cid-1", "--body", "Test note body"],
         )
 
     mock_activity.assert_called_once_with(
@@ -2311,7 +2720,7 @@ def test_note_add_contact_not_found(
     ):
         result = runner.invoke(
             main,
-            ["note", "add", "--contact-id", "cid-missing", "Some note"],
+            ["note", "add", "--contact-id", "cid-missing", "--body", "Some note"],
         )
 
     assert result.exit_code == 1
@@ -2330,7 +2739,7 @@ def test_note_add_company_not_found(
     ):
         result = runner.invoke(
             main,
-            ["note", "add", "--company-id", "comp-missing", "Some note"],
+            ["note", "add", "--company-id", "comp-missing", "--body", "Some note"],
         )
 
     assert result.exit_code == 1
@@ -2345,11 +2754,51 @@ def test_note_add_no_entity(runner: CliRunner, mock_connection: MagicMock) -> No
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
     ):
-        result = runner.invoke(main, ["note", "add", "Some note"])
+        result = runner.invoke(main, ["note", "add", "--body", "Some note"])
 
     assert result.exit_code == 1
     data = json.loads(result.output)
     assert data["error"] == "missing_filter"
+
+
+def test_note_add_empty_body(runner: CliRunner, mock_connection: MagicMock) -> None:
+    """note add with empty body should error."""
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+    ):
+        result = runner.invoke(
+            main, ["note", "add", "--contact-id", "cid-1", "--body", ""]
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "validation_error"
+    assert "empty" in data["message"]
+
+
+def test_note_add_whitespace_body(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    """note add with whitespace-only body should error."""
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+    ):
+        result = runner.invoke(
+            main, ["note", "add", "--contact-id", "cid-1", "--body", "   "]
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "validation_error"
+    assert "empty" in data["message"]
+
+
+def test_note_add_missing_body(runner: CliRunner, mock_connection: MagicMock) -> None:
+    """note add without --body should error."""
+    result = runner.invoke(main, ["note", "add", "--contact-id", "cid-1"])
+    assert result.exit_code != 0
 
 
 # -- note list -----------------------------------------------------------------
@@ -2360,9 +2809,11 @@ def test_note_list(runner: CliRunner, mock_connection: MagicMock) -> None:
         _make_note(id="id-1", body="First note"),
         _make_note(id="id-2", body="Second note"),
     ]
+    contact = _make_contact()
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=contact),
         patch("mailpilot.database.list_notes", return_value=notes),
     ):
         result = runner.invoke(main, ["note", "list", "--contact-id", "cid-1"])
@@ -2374,9 +2825,11 @@ def test_note_list(runner: CliRunner, mock_connection: MagicMock) -> None:
 
 
 def test_note_list_with_limit(runner: CliRunner, mock_connection: MagicMock) -> None:
+    contact = _make_contact()
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=contact),
         patch("mailpilot.database.list_notes", return_value=[]) as mock_list,
     ):
         result = runner.invoke(
@@ -2400,3 +2853,69 @@ def test_note_list_no_entity(runner: CliRunner, mock_connection: MagicMock) -> N
     assert result.exit_code == 1
     data = json.loads(result.output)
     assert data["error"] == "missing_filter"
+
+
+# -- note view -----------------------------------------------------------------
+
+
+def test_note_view(runner: CliRunner, mock_connection: MagicMock) -> None:
+    note = _make_note()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_note", return_value=note) as mock_get,
+    ):
+        result = runner.invoke(main, ["note", "view", note.id])
+
+    assert result.exit_code == 0
+    mock_get.assert_called_once_with(mock_connection, note.id)
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["id"] == note.id
+    assert data["body"] == "Test note body"
+
+
+def test_note_view_not_found(runner: CliRunner, mock_connection: MagicMock) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_note", return_value=None),
+    ):
+        result = runner.invoke(main, ["note", "view", "nonexistent-id"])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "note" in data["message"]
+
+
+def test_note_list_contact_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=None),
+    ):
+        result = runner.invoke(main, ["note", "list", "--contact-id", "cid-missing"])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "contact" in data["message"]
+
+
+def test_note_list_company_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_company", return_value=None),
+    ):
+        result = runner.invoke(main, ["note", "list", "--company-id", "comp-missing"])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "company" in data["message"]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -14,6 +14,7 @@ from conftest import (
     make_test_activity,
     make_test_company,
     make_test_contact,
+    make_test_note,
     make_test_tag,
     make_test_workflow,
 )
@@ -35,6 +36,7 @@ from mailpilot.database import (
     get_email_by_gmail_message_id,
     get_emails_by_gmail_thread_id,
     get_last_cold_outbound,
+    get_note,
     get_status_counts,
     get_workflow,
     list_accounts,
@@ -43,6 +45,7 @@ from mailpilot.database import (
     list_contacts,
     list_emails,
     list_entities_by_tag,
+    list_notes,
     list_tags,
     list_workflows,
     pause_workflow,
@@ -1315,3 +1318,103 @@ def test_status_counts_includes_tags(
     make_test_tag(database_connection, entity_type="contact", entity_id=contact.id)
     counts = get_status_counts(database_connection)
     assert counts["tags"] == 1
+
+
+# -- Note ---------------------------------------------------------------------
+
+
+def test_create_note(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    note = make_test_note(
+        database_connection, entity_type="contact", entity_id=contact.id
+    )
+    assert note.entity_type == "contact"
+    assert note.entity_id == contact.id
+    assert note.body == "Test note body"
+    assert note.id
+
+
+def test_create_note_on_company(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    company = make_test_company(database_connection)
+    note = make_test_note(
+        database_connection,
+        entity_type="company",
+        entity_id=company.id,
+        body="Company note",
+    )
+    assert note.entity_type == "company"
+    assert note.body == "Company note"
+
+
+def test_list_notes(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    make_test_note(
+        database_connection, entity_type="contact", entity_id=contact.id, body="first"
+    )
+    make_test_note(
+        database_connection, entity_type="contact", entity_id=contact.id, body="second"
+    )
+    notes = list_notes(database_connection, entity_type="contact", entity_id=contact.id)
+    assert len(notes) == 2
+    # Ordered by created_at DESC
+    assert notes[0].body == "second"
+    assert notes[1].body == "first"
+
+
+def test_list_notes_empty(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    notes = list_notes(database_connection, entity_type="contact", entity_id=contact.id)
+    assert notes == []
+
+
+def test_list_notes_with_limit(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    make_test_note(
+        database_connection, entity_type="contact", entity_id=contact.id, body="first"
+    )
+    make_test_note(
+        database_connection, entity_type="contact", entity_id=contact.id, body="second"
+    )
+    notes = list_notes(
+        database_connection, entity_type="contact", entity_id=contact.id, limit=1
+    )
+    assert len(notes) == 1
+
+
+def test_get_note(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    created = make_test_note(
+        database_connection, entity_type="contact", entity_id=contact.id
+    )
+    found = get_note(database_connection, created.id)
+    assert found is not None
+    assert found.id == created.id
+    assert found.body == "Test note body"
+
+
+def test_get_note_not_found(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    found = get_note(database_connection, "nonexistent-id")
+    assert found is None
+
+
+def test_status_counts_includes_notes(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    contact = make_test_contact(database_connection)
+    make_test_note(database_connection, entity_type="contact", entity_id=contact.id)
+    counts = get_status_counts(database_connection)
+    assert counts["notes"] == 1


### PR DESCRIPTION
## Summary

Implements the `note` table for freeform text annotations on contacts and companies, and adds comprehensive input validation and entity existence checks across all CLI commands.

Part of CRM evolution (ADR-08). Resolves #45.

## Changes

**Note table (new feature):**
- Schema: `note` table with polymorphic `entity_type`/`entity_id` pattern (same as `tag`)
- Model: `Note` Pydantic model; `TagEntityType` renamed to shared `EntityType`
- Database: `create_note`, `list_notes`, `get_note` functions (append-only, no update)
- CLI: `mailpilot note add --contact-id|--company-id ID --body TEXT`
- CLI: `mailpilot note list --contact-id|--company-id ID [--limit N]`
- CLI: `mailpilot note view ID`
- Activity record created on `note add` for contacts
- Note count included in `mailpilot status`

**CLI hardening (applied across all command groups):**
- Empty/whitespace-only input rejected on: `account create --email`, `company create --domain`, `workflow create --name`, `activity create --summary`, `tag add NAME`, `note add --body`
- FK existence validated on create: `contact create --company-id`, `workflow create --account-id`, `activity create --contact-id/--company-id`
- Entity existence validated on list when optional FK filter provided: `activity list`, `email list`, `contact list`, `workflow list`, `note list`, `tag list`
- `tag remove` now validates entity exists before attempting delete (previously returned misleading "tag not found" for invalid entity IDs); also eliminates redundant `get_contact` DB call in activity creation path
- All errors return structured JSON with `"error"` code and `"ok": false`

**Documentation:**
- CLAUDE.md: updated CLI spec (`--body` option, `note view`); added input validation conventions and test-patching gotcha