### PR TITLE
feat(agent): implement workflow agent invocation

### DIFF
--- a/src/mailpilot/agent/__init__.py
+++ b/src/mailpilot/agent/__init__.py
@@ -3,8 +3,9 @@
 This package separates agent construction from tool definitions and
 classification. Files:
 
-- ``__init__`` -- ``invoke_workflow_agent()`` entry point
-- ``tools`` -- ``@tool`` decorated functions (send_email, create_task, etc.)
+- ``__init__`` -- re-exports ``invoke_workflow_agent()``
+- ``invoke`` -- agent construction, invocation, tool-use enforcement
+- ``tools`` -- standalone tool functions (send_email, create_task, etc.)
 - ``classify`` -- ``classify_email()`` structured output (not an agent)
 """
 
@@ -13,30 +14,36 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from mailpilot.models import Email, Workflow
+    import psycopg
+
+    from mailpilot.models import Contact, Email, Workflow
+    from mailpilot.settings import Settings
 
 
-async def invoke_workflow_agent(
+def invoke_workflow_agent(  # noqa: PLR0913
+    connection: psycopg.Connection[dict[str, Any]],
+    settings: Settings,
     workflow: Workflow,
+    contact: Contact,
     email: Email | None = None,
     task_description: str = "",
     task_context: dict[str, Any] | None = None,
-) -> None:
-    """Run the workflow's Pydantic AI agent.
+    model_override: object | None = None,
+) -> dict[str, Any] | None:
+    """Run the workflow's Pydantic AI agent for a contact.
 
-    The agent is stateless -- each invocation gets fresh context from the
-    database. It makes all business decisions: what to send, when to follow
-    up, when to give up.
-
-    Three trigger types:
-        - Email arrives: ``email`` is set, agent processes the inbound message
-        - Task due: ``task_description`` + ``task_context`` are set
-        - Manual send: called from CLI with contact list via workflow
-
-    Args:
-        workflow: Workflow with instructions (system prompt) and objective.
-        email: Triggering inbound email, if any.
-        task_description: Deferred task description, if triggered by task runner.
-        task_context: Arbitrary JSON context from the task row.
+    Thin re-export that defers the heavy import to avoid circular imports
+    (agent -> tools -> sync -> routing -> agent).
     """
-    raise NotImplementedError
+    from mailpilot.agent.invoke import invoke_workflow_agent as _invoke
+
+    return _invoke(
+        connection,
+        settings,
+        workflow,
+        contact,
+        email=email,
+        task_description=task_description,
+        task_context=task_context,
+        model_override=model_override,
+    )

--- a/src/mailpilot/agent/__init__.py
+++ b/src/mailpilot/agent/__init__.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import psycopg
+    from pydantic_ai.models import Model
 
     from mailpilot.models import Contact, Email, Workflow
     from mailpilot.settings import Settings
@@ -28,7 +29,7 @@ def invoke_workflow_agent(  # noqa: PLR0913
     email: Email | None = None,
     task_description: str = "",
     task_context: dict[str, Any] | None = None,
-    model_override: object | None = None,
+    model_override: Model[Any] | str | None = None,
 ) -> dict[str, Any] | None:
     """Run the workflow's Pydantic AI agent for a contact.
 

--- a/src/mailpilot/agent/invoke.py
+++ b/src/mailpilot/agent/invoke.py
@@ -21,8 +21,8 @@ from typing import Any
 
 import logfire
 import psycopg
-from pydantic_ai import Agent, RunContext
-from pydantic_ai.messages import ToolCallPart
+from pydantic_ai import Agent, RunContext, Tool
+from pydantic_ai.messages import ToolReturnPart
 
 from mailpilot import database
 from mailpilot.agent import tools as agent_tools
@@ -229,17 +229,17 @@ def _wrap_noop(
 # -- Agent construction --------------------------------------------------------
 
 
-_TOOLS = [
-    _wrap_send_email,
-    _wrap_create_task,
-    _wrap_cancel_task,
-    _wrap_update_contact_status,
-    _wrap_disable_contact,
-    _wrap_list_workflow_contacts,
-    _wrap_search_emails,
-    _wrap_read_contact,
-    _wrap_read_company,
-    _wrap_noop,
+_TOOLS: list[Tool[AgentDeps]] = [
+    Tool(_wrap_send_email, name="send_email"),
+    Tool(_wrap_create_task, name="create_task"),
+    Tool(_wrap_cancel_task, name="cancel_task"),
+    Tool(_wrap_update_contact_status, name="update_contact_status"),
+    Tool(_wrap_disable_contact, name="disable_contact"),
+    Tool(_wrap_list_workflow_contacts, name="list_workflow_contacts"),
+    Tool(_wrap_search_emails, name="search_emails"),
+    Tool(_wrap_read_contact, name="read_contact"),
+    Tool(_wrap_read_company, name="read_company"),
+    Tool(_wrap_noop, name="noop"),
 ]
 
 
@@ -325,10 +325,14 @@ def _build_user_prompt(  # noqa: PLR0913
 # -- Tool-use enforcement ------------------------------------------------------
 
 
-def _count_tool_calls(messages: list[Any]) -> int:
-    """Count tool calls in the agent's message history."""
+def _count_successful_tool_calls(messages: list[Any]) -> int:
+    """Count successful tool executions in the agent's message history.
+
+    Counts ToolReturnPart with outcome='success' rather than ToolCallPart
+    to exclude failed attempts (wrong tool name, validation errors).
+    """
     return sum(
-        isinstance(part, ToolCallPart)
+        isinstance(part, ToolReturnPart) and part.outcome == "success"
         for msg in messages
         for part in (msg.parts if hasattr(msg, "parts") else [])
     )
@@ -442,16 +446,15 @@ def invoke_workflow_agent(  # noqa: PLR0913
             result = agent.run_sync(prompt, model=model, deps=deps)  # type: ignore[arg-type]
 
             # Tool-use enforcement.
-            tool_call_count = _count_tool_calls(result.all_messages())
+            tool_call_count = _count_successful_tool_calls(result.all_messages())
             span.set_attribute("tool_call_count", tool_call_count)
 
             if tool_call_count == 0:
-                agent_output = result.output
                 logfire.warn(
                     "agent.no_tools_called",
                     workflow_id=workflow.id,
                     contact_id=contact.id,
-                    agent_output=str(agent_output),
+                    agent_output=result.output,
                 )
                 raise AgentDidNotUseToolsError(
                     f"agent completed without calling any tools: "

--- a/src/mailpilot/agent/invoke.py
+++ b/src/mailpilot/agent/invoke.py
@@ -23,6 +23,7 @@ import logfire
 import psycopg
 from pydantic_ai import Agent, RunContext, Tool
 from pydantic_ai.messages import ToolReturnPart
+from pydantic_ai.models import Model
 
 from mailpilot import database
 from mailpilot.agent import tools as agent_tools
@@ -349,7 +350,7 @@ def invoke_workflow_agent(  # noqa: PLR0913
     email: Email | None = None,
     task_description: str = "",
     task_context: dict[str, Any] | None = None,
-    model_override: object | None = None,
+    model_override: Model | str | None = None,
 ) -> dict[str, Any] | None:
     """Run the workflow's Pydantic AI agent for a contact.
 
@@ -443,7 +444,7 @@ def invoke_workflow_agent(  # noqa: PLR0913
 
             span.set_attribute("prompt_length", len(prompt))
 
-            result = agent.run_sync(prompt, model=model, deps=deps)  # type: ignore[arg-type]
+            result = agent.run_sync(prompt, model=model, deps=deps)
 
             # Tool-use enforcement.
             tool_call_count = _count_successful_tool_calls(result.all_messages())

--- a/src/mailpilot/agent/invoke.py
+++ b/src/mailpilot/agent/invoke.py
@@ -1,0 +1,470 @@
+"""Workflow agent invocation.
+
+Builds and runs a Pydantic AI agent for a given workflow + contact pair.
+This is the central execution unit -- both inbound routing and outbound
+campaigns culminate here.
+
+Advisory locking: a PostgreSQL advisory lock keyed on
+``(workflow_id, contact_id)`` prevents concurrent invocations for the
+same pair. If the lock is already held, the invocation is skipped.
+
+Tool-use enforcement: the agent must call at least one tool per run.
+``noop(reason)`` is the explicit "do nothing" escape hatch. A run with
+zero tool calls raises ``AgentDidNotUseToolsError``.
+"""
+
+from __future__ import annotations
+
+import zlib
+from dataclasses import dataclass
+from typing import Any
+
+import logfire
+import psycopg
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.messages import ToolCallPart
+
+from mailpilot import database
+from mailpilot.agent import tools as agent_tools
+from mailpilot.exceptions import AgentDidNotUseToolsError
+from mailpilot.gmail import GmailClient
+from mailpilot.models import Account, Contact, Email, Workflow
+from mailpilot.settings import Settings
+
+
+@dataclass
+class AgentDeps:
+    """Dependencies injected into every agent tool via RunContext."""
+
+    connection: psycopg.Connection[dict[str, Any]]
+    account: Account
+    gmail_client: GmailClient
+    settings: Settings
+    workflow_id: str
+
+
+# -- Advisory lock -------------------------------------------------------------
+
+
+def _advisory_lock_key(workflow_id: str, contact_id: str) -> int:
+    """Compute a stable bigint key for PostgreSQL advisory locking."""
+    return zlib.crc32(f"{workflow_id}:{contact_id}".encode())
+
+
+def _try_acquire_advisory_lock(
+    connection: psycopg.Connection[dict[str, Any]],
+    workflow_id: str,
+    contact_id: str,
+) -> bool:
+    """Try to acquire a session-level advisory lock. Non-blocking.
+
+    Returns True if lock was acquired, False if already held elsewhere.
+    """
+    key = _advisory_lock_key(workflow_id, contact_id)
+    row = connection.execute(
+        "SELECT pg_try_advisory_lock(%(key)s) AS acquired",
+        {"key": key},
+    ).fetchone()
+    return bool(row and row["acquired"])
+
+
+def _release_advisory_lock(
+    connection: psycopg.Connection[dict[str, Any]],
+    workflow_id: str,
+    contact_id: str,
+) -> None:
+    """Release a session-level advisory lock."""
+    key = _advisory_lock_key(workflow_id, contact_id)
+    connection.execute(
+        "SELECT pg_advisory_unlock(%(key)s)",
+        {"key": key},
+    )
+
+
+# -- Tool wrappers -------------------------------------------------------------
+# Thin functions that unpack AgentDeps from RunContext and delegate to the
+# standalone tool functions in agent/tools.py.
+
+
+def _wrap_send_email(
+    ctx: RunContext[AgentDeps],
+    to: str,
+    subject: str,
+    body: str,
+    thread_id: str | None = None,
+) -> dict[str, Any]:
+    """Send an email via Gmail API."""
+    return agent_tools.send_email(
+        connection=ctx.deps.connection,
+        account=ctx.deps.account,
+        gmail_client=ctx.deps.gmail_client,
+        settings=ctx.deps.settings,
+        workflow_id=ctx.deps.workflow_id,
+        to=to,
+        subject=subject,
+        body=body,
+        thread_id=thread_id,
+    )
+
+
+def _wrap_create_task(  # noqa: PLR0913
+    ctx: RunContext[AgentDeps],
+    contact_id: str,
+    description: str,
+    scheduled_at: str,
+    context: dict[str, Any] | None = None,
+    email_id: str | None = None,
+) -> dict[str, str]:
+    """Schedule deferred work for later execution."""
+    return agent_tools.create_task(
+        connection=ctx.deps.connection,
+        workflow_id=ctx.deps.workflow_id,
+        contact_id=contact_id,
+        description=description,
+        scheduled_at=scheduled_at,
+        context=context,
+        email_id=email_id,
+    )
+
+
+def _wrap_cancel_task(
+    ctx: RunContext[AgentDeps],
+    task_id: str,
+) -> dict[str, str]:
+    """Cancel a pending task."""
+    return agent_tools.cancel_task(
+        connection=ctx.deps.connection,
+        task_id=task_id,
+    )
+
+
+def _wrap_update_contact_status(
+    ctx: RunContext[AgentDeps],
+    contact_id: str,
+    status: str,
+    reason: str,
+) -> dict[str, str]:
+    """Report outcome for a contact in the current workflow."""
+    return agent_tools.update_contact_status(
+        connection=ctx.deps.connection,
+        workflow_id=ctx.deps.workflow_id,
+        contact_id=contact_id,
+        status=status,
+        reason=reason,
+    )
+
+
+def _wrap_disable_contact(
+    ctx: RunContext[AgentDeps],
+    contact_id: str,
+    status: str,
+    reason: str,
+) -> dict[str, str]:
+    """Set a global block on a contact (bounced or unsubscribed)."""
+    return agent_tools.disable_contact(
+        connection=ctx.deps.connection,
+        contact_id=contact_id,
+        status=status,
+        reason=reason,
+    )
+
+
+def _wrap_list_workflow_contacts(
+    ctx: RunContext[AgentDeps],
+) -> list[dict[str, Any]]:
+    """List contacts in the current workflow with their outcome status."""
+    return agent_tools.list_workflow_contacts(
+        connection=ctx.deps.connection,
+        workflow_id=ctx.deps.workflow_id,
+    )
+
+
+def _wrap_search_emails(
+    ctx: RunContext[AgentDeps],
+    query: str,
+) -> list[dict[str, Any]]:
+    """Search email history for the current account."""
+    return agent_tools.search_emails(
+        connection=ctx.deps.connection,
+        account_id=ctx.deps.account.id,
+        query=query,
+    )
+
+
+def _wrap_read_contact(
+    ctx: RunContext[AgentDeps],
+    email: str,
+) -> dict[str, Any] | None:
+    """Look up a contact by email address."""
+    return agent_tools.read_contact(
+        connection=ctx.deps.connection,
+        email=email,
+    )
+
+
+def _wrap_read_company(
+    ctx: RunContext[AgentDeps],
+    domain: str,
+) -> dict[str, Any] | None:
+    """Look up a company by domain."""
+    return agent_tools.read_company(
+        connection=ctx.deps.connection,
+        domain=domain,
+    )
+
+
+def _wrap_noop(
+    ctx: RunContext[AgentDeps],
+    reason: str,
+) -> dict[str, Any]:
+    """Explicitly decline to act.
+
+    Call this tool when, after reviewing context, no action is appropriate.
+    You must still call a tool every turn -- noop is the explicit "do nothing"
+    signal.
+    """
+    return agent_tools.noop(reason=reason)
+
+
+# -- Agent construction --------------------------------------------------------
+
+
+_TOOLS = [
+    _wrap_send_email,
+    _wrap_create_task,
+    _wrap_cancel_task,
+    _wrap_update_contact_status,
+    _wrap_disable_contact,
+    _wrap_list_workflow_contacts,
+    _wrap_search_emails,
+    _wrap_read_contact,
+    _wrap_read_company,
+    _wrap_noop,
+]
+
+
+def _build_agent(workflow: Workflow) -> Agent[AgentDeps, str]:
+    """Build a Pydantic AI agent for a workflow."""
+    return Agent(
+        deps_type=AgentDeps,
+        instructions=workflow.instructions,
+        tools=_TOOLS,
+    )
+
+
+# -- Prompt assembly -----------------------------------------------------------
+
+
+def _format_email_history(email_history: list[Email]) -> str:
+    """Format email history for the agent prompt."""
+    if not email_history:
+        return "\nNo prior email history with this contact."
+    lines = [f"\nEmail history ({len(email_history)} messages):"]
+    for msg in email_history:
+        direction = "SENT" if msg.direction == "outbound" else "RECEIVED"
+        lines.append(f"  [{direction}] {msg.subject}")
+        if msg.body_text:
+            body_preview = msg.body_text[:500]
+            if len(msg.body_text) > 500:
+                body_preview += "..."
+            lines.append(f"  {body_preview}")
+    return "\n".join(lines)
+
+
+def _format_trigger(
+    email: Email | None,
+    task_description: str,
+    task_context: dict[str, Any] | None,
+) -> str:
+    """Format the trigger context section of the prompt."""
+    if email is not None:
+        return (
+            f"\nNew inbound email:\nSubject: {email.subject}\nBody:\n{email.body_text}"
+        )
+    if task_description:
+        lines = ["\nDeferred task:", f"Description: {task_description}"]
+        if task_context:
+            lines.append(f"Context: {task_context}")
+        return "\n".join(lines)
+    return (
+        "\nThis is an outbound invocation. "
+        "Review the contact and email history, then take appropriate action."
+    )
+
+
+def _build_user_prompt(  # noqa: PLR0913
+    workflow: Workflow,
+    contact: Contact,
+    email_history: list[Email],
+    email: Email | None = None,
+    task_description: str = "",
+    task_context: dict[str, Any] | None = None,
+) -> str:
+    """Assemble the user prompt for the agent."""
+    sections: list[str] = [
+        f"Workflow: {workflow.name}",
+        f"Objective: {workflow.objective}",
+        f"Type: {workflow.type}",
+        f"\nContact: {contact.email}",
+    ]
+
+    if contact.first_name or contact.last_name:
+        name = f"{contact.first_name or ''} {contact.last_name or ''}".strip()
+        sections.append(f"Name: {name}")
+    if contact.position:
+        sections.append(f"Position: {contact.position}")
+    if contact.domain:
+        sections.append(f"Domain: {contact.domain}")
+
+    sections.append(_format_email_history(email_history))
+    sections.append(_format_trigger(email, task_description, task_context))
+
+    return "\n".join(sections)
+
+
+# -- Tool-use enforcement ------------------------------------------------------
+
+
+def _count_tool_calls(messages: list[Any]) -> int:
+    """Count tool calls in the agent's message history."""
+    return sum(
+        isinstance(part, ToolCallPart)
+        for msg in messages
+        for part in (msg.parts if hasattr(msg, "parts") else [])
+    )
+
+
+# -- Main entry point ----------------------------------------------------------
+
+
+def invoke_workflow_agent(  # noqa: PLR0913
+    connection: psycopg.Connection[dict[str, Any]],
+    settings: Settings,
+    workflow: Workflow,
+    contact: Contact,
+    email: Email | None = None,
+    task_description: str = "",
+    task_context: dict[str, Any] | None = None,
+    model_override: object | None = None,
+) -> dict[str, Any] | None:
+    """Run the workflow's Pydantic AI agent for a contact.
+
+    The agent is stateless -- each invocation gets fresh context from the
+    database.
+
+    Args:
+        connection: Open database connection.
+        settings: Application settings (API keys, model config).
+        workflow: Workflow with instructions (system prompt) and objective.
+        contact: Target contact.
+        email: Triggering inbound email, if any.
+        task_description: Deferred task description, if triggered by task runner.
+        task_context: Arbitrary JSON context from the task row.
+        model_override: Override the LLM model (for testing with FunctionModel).
+
+    Returns:
+        Dict with invocation result, or None if skipped (lock held).
+
+    Raises:
+        AgentDidNotUseToolsError: If the agent completed without calling any tools.
+    """
+    with logfire.span(
+        "agent.invoke",
+        workflow_id=workflow.id,
+        contact_id=contact.id,
+        workflow_type=workflow.type,
+        trigger="email" if email else ("task" if task_description else "manual"),
+    ) as span:
+        # Acquire advisory lock.
+        if not _try_acquire_advisory_lock(connection, workflow.id, contact.id):
+            logfire.debug(
+                "agent.invoke.skipped_lock_held",
+                workflow_id=workflow.id,
+                contact_id=contact.id,
+            )
+            span.set_attribute("result", "skipped_lock_held")
+            return None
+
+        try:
+            # Load account for this workflow.
+            account = database.get_account(connection, workflow.account_id)
+            if account is None:
+                raise ValueError(
+                    f"account not found for workflow: {workflow.account_id}"
+                )
+
+            # Load email history between account and contact.
+            email_history = database.list_emails(
+                connection,
+                contact_id=contact.id,
+                account_id=account.id,
+            )
+
+            # Build agent and deps.
+            agent = _build_agent(workflow)
+            if model_override is not None:
+                model = model_override
+            else:
+                from pydantic_ai.models.anthropic import AnthropicModel
+                from pydantic_ai.providers.anthropic import AnthropicProvider
+
+                if not settings.anthropic_api_key:
+                    raise ValueError(
+                        "anthropic_api_key is required for agent invocation; "
+                        "set it via `mailpilot config set anthropic_api_key ...`",
+                    )
+                model = AnthropicModel(
+                    settings.anthropic_model,
+                    provider=AnthropicProvider(api_key=settings.anthropic_api_key),
+                )
+
+            gmail_client = GmailClient(account.email)
+            deps = AgentDeps(
+                connection=connection,
+                account=account,
+                gmail_client=gmail_client,
+                settings=settings,
+                workflow_id=workflow.id,
+            )
+
+            # Assemble prompt and run.
+            prompt = _build_user_prompt(
+                workflow=workflow,
+                contact=contact,
+                email_history=email_history,
+                email=email,
+                task_description=task_description,
+                task_context=task_context,
+            )
+
+            span.set_attribute("prompt_length", len(prompt))
+
+            result = agent.run_sync(prompt, model=model, deps=deps)  # type: ignore[arg-type]
+
+            # Tool-use enforcement.
+            tool_call_count = _count_tool_calls(result.all_messages())
+            span.set_attribute("tool_call_count", tool_call_count)
+
+            if tool_call_count == 0:
+                agent_output = result.output
+                logfire.warn(
+                    "agent.no_tools_called",
+                    workflow_id=workflow.id,
+                    contact_id=contact.id,
+                    agent_output=str(agent_output),
+                )
+                raise AgentDidNotUseToolsError(
+                    f"agent completed without calling any tools: "
+                    f"workflow={workflow.id}, contact={contact.id}"
+                )
+
+            span.set_attribute("result", "completed")
+            return {
+                "workflow_id": workflow.id,
+                "contact_id": contact.id,
+                "status": "completed",
+                "tool_calls": tool_call_count,
+            }
+
+        finally:
+            _release_advisory_lock(connection, workflow.id, contact.id)

--- a/src/mailpilot/agent/invoke.py
+++ b/src/mailpilot/agent/invoke.py
@@ -47,9 +47,24 @@ class AgentDeps:
 # -- Advisory lock -------------------------------------------------------------
 
 
-def _advisory_lock_key(workflow_id: str, contact_id: str) -> int:
-    """Compute a stable bigint key for PostgreSQL advisory locking."""
-    return zlib.crc32(f"{workflow_id}:{contact_id}".encode())
+def _to_signed_int32(value: int) -> int:
+    """Convert an unsigned 32-bit integer to a signed 32-bit integer."""
+    if value >= 0x80000000:
+        return value - 0x100000000
+    return value
+
+
+def _advisory_lock_keys(workflow_id: str, contact_id: str) -> tuple[int, int]:
+    """Compute two int32 keys for PostgreSQL two-argument advisory locking.
+
+    Uses CRC-32 of each ID independently, giving 64 bits of collision space
+    (one CRC-32 per dimension) instead of 32 bits from a single combined hash.
+    Values are converted to signed int32 to match PostgreSQL's integer type.
+    """
+    return (
+        _to_signed_int32(zlib.crc32(workflow_id.encode())),
+        _to_signed_int32(zlib.crc32(contact_id.encode())),
+    )
 
 
 def _try_acquire_advisory_lock(
@@ -61,10 +76,10 @@ def _try_acquire_advisory_lock(
 
     Returns True if lock was acquired, False if already held elsewhere.
     """
-    key = _advisory_lock_key(workflow_id, contact_id)
+    k1, k2 = _advisory_lock_keys(workflow_id, contact_id)
     row = connection.execute(
-        "SELECT pg_try_advisory_lock(%(key)s) AS acquired",
-        {"key": key},
+        "SELECT pg_try_advisory_lock(%(k1)s, %(k2)s) AS acquired",
+        {"k1": k1, "k2": k2},
     ).fetchone()
     return bool(row and row["acquired"])
 
@@ -75,10 +90,10 @@ def _release_advisory_lock(
     contact_id: str,
 ) -> None:
     """Release a session-level advisory lock."""
-    key = _advisory_lock_key(workflow_id, contact_id)
+    k1, k2 = _advisory_lock_keys(workflow_id, contact_id)
     connection.execute(
-        "SELECT pg_advisory_unlock(%(key)s)",
-        {"key": key},
+        "SELECT pg_advisory_unlock(%(k1)s, %(k2)s)",
+        {"k1": k1, "k2": k2},
     )
 
 

--- a/src/mailpilot/agent/tools.py
+++ b/src/mailpilot/agent/tools.py
@@ -331,3 +331,20 @@ def read_company(
         if company is None:
             return None
         return company.model_dump()
+
+
+def noop(reason: str) -> dict[str, Any]:
+    """Explicitly decline to act.
+
+    Call this tool when, after reviewing context, no action is appropriate.
+    You must still call a tool every turn -- noop is the explicit "do nothing"
+    signal.
+
+    Args:
+        reason: Why no action is needed.
+
+    Returns:
+        Acknowledgement dict.
+    """
+    with logfire.span("agent.tool.noop", reason=reason):
+        return {"acknowledged": True, "reason": reason}

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -1354,7 +1354,12 @@ def workflow_pause(workflow_id: str) -> None:
 def workflow_run(workflow_id: str, contact_id: str) -> None:
     """Invoke the workflow agent for a single contact (outbound only)."""
     from mailpilot.agent import invoke_workflow_agent
-    from mailpilot.database import get_contact, get_workflow, initialize_database
+    from mailpilot.database import (
+        get_contact,
+        get_workflow,
+        get_workflow_contact,
+        initialize_database,
+    )
     from mailpilot.exceptions import AgentDidNotUseToolsError
     from mailpilot.settings import get_settings
 
@@ -1375,6 +1380,11 @@ def workflow_run(workflow_id: str, contact_id: str) -> None:
         contact = get_contact(connection, contact_id)
         if contact is None:
             output_error(f"contact not found: {contact_id}", "not_found")
+        if get_workflow_contact(connection, workflow_id, contact.id) is None:
+            output_error(
+                f"contact {contact_id} is not enrolled in workflow {workflow_id}",
+                "not_found",
+            )
         try:
             result = invoke_workflow_agent(connection, settings, wf, contact)
         except AgentDidNotUseToolsError:

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -1353,11 +1353,12 @@ def workflow_pause(workflow_id: str) -> None:
 @click.option("--contact-id", required=True, help="Contact ID.")
 def workflow_run(workflow_id: str, contact_id: str) -> None:
     """Invoke the workflow agent for a single contact (outbound only)."""
-    import asyncio
-
     from mailpilot.agent import invoke_workflow_agent
     from mailpilot.database import get_contact, get_workflow, initialize_database
+    from mailpilot.exceptions import AgentDidNotUseToolsError
+    from mailpilot.settings import get_settings
 
+    settings = get_settings()
     connection = initialize_database(_database_url())
     try:
         wf = get_workflow(connection, workflow_id)
@@ -1374,14 +1375,26 @@ def workflow_run(workflow_id: str, contact_id: str) -> None:
         contact = get_contact(connection, contact_id)
         if contact is None:
             output_error(f"contact not found: {contact_id}", "not_found")
-        result = invoke_workflow_agent(wf)
-        if asyncio.iscoroutine(result):
-            asyncio.run(result)
+        try:
+            result = invoke_workflow_agent(connection, settings, wf, contact)
+        except AgentDidNotUseToolsError:
+            output_error(
+                f"agent completed without calling any tools: "
+                f"workflow={workflow_id}, contact={contact_id}",
+                "agent_no_tools",
+            )
+        if result is None:
+            output_error(
+                f"invocation skipped: advisory lock held for "
+                f"workflow={workflow_id}, contact={contact_id}",
+                "lock_held",
+            )
         output(
             {
                 "workflow_id": wf.id,
                 "contact_id": contact.id,
-                "status": "invoked",
+                "status": "completed",
+                "tool_calls": result["tool_calls"],
             }
         )
     finally:

--- a/src/mailpilot/exceptions.py
+++ b/src/mailpilot/exceptions.py
@@ -24,3 +24,7 @@ class ClassificationError(MailPilotError):
 
 class SyncError(MailPilotError):
     """Gmail sync operation failed."""
+
+
+class AgentDidNotUseToolsError(MailPilotError):
+    """Agent completed a run without calling any tools."""

--- a/tests/test_agent_invoke.py
+++ b/tests/test_agent_invoke.py
@@ -1,0 +1,295 @@
+"""Tests for workflow agent invocation."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import psycopg
+import pytest
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+)
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from conftest import (
+    make_test_account,
+    make_test_contact,
+    make_test_settings,
+    make_test_workflow,
+)
+from mailpilot.agent.invoke import (
+    _advisory_lock_key,  # pyright: ignore[reportPrivateUsage]
+    invoke_workflow_agent,
+)
+from mailpilot.database import (
+    activate_workflow,
+    create_workflow_contact,
+    update_workflow,
+)
+from mailpilot.exceptions import AgentDidNotUseToolsError
+
+# -- Helpers -------------------------------------------------------------------
+
+
+def _activate(connection: psycopg.Connection[dict[str, Any]], workflow_id: str) -> None:
+    """Fill required fields and activate a workflow."""
+    update_workflow(
+        connection,
+        workflow_id,
+        objective="Test objective",
+        instructions="You are a sales outreach agent. Send an email to the contact.",
+    )
+    activate_workflow(connection, workflow_id)
+
+
+def _setup(
+    connection: psycopg.Connection[dict[str, Any]],
+) -> tuple[Any, Any, Any]:
+    """Create account, contact, and active outbound workflow."""
+    account = make_test_account(connection, email="sender@example.com")
+    contact = make_test_contact(connection, email="lead@acme.com", domain="acme.com")
+    workflow = make_test_workflow(connection, account_id=account.id)
+    _activate(connection, workflow.id)
+    create_workflow_contact(connection, workflow.id, contact.id)
+    return account, contact, workflow
+
+
+def _model_that_calls_noop(
+    messages: list[ModelMessage], info: AgentInfo
+) -> ModelResponse:
+    """FunctionModel that calls the noop tool then finishes."""
+    # First call: invoke noop tool
+    for msg in messages:
+        for part in msg.parts if hasattr(msg, "parts") else []:
+            if isinstance(part, ToolCallPart):
+                # Tool result received -- finish with text
+                return ModelResponse(
+                    parts=[TextPart(content="Done, no action needed.")]
+                )
+    return ModelResponse(
+        parts=[ToolCallPart(tool_name="noop", args={"reason": "no action needed"})]
+    )
+
+
+def _model_that_calls_tool(tool_name: str, tool_args: dict[str, Any]) -> FunctionModel:
+    """Build a FunctionModel that calls a specific tool then finishes."""
+    call_count = 0
+
+    def _respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return ModelResponse(
+                parts=[ToolCallPart(tool_name=tool_name, args=tool_args)]
+            )
+        return ModelResponse(parts=[TextPart(content="Done.")])
+
+    return FunctionModel(_respond)
+
+
+def _model_no_tools(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+    """FunctionModel that returns text only, no tool calls."""
+    return ModelResponse(
+        parts=[TextPart(content="I thought about it but decided not to act.")]
+    )
+
+
+def _capturing_model(
+    captured: list[ModelMessage],
+) -> FunctionModel:
+    """Build a FunctionModel that captures messages on first call, then finishes."""
+    call_count = 0
+
+    def _respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            captured.extend(messages)
+            return ModelResponse(
+                parts=[ToolCallPart(tool_name="noop", args={"reason": "testing"})]
+            )
+        return ModelResponse(parts=[TextPart(content="Done")])
+
+    return FunctionModel(_respond)
+
+
+# -- Tests: tool-use enforcement -----------------------------------------------
+
+
+def test_agent_calls_noop_passes_enforcement(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """Agent calls noop -> enforcement passes (noop counts as a tool call)."""
+    _account, contact, workflow = _setup(database_connection)
+    settings = make_test_settings(
+        anthropic_api_key="sk-test", anthropic_model="test-model"
+    )
+    with patch("mailpilot.agent.invoke.GmailClient"):
+        invoke_workflow_agent(
+            database_connection,
+            settings,
+            workflow,
+            contact,
+            model_override=FunctionModel(_model_that_calls_noop),
+        )
+    # No exception means enforcement passed.
+
+
+def test_agent_no_tool_calls_raises(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """Agent returns text only -> enforcement raises AgentDidNotUseToolsError."""
+    _account, contact, workflow = _setup(database_connection)
+    settings = make_test_settings(
+        anthropic_api_key="sk-test", anthropic_model="test-model"
+    )
+    with (
+        patch("mailpilot.agent.invoke.GmailClient"),
+        pytest.raises(AgentDidNotUseToolsError, match=workflow.id),
+    ):
+        invoke_workflow_agent(
+            database_connection,
+            settings,
+            workflow,
+            contact,
+            model_override=FunctionModel(_model_no_tools),
+        )
+
+
+def test_agent_calls_real_tool_passes_enforcement(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """Agent calls a real tool (read_contact) -> enforcement passes."""
+    _account, contact, workflow = _setup(database_connection)
+    settings = make_test_settings(
+        anthropic_api_key="sk-test", anthropic_model="test-model"
+    )
+    model = _model_that_calls_tool("read_contact", {"email": contact.email})
+    with patch("mailpilot.agent.invoke.GmailClient"):
+        invoke_workflow_agent(
+            database_connection,
+            settings,
+            workflow,
+            contact,
+            model_override=model,
+        )
+
+
+# -- Tests: advisory lock ------------------------------------------------------
+
+
+def test_advisory_lock_skip_when_held(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """When advisory lock is already held, invocation is skipped (returns None)."""
+    _account, contact, workflow = _setup(database_connection)
+    settings = make_test_settings(
+        anthropic_api_key="sk-test", anthropic_model="test-model"
+    )
+
+    # Acquire the same advisory lock from a separate connection to simulate
+    # a concurrent invocation.
+    from conftest import TEST_DATABASE_URL
+
+    blocker = psycopg.connect(TEST_DATABASE_URL)
+    try:
+        lock_key = _advisory_lock_key(workflow.id, contact.id)
+        blocker.execute("SELECT pg_advisory_lock(%s)", (lock_key,))
+
+        result = invoke_workflow_agent(
+            database_connection,
+            settings,
+            workflow,
+            contact,
+            model_override=FunctionModel(_model_that_calls_noop),
+        )
+        assert result is None
+    finally:
+        blocker.close()
+
+
+# -- Tests: email history context -----------------------------------------------
+
+
+def test_email_history_loaded(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """Agent receives email history between account and contact in the prompt."""
+    account, contact, workflow = _setup(database_connection)
+    settings = make_test_settings(
+        anthropic_api_key="sk-test", anthropic_model="test-model"
+    )
+
+    # Create an email in the history.
+    from mailpilot.database import create_email
+
+    create_email(
+        database_connection,
+        gmail_message_id="msg-hist-1",
+        gmail_thread_id="thread-hist-1",
+        account_id=account.id,
+        contact_id=contact.id,
+        direction="outbound",
+        subject="Previous outreach",
+        body_text="Hi, interested in a demo?",
+    )
+
+    captured_messages: list[ModelMessage] = []
+    with patch("mailpilot.agent.invoke.GmailClient"):
+        invoke_workflow_agent(
+            database_connection,
+            settings,
+            workflow,
+            contact,
+            model_override=_capturing_model(captured_messages),
+        )
+
+    all_text = str(captured_messages)
+    assert "Previous outreach" in all_text
+
+
+# -- Tests: trigger context ----------------------------------------------------
+
+
+def test_inbound_email_trigger(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """When an inbound email is provided, it appears in the agent prompt."""
+    account, contact, workflow = _setup(database_connection)
+    # Make it inbound for this test.
+    update_workflow(database_connection, workflow.id, type="inbound")
+    settings = make_test_settings(
+        anthropic_api_key="sk-test", anthropic_model="test-model"
+    )
+
+    from mailpilot.database import create_email
+
+    email = create_email(
+        database_connection,
+        gmail_message_id="msg-inbound-1",
+        gmail_thread_id="thread-inbound-1",
+        account_id=account.id,
+        contact_id=contact.id,
+        direction="inbound",
+        subject="Question about pricing",
+        body_text="How much does your product cost?",
+    )
+
+    captured_messages: list[ModelMessage] = []
+    with patch("mailpilot.agent.invoke.GmailClient"):
+        invoke_workflow_agent(
+            database_connection,
+            settings,
+            workflow,
+            contact,
+            email=email,
+            model_override=_capturing_model(captured_messages),
+        )
+
+    all_text = str(captured_messages)
+    assert "Question about pricing" in all_text
+    assert "How much does your product cost?" in all_text

--- a/tests/test_agent_invoke.py
+++ b/tests/test_agent_invoke.py
@@ -22,7 +22,7 @@ from conftest import (
     make_test_workflow,
 )
 from mailpilot.agent.invoke import (
-    _advisory_lock_key,  # pyright: ignore[reportPrivateUsage]
+    _advisory_lock_keys,  # pyright: ignore[reportPrivateUsage]
     invoke_workflow_agent,
 )
 from mailpilot.database import (
@@ -197,8 +197,8 @@ def test_advisory_lock_skip_when_held(
 
     blocker = psycopg.connect(TEST_DATABASE_URL)
     try:
-        lock_key = _advisory_lock_key(workflow.id, contact.id)
-        blocker.execute("SELECT pg_advisory_lock(%s)", (lock_key,))
+        k1, k2 = _advisory_lock_keys(workflow.id, contact.id)
+        blocker.execute("SELECT pg_advisory_lock(%s, %s)", (k1, k2))
 
         result = invoke_workflow_agent(
             database_connection,
@@ -293,3 +293,75 @@ def test_inbound_email_trigger(
     all_text = str(captured_messages)
     assert "Question about pricing" in all_text
     assert "How much does your product cost?" in all_text
+
+
+def test_deferred_task_trigger(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """When task_description is provided, it appears in the agent prompt."""
+    _account, contact, workflow = _setup(database_connection)
+    settings = make_test_settings(
+        anthropic_api_key="sk-test", anthropic_model="test-model"
+    )
+
+    captured_messages: list[ModelMessage] = []
+    with patch("mailpilot.agent.invoke.GmailClient"):
+        invoke_workflow_agent(
+            database_connection,
+            settings,
+            workflow,
+            contact,
+            task_description="Follow up on demo request",
+            task_context={"days_since_last": 7},
+            model_override=_capturing_model(captured_messages),
+        )
+
+    all_text = str(captured_messages)
+    assert "Follow up on demo request" in all_text
+    assert "days_since_last" in all_text
+
+
+# -- Tests: early-exit paths ---------------------------------------------------
+
+
+def test_account_not_found_raises(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """When workflow references a deleted account, raises ValueError."""
+    _account, contact, workflow = _setup(database_connection)
+    settings = make_test_settings(
+        anthropic_api_key="sk-test", anthropic_model="test-model"
+    )
+
+    with (
+        patch("mailpilot.agent.invoke.GmailClient"),
+        patch("mailpilot.agent.invoke.database.get_account", return_value=None),
+        pytest.raises(ValueError, match="account not found"),
+    ):
+        invoke_workflow_agent(
+            database_connection,
+            settings,
+            workflow,
+            contact,
+            model_override=FunctionModel(_model_that_calls_noop),
+        )
+
+
+def test_missing_api_key_raises(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """When no model_override and no anthropic_api_key, raises ValueError."""
+    _account, contact, workflow = _setup(database_connection)
+    settings = make_test_settings(anthropic_api_key="", anthropic_model="test-model")
+
+    with (
+        patch("mailpilot.agent.invoke.GmailClient"),
+        pytest.raises(ValueError, match="anthropic_api_key is required"),
+    ):
+        invoke_workflow_agent(
+            database_connection,
+            settings,
+            workflow,
+            contact,
+            # No model_override -- forces the real model path.
+        )

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -20,6 +20,7 @@ from mailpilot.agent.tools import (
     create_task,
     disable_contact,
     list_workflow_contacts,
+    noop,
     read_company,
     read_contact,
     search_emails,
@@ -501,3 +502,12 @@ def test_read_company_not_found(
 ):
     result = read_company(connection=database_connection, domain="nonexistent.com")
     assert result is None
+
+
+# -- noop ----------------------------------------------------------------------
+
+
+def test_noop() -> None:
+    result = noop(reason="no action needed")
+    assert result["acknowledged"] is True
+    assert result["reason"] == "no action needed"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1802,12 +1802,20 @@ def test_workflow_run(runner: CliRunner, mock_connection: MagicMock) -> None:
         created_at=_NOW,
         updated_at=_NOW,
     )
+    invoke_result = {
+        "workflow_id": _WORKFLOW_ID,
+        "contact_id": _CONTACT_ID,
+        "status": "completed",
+        "tool_calls": 2,
+    }
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
         patch("mailpilot.database.get_workflow", return_value=workflow),
         patch("mailpilot.database.get_contact", return_value=contact),
-        patch("mailpilot.agent.invoke_workflow_agent") as mock_invoke,
+        patch(
+            "mailpilot.agent.invoke_workflow_agent", return_value=invoke_result
+        ) as mock_invoke,
     ):
         result = runner.invoke(
             main,
@@ -1943,6 +1951,77 @@ def test_workflow_run_contact_not_found(
     assert result.exit_code == 1
     data = json.loads(result.output)
     assert data["error"] == "not_found"
+
+
+def test_workflow_run_agent_no_tools(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    from mailpilot.exceptions import AgentDidNotUseToolsError
+
+    workflow = _make_workflow(status="active")
+    contact = Contact(
+        id=_CONTACT_ID,
+        email="lead@acme.com",
+        domain="acme.com",
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_workflow", return_value=workflow),
+        patch("mailpilot.database.get_contact", return_value=contact),
+        patch(
+            "mailpilot.agent.invoke_workflow_agent",
+            side_effect=AgentDidNotUseToolsError("no tools"),
+        ),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "workflow",
+                "run",
+                "--workflow-id",
+                _WORKFLOW_ID,
+                "--contact-id",
+                _CONTACT_ID,
+            ],
+        )
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "agent_no_tools"
+
+
+def test_workflow_run_lock_held(runner: CliRunner, mock_connection: MagicMock) -> None:
+    workflow = _make_workflow(status="active")
+    contact = Contact(
+        id=_CONTACT_ID,
+        email="lead@acme.com",
+        domain="acme.com",
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_workflow", return_value=workflow),
+        patch("mailpilot.database.get_contact", return_value=contact),
+        patch("mailpilot.agent.invoke_workflow_agent", return_value=None),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "workflow",
+                "run",
+                "--workflow-id",
+                _WORKFLOW_ID,
+                "--contact-id",
+                _CONTACT_ID,
+            ],
+        )
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "lock_held"
 
 
 # -- Activity ------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,7 @@ from mailpilot.models import (
     Note,
     Tag,
     Workflow,
+    WorkflowContact,
 )
 
 _NOW = datetime(2024, 1, 1, tzinfo=UTC)
@@ -1802,6 +1803,12 @@ def test_workflow_run(runner: CliRunner, mock_connection: MagicMock) -> None:
         created_at=_NOW,
         updated_at=_NOW,
     )
+    wc = WorkflowContact(
+        workflow_id=_WORKFLOW_ID,
+        contact_id=_CONTACT_ID,
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
     invoke_result = {
         "workflow_id": _WORKFLOW_ID,
         "contact_id": _CONTACT_ID,
@@ -1813,6 +1820,7 @@ def test_workflow_run(runner: CliRunner, mock_connection: MagicMock) -> None:
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
         patch("mailpilot.database.get_workflow", return_value=workflow),
         patch("mailpilot.database.get_contact", return_value=contact),
+        patch("mailpilot.database.get_workflow_contact", return_value=wc),
         patch(
             "mailpilot.agent.invoke_workflow_agent", return_value=invoke_result
         ) as mock_invoke,
@@ -1953,11 +1961,9 @@ def test_workflow_run_contact_not_found(
     assert data["error"] == "not_found"
 
 
-def test_workflow_run_agent_no_tools(
+def test_workflow_run_contact_not_enrolled(
     runner: CliRunner, mock_connection: MagicMock
 ) -> None:
-    from mailpilot.exceptions import AgentDidNotUseToolsError
-
     workflow = _make_workflow(status="active")
     contact = Contact(
         id=_CONTACT_ID,
@@ -1971,6 +1977,50 @@ def test_workflow_run_agent_no_tools(
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
         patch("mailpilot.database.get_workflow", return_value=workflow),
         patch("mailpilot.database.get_contact", return_value=contact),
+        patch("mailpilot.database.get_workflow_contact", return_value=None),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "workflow",
+                "run",
+                "--workflow-id",
+                _WORKFLOW_ID,
+                "--contact-id",
+                _CONTACT_ID,
+            ],
+        )
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "not enrolled" in data["message"]
+
+
+def test_workflow_run_agent_no_tools(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    from mailpilot.exceptions import AgentDidNotUseToolsError
+
+    workflow = _make_workflow(status="active")
+    contact = Contact(
+        id=_CONTACT_ID,
+        email="lead@acme.com",
+        domain="acme.com",
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    wc = WorkflowContact(
+        workflow_id=_WORKFLOW_ID,
+        contact_id=_CONTACT_ID,
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_workflow", return_value=workflow),
+        patch("mailpilot.database.get_contact", return_value=contact),
+        patch("mailpilot.database.get_workflow_contact", return_value=wc),
         patch(
             "mailpilot.agent.invoke_workflow_agent",
             side_effect=AgentDidNotUseToolsError("no tools"),
@@ -2001,11 +2051,18 @@ def test_workflow_run_lock_held(runner: CliRunner, mock_connection: MagicMock) -
         created_at=_NOW,
         updated_at=_NOW,
     )
+    wc = WorkflowContact(
+        workflow_id=_WORKFLOW_ID,
+        contact_id=_CONTACT_ID,
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
         patch("mailpilot.database.get_workflow", return_value=workflow),
         patch("mailpilot.database.get_contact", return_value=contact),
+        patch("mailpilot.database.get_workflow_contact", return_value=wc),
         patch("mailpilot.agent.invoke_workflow_agent", return_value=None),
     ):
         result = runner.invoke(


### PR DESCRIPTION
## Summary

Implement the agent invocation module that builds and runs a Pydantic AI agent for a given workflow + contact pair. This is the central execution unit -- both inbound routing and outbound campaigns culminate in an agent invocation.

- `invoke_workflow_agent()` with PostgreSQL advisory locking, email history loading, and Pydantic AI agent construction
- Tool-use enforcement: post-run check that at least one tool was called, with `noop(reason)` as explicit "do nothing" escape hatch
- `AgentDidNotUseToolsError` for runs with zero tool calls
- Outbound 30-day cooldown check before invocation
- CLI `workflow run` wired to agent invocation with full input validation (workflow active, type=outbound, contact exists, contact enrolled in workflow)
- Two-argument PostgreSQL advisory lock on (workflow_id, contact_id) for 64-bit collision space

## Changes

- `src/mailpilot/agent/invoke.py` -- new module: agent construction, advisory locking, prompt assembly, tool-use enforcement
- `src/mailpilot/agent/__init__.py` -- re-export wrapper with deferred import to avoid circular deps
- `src/mailpilot/agent/tools.py` -- add `noop(reason)` tool
- `src/mailpilot/exceptions.py` -- add `AgentDidNotUseToolsError`
- `src/mailpilot/cli.py` -- wire `workflow run` command with enrollment validation
- `tests/test_agent_invoke.py` -- 9 tests: tool-use enforcement (noop, real tool, no tools), advisory lock contention, email history context, inbound/task/outbound triggers, account-not-found, missing API key
- `tests/test_cli.py` -- 8 tests: happy path, not-found, requires-active, requires-outbound, contact-not-found, contact-not-enrolled, agent-no-tools, lock-held

Resolves #12