### PR TITLE
feat(cli): add unified list filters across email, workflow, contact, and note commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ mailpilot company import FILE
 mailpilot contact create --email E [--first-name F] [--last-name L] [opts]
 mailpilot contact update ID [--email E] [--first-name F] [--last-name L] [opts]
 mailpilot contact search QUERY [--limit N]
-mailpilot contact list [--limit N] [--domain D] [--company-id ID]
+mailpilot contact list [--limit N] [--domain D] [--company-id ID] [--status active|bounced|unsubscribed]
 mailpilot contact view ID
 mailpilot contact export FILE
 mailpilot contact import FILE
@@ -82,14 +82,14 @@ mailpilot contact import FILE
 mailpilot workflow create --name N --type inbound|outbound --account-id ID [--objective O] [--instructions-file F]
 mailpilot workflow update ID [--name N] [--objective O] [--instructions-file F]
 mailpilot workflow search QUERY [--limit N]
-mailpilot workflow list [--account-id ID]
+mailpilot workflow list [--account-id ID] [--status draft|active|paused] [--type inbound|outbound]
 mailpilot workflow view ID
 mailpilot workflow activate ID
 mailpilot workflow pause ID
 mailpilot workflow run --workflow-id ID --contact-id ID
 
 mailpilot email search QUERY [--limit N]
-mailpilot email list [--limit N] [--contact-id ID] [--account-id ID]
+mailpilot email list [--limit N] [--contact-id ID] [--account-id ID] [--since ISO] [--thread-id TEXT] [--direction inbound|outbound] [--workflow-id ID] [--status sent|received|bounced]
 mailpilot email view ID
 mailpilot email send --account-id ID --to E --subject S --body B [--contact-id ID] [--workflow-id ID] [--thread-id ID]
 
@@ -108,8 +108,8 @@ mailpilot tag search NAME [--type contact|company] [--limit N]
 mailpilot note add --contact-id ID --body TEXT
 mailpilot note add --company-id ID --body TEXT
 mailpilot note view ID
-mailpilot note list --contact-id ID [--limit N]
-mailpilot note list --company-id ID [--limit N]
+mailpilot note list --contact-id ID [--limit N] [--since ISO]
+mailpilot note list --company-id ID [--limit N] [--since ISO]
 
 mailpilot run
 

--- a/docs/superpowers/specs/2026-04-21-workflow-contact-cli-design.md
+++ b/docs/superpowers/specs/2026-04-21-workflow-contact-cli-design.md
@@ -1,0 +1,262 @@
+# Workflow Contact CLI
+
+## Context
+
+The `workflow_contact` junction table exists with full CRUD in the database layer (`create_workflow_contact`, `get_workflow_contact`, `list_workflow_contacts`, `update_workflow_contact`), but has zero CLI exposure. The only command that touches `workflow_contact` is `workflow run`, which requires enrollment to already exist. To enroll a contact, the operator had to drop to raw SQL.
+
+This blocks the primary use case: Claude Code orchestrating outbound campaigns (cold-emailing 10-50 contacts) and reviewing inbound workflow outcomes -- entirely through the CLI.
+
+## CLI Commands
+
+Four new commands under a `workflow contact` subgroup:
+
+```
+mailpilot workflow contact add    --workflow-id ID --contact-id ID
+mailpilot workflow contact remove --workflow-id ID --contact-id ID
+mailpilot workflow contact list   --workflow-id ID [--status pending|active|completed|failed] [--limit N]
+mailpilot workflow contact update --workflow-id ID --contact-id ID --status S [--reason R]
+```
+
+### `workflow contact add`
+
+Enroll a contact in a workflow. Works for both inbound and outbound workflows.
+
+**Validation:**
+
+1. `--workflow-id` and `--contact-id` are required.
+2. Workflow must exist (`get_workflow`). Error: `not_found`.
+3. Contact must exist (`get_contact`). Error: `not_found`.
+
+**Behavior:** Calls `create_workflow_contact(conn, workflow_id, contact_id)`. Default status is `pending`. Idempotent -- if enrollment already exists (`create_workflow_contact` returns `None`), fetch and return the existing row via `get_workflow_contact`. No error on duplicate.
+
+**Output:**
+
+```json
+{
+  "workflow_id": "...",
+  "contact_id": "...",
+  "status": "pending",
+  "reason": "",
+  "created_at": "...",
+  "updated_at": "...",
+  "ok": true
+}
+```
+
+### `workflow contact remove`
+
+Remove a contact from a workflow.
+
+**Validation:**
+
+1. `--workflow-id` and `--contact-id` are required.
+2. Enrollment must exist. Error: `not_found` with message "workflow-contact not found".
+
+**Behavior:** Calls new `delete_workflow_contact(conn, workflow_id, contact_id)`.
+
+**Output:**
+
+```json
+{
+  "workflow_id": "...",
+  "contact_id": "...",
+  "ok": true
+}
+```
+
+### `workflow contact list`
+
+List contacts enrolled in a workflow with enriched contact info.
+
+**Options:**
+
+- `--workflow-id ID` (required)
+- `--status pending|active|completed|failed` (optional filter)
+- `--limit N` (default: 100)
+
+**Validation:**
+
+1. Workflow must exist (`get_workflow`). Error: `not_found`.
+
+**Behavior:** Calls modified `list_workflow_contacts` that JOINs the `contact` table to include `contact_email` and `contact_name`.
+
+**Output:**
+
+```json
+{
+  "contacts": [
+    {
+      "workflow_id": "...",
+      "contact_id": "...",
+      "contact_email": "alice@co.com",
+      "contact_name": "Alice Smith",
+      "status": "pending",
+      "reason": "",
+      "created_at": "...",
+      "updated_at": "..."
+    }
+  ],
+  "ok": true
+}
+```
+
+### `workflow contact update`
+
+Update enrollment status and reason.
+
+**Options:**
+
+- `--workflow-id ID` (required)
+- `--contact-id ID` (required)
+- `--status pending|active|completed|failed` (required)
+- `--reason TEXT` (optional)
+
+**Validation:**
+
+1. `--status` is required (nothing to update without it).
+2. Enrollment must exist (`update_workflow_contact` returns `None`). Error: `not_found`.
+
+**Behavior:** Calls `update_workflow_contact(conn, workflow_id, contact_id, status=status, reason=reason)`. Only passes `reason` if provided.
+
+**Output:**
+
+```json
+{
+  "workflow_id": "...",
+  "contact_id": "...",
+  "status": "completed",
+  "reason": "Demo booked",
+  "created_at": "...",
+  "updated_at": "...",
+  "ok": true
+}
+```
+
+## Database Layer
+
+### Existing functions (no changes)
+
+- `create_workflow_contact(conn, workflow_id, contact_id) -> WorkflowContact | None`
+- `get_workflow_contact(conn, workflow_id, contact_id) -> WorkflowContact | None`
+- `update_workflow_contact(conn, workflow_id, contact_id, **fields) -> WorkflowContact | None`
+
+### New function (enriched list)
+
+`list_workflow_contacts_enriched(conn, workflow_id, status=None, limit=100) -> list[WorkflowContactDetail]`
+
+Separate function from `list_workflow_contacts` because the original is used by the agent tools layer and must keep returning `list[WorkflowContact]`. The CLI uses this enriched variant.
+
+```sql
+SELECT wc.*, c.email AS contact_email,
+       TRIM(COALESCE(c.first_name, '') || ' ' || COALESCE(c.last_name, '')) AS contact_name
+FROM workflow_contact wc
+JOIN contact c ON c.id = wc.contact_id
+WHERE wc.workflow_id = %(workflow_id)s
+  [AND wc.status = %(status)s]
+ORDER BY wc.created_at
+LIMIT %(limit)s
+```
+
+The existing `list_workflow_contacts` is unchanged (agent tools keep using it).
+
+### New function
+
+`delete_workflow_contact(conn, workflow_id, contact_id) -> bool`
+
+```sql
+DELETE FROM workflow_contact
+WHERE workflow_id = %(workflow_id)s AND contact_id = %(contact_id)s
+RETURNING workflow_id
+```
+
+Returns `True` if a row was deleted, `False` if not found. Commits on success.
+
+## Model
+
+New model in `models.py`:
+
+```python
+class WorkflowContactDetail(BaseModel):
+    """Enriched workflow-contact with contact info for list display."""
+
+    workflow_id: str
+    contact_id: str
+    contact_email: str
+    contact_name: str
+    status: ContactOutcome
+    reason: str
+    created_at: datetime
+    updated_at: datetime
+```
+
+## CLAUDE.md Update
+
+Add to CLI reference under the workflow section:
+
+```
+mailpilot workflow contact add --workflow-id ID --contact-id ID
+mailpilot workflow contact remove --workflow-id ID --contact-id ID
+mailpilot workflow contact list --workflow-id ID [--status pending|active|completed|failed] [--limit N]
+mailpilot workflow contact update --workflow-id ID --contact-id ID --status S [--reason R]
+```
+
+## End-to-End Scenarios
+
+### Outbound cold email (10-50 contacts)
+
+```bash
+# 1. Create and configure workflow
+mailpilot workflow create --name "Q2 Outreach" --type outbound \
+  --account-id $ACCT --objective "Book demo" --instructions-file campaign.md
+mailpilot workflow activate $WF
+
+# 2. Enroll contacts (Claude Code loops)
+mailpilot workflow contact add --workflow-id $WF --contact-id $C1
+mailpilot workflow contact add --workflow-id $WF --contact-id $C2
+
+# 3. Verify enrollment
+mailpilot workflow contact list --workflow-id $WF --status pending
+
+# 4. Run per contact (Claude Code loops)
+mailpilot workflow run --workflow-id $WF --contact-id $C1
+mailpilot workflow run --workflow-id $WF --contact-id $C2
+
+# 5. Review outcomes
+mailpilot workflow contact list --workflow-id $WF --status completed
+mailpilot workflow contact list --workflow-id $WF --status failed
+```
+
+### Inbound auto-reply (demo@lab5.ca scenario)
+
+```bash
+# 1. Create account and inbound workflow
+mailpilot account create --email demo@lab5.ca --display-name "Demo"
+mailpilot workflow create --name "Product Q&A" --type inbound \
+  --account-id $ACCT --objective "Answer product questions" \
+  --instructions-file demo-agent.md
+mailpilot workflow activate $WF
+
+# 2. Optionally pre-seed key accounts
+mailpilot workflow contact add --workflow-id $WF --contact-id $KEY_ACCT
+
+# 3. Start watching for emails (routing auto-enrolls unknown senders)
+mailpilot run
+
+# 4. Review who has been served
+mailpilot workflow contact list --workflow-id $WF
+mailpilot workflow contact list --workflow-id $WF --status completed
+```
+
+## Verification
+
+1. `make check` -- all lint, types, and tests pass.
+2. Manual test against default database:
+   - `mailpilot workflow contact add --workflow-id $WF --contact-id $C` -- enrolls contact.
+   - `mailpilot workflow contact add --workflow-id $WF --contact-id $C` -- idempotent, returns same row.
+   - `mailpilot workflow contact list --workflow-id $WF` -- shows enriched output with email/name.
+   - `mailpilot workflow contact list --workflow-id $WF --status pending` -- filters by status.
+   - `mailpilot workflow contact update --workflow-id $WF --contact-id $C --status completed --reason "Demo booked"` -- updates status.
+   - `mailpilot workflow contact remove --workflow-id $WF --contact-id $C` -- removes enrollment.
+   - `mailpilot workflow contact remove --workflow-id $WF --contact-id $C` -- returns not_found.
+3. `mailpilot workflow contact list --workflow-id BOGUS` -- returns not_found error.
+4. `mailpilot workflow contact add --workflow-id $WF --contact-id BOGUS` -- returns not_found error.

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -567,7 +567,15 @@ def contact_search(query: str, limit: int) -> None:
 @click.option("--limit", default=100, help="Maximum results.")
 @click.option("--domain", default=None, help="Filter by domain.")
 @click.option("--company-id", default=None, help="Filter by company ID.")
-def contact_list(limit: int, domain: str | None, company_id: str | None) -> None:
+@click.option(
+    "--status",
+    default=None,
+    type=click.Choice(["active", "bounced", "unsubscribed"]),
+    help="Filter by contact status.",
+)
+def contact_list(
+    limit: int, domain: str | None, company_id: str | None, status: str | None
+) -> None:
     """List contacts."""
     from mailpilot.database import get_company, initialize_database, list_contacts
 
@@ -576,7 +584,7 @@ def contact_list(limit: int, domain: str | None, company_id: str | None) -> None
         if company_id is not None and get_company(connection, company_id) is None:
             output_error(f"company not found: {company_id}", "not_found")
         contacts = list_contacts(
-            connection, limit=limit, domain=domain, company_id=company_id
+            connection, limit=limit, domain=domain, company_id=company_id, status=status
         )
         output({"contacts": [c.model_dump(mode="json") for c in contacts]})
     finally:
@@ -673,11 +681,36 @@ def email_search(query: str, limit: int) -> None:
 @click.option("--limit", default=100, help="Maximum number of results.")
 @click.option("--contact-id", default=None, help="Filter by contact ID.")
 @click.option("--account-id", default=None, help="Filter by account ID.")
-def email_list(limit: int, contact_id: str | None, account_id: str | None) -> None:
+@click.option("--since", default=None, help="ISO datetime lower bound.")
+@click.option("--thread-id", default=None, help="Filter by Gmail thread ID.")
+@click.option(
+    "--direction",
+    default=None,
+    type=click.Choice(["inbound", "outbound"]),
+    help="Filter by direction.",
+)
+@click.option("--workflow-id", default=None, help="Filter by workflow ID.")
+@click.option(
+    "--status",
+    default=None,
+    type=click.Choice(["sent", "received", "bounced"]),
+    help="Filter by email status.",
+)
+def email_list(
+    limit: int,
+    contact_id: str | None,
+    account_id: str | None,
+    since: str | None,
+    thread_id: str | None,
+    direction: str | None,
+    workflow_id: str | None,
+    status: str | None,
+) -> None:
     """List emails with optional filters."""
     from mailpilot.database import (
         get_account,
         get_contact,
+        get_workflow,
         initialize_database,
         list_emails,
     )
@@ -688,8 +721,18 @@ def email_list(limit: int, contact_id: str | None, account_id: str | None) -> No
             output_error(f"contact not found: {contact_id}", "not_found")
         if account_id is not None and get_account(connection, account_id) is None:
             output_error(f"account not found: {account_id}", "not_found")
+        if workflow_id is not None and get_workflow(connection, workflow_id) is None:
+            output_error(f"workflow not found: {workflow_id}", "not_found")
         emails = list_emails(
-            connection, limit=limit, contact_id=contact_id, account_id=account_id
+            connection,
+            limit=limit,
+            contact_id=contact_id,
+            account_id=account_id,
+            since=since,
+            thread_id=thread_id,
+            direction=direction,
+            workflow_id=workflow_id,
+            status=status,
         )
         output({"emails": [e.model_dump(mode="json") for e in emails]})
     finally:
@@ -1120,7 +1163,10 @@ def note_add(contact_id: str | None, company_id: str | None, body: str) -> None:
 @click.option("--contact-id", default=None, help="Contact ID.")
 @click.option("--company-id", default=None, help="Company ID.")
 @click.option("--limit", default=100, help="Maximum results.")
-def note_list(contact_id: str | None, company_id: str | None, limit: int) -> None:
+@click.option("--since", default=None, help="ISO datetime lower bound.")
+def note_list(
+    contact_id: str | None, company_id: str | None, limit: int, since: str | None
+) -> None:
     """List notes on a contact or company."""
     from mailpilot.database import (
         get_company,
@@ -1138,7 +1184,11 @@ def note_list(contact_id: str | None, company_id: str | None, limit: int) -> Non
         elif get_company(connection, entity_id) is None:
             output_error(f"company {entity_id} not found", "not_found")
         notes = list_notes(
-            connection, entity_type=entity_type, entity_id=entity_id, limit=limit
+            connection,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            limit=limit,
+            since=since,
         )
         output({"notes": [n.model_dump(mode="json") for n in notes]})
     finally:
@@ -1284,7 +1334,22 @@ def workflow_search(query: str, limit: int) -> None:
 
 @workflow.command("list")
 @click.option("--account-id", default=None, help="Filter by account ID.")
-def workflow_list(account_id: str | None) -> None:
+@click.option(
+    "--status",
+    default=None,
+    type=click.Choice(["draft", "active", "paused"]),
+    help="Filter by workflow status.",
+)
+@click.option(
+    "--type",
+    "workflow_type",
+    default=None,
+    type=click.Choice(["inbound", "outbound"]),
+    help="Filter by workflow type.",
+)
+def workflow_list(
+    account_id: str | None, status: str | None, workflow_type: str | None
+) -> None:
     """List workflows."""
     from mailpilot.database import get_account, initialize_database, list_workflows
 
@@ -1292,7 +1357,12 @@ def workflow_list(account_id: str | None) -> None:
     try:
         if account_id is not None and get_account(connection, account_id) is None:
             output_error(f"account not found: {account_id}", "not_found")
-        workflows = list_workflows(connection, account_id=account_id)
+        workflows = list_workflows(
+            connection,
+            account_id=account_id,
+            status=status,
+            workflow_type=workflow_type,
+        )
         output({"workflows": [w.model_dump(mode="json") for w in workflows]})
     finally:
         connection.close()

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -2181,25 +2181,23 @@ def list_notes(
         limit=limit,
         since=since,
     ) as span:
+        conditions: list[SQL] = [
+            SQL("entity_type = %(entity_type)s"),
+            SQL("entity_id = %(entity_id)s"),
+        ]
         params: dict[str, object] = {
             "entity_type": entity_type,
             "entity_id": entity_id,
             "limit": limit,
         }
-        since_clause = ""
         if since is not None:
-            since_clause = "AND created_at >= %(since)s"
+            conditions.append(SQL("created_at >= %(since)s"))
             params["since"] = since
-        rows = connection.execute(
-            f"""\
-            SELECT * FROM note
-            WHERE entity_type = %(entity_type)s AND entity_id = %(entity_id)s
-            {since_clause}
-            ORDER BY created_at DESC
-            LIMIT %(limit)s
-            """,
-            params,
-        ).fetchall()
+        where = SQL("WHERE ") + SQL(" AND ").join(conditions)
+        query = SQL(
+            "SELECT * FROM note {} ORDER BY created_at DESC LIMIT %(limit)s"
+        ).format(where)
+        rows = connection.execute(query, params).fetchall()
         notes = [Note.model_validate(row) for row in rows]
         span.set_attribute("note_count", len(notes))
         return notes

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -669,6 +669,7 @@ def list_contacts(
     limit: int = 100,
     domain: str | None = None,
     company_id: str | None = None,
+    status: str | None = None,
 ) -> list[Contact]:
     """List contacts with optional filters.
 
@@ -677,6 +678,7 @@ def list_contacts(
         limit: Maximum number of contacts to return.
         domain: Filter by domain.
         company_id: Filter by company ID.
+        status: Filter by contact status ("active", "bounced", "unsubscribed").
 
     Returns:
         List of contacts ordered by email.
@@ -686,6 +688,7 @@ def list_contacts(
         limit=limit,
         domain=domain,
         company_id=company_id,
+        status=status,
     ) as span:
         conditions: list[SQL] = []
         params: dict[str, object] = {"limit": limit}
@@ -695,6 +698,9 @@ def list_contacts(
         if company_id is not None:
             conditions.append(SQL("company_id = %(company_id)s"))
             params["company_id"] = company_id
+        if status is not None:
+            conditions.append(SQL("status = %(status)s"))
+            params["status"] = status
         where = SQL("WHERE ") + SQL(" AND ").join(conditions) if conditions else SQL("")
         query = SQL("SELECT * FROM contact {} ORDER BY email LIMIT %(limit)s").format(
             where
@@ -890,13 +896,15 @@ def list_workflows(
     connection: psycopg.Connection[dict[str, Any]],
     account_id: str | None = None,
     status: str | None = None,
+    workflow_type: str | None = None,
 ) -> list[Workflow]:
-    """List workflows with optional account and status filters.
+    """List workflows with optional account, status, and type filters.
 
     Args:
         connection: Open database connection.
         account_id: Filter by account ID.
         status: Filter by workflow status (e.g., "active").
+        workflow_type: Filter by workflow type ("inbound" or "outbound").
 
     Returns:
         List of workflows ordered by creation time.
@@ -905,6 +913,7 @@ def list_workflows(
         "db.workflow.list",
         account_id=account_id,
         status=status,
+        workflow_type=workflow_type,
     ) as span:
         conditions: list[SQL] = []
         params: dict[str, object] = {}
@@ -914,6 +923,9 @@ def list_workflows(
         if status is not None:
             conditions.append(SQL("status = %(status)s"))
             params["status"] = status
+        if workflow_type is not None:
+            conditions.append(SQL("type = %(workflow_type)s"))
+            params["workflow_type"] = workflow_type
         where = SQL("WHERE ") + SQL(" AND ").join(conditions) if conditions else SQL("")
         query = SQL("SELECT * FROM workflow {} ORDER BY created_at").format(where)
         rows = connection.execute(query, params).fetchall()
@@ -1355,6 +1367,11 @@ def list_emails(
     limit: int = 100,
     contact_id: str | None = None,
     account_id: str | None = None,
+    since: str | None = None,
+    thread_id: str | None = None,
+    direction: str | None = None,
+    workflow_id: str | None = None,
+    status: str | None = None,
 ) -> list[Email]:
     """List emails with optional filters.
 
@@ -1363,6 +1380,11 @@ def list_emails(
         limit: Maximum number of emails to return.
         contact_id: Filter by contact ID.
         account_id: Filter by account ID.
+        since: ISO datetime lower bound for COALESCE(sent_at, received_at).
+        thread_id: Filter by Gmail thread ID.
+        direction: Filter by direction ("inbound" or "outbound").
+        workflow_id: Filter by workflow ID.
+        status: Filter by email status ("sent", "received", "bounced").
 
     Returns:
         List of emails ordered by creation time descending.
@@ -1372,6 +1394,11 @@ def list_emails(
         limit=limit,
         contact_id=contact_id,
         account_id=account_id,
+        since=since,
+        thread_id=thread_id,
+        direction=direction,
+        workflow_id=workflow_id,
+        status=status,
     ) as span:
         conditions: list[SQL] = []
         params: dict[str, object] = {"limit": limit}
@@ -1381,6 +1408,21 @@ def list_emails(
         if account_id is not None:
             conditions.append(SQL("account_id = %(account_id)s"))
             params["account_id"] = account_id
+        if since is not None:
+            conditions.append(SQL("COALESCE(sent_at, received_at) >= %(since)s"))
+            params["since"] = since
+        if thread_id is not None:
+            conditions.append(SQL("gmail_thread_id = %(thread_id)s"))
+            params["thread_id"] = thread_id
+        if direction is not None:
+            conditions.append(SQL("direction = %(direction)s"))
+            params["direction"] = direction
+        if workflow_id is not None:
+            conditions.append(SQL("workflow_id = %(workflow_id)s"))
+            params["workflow_id"] = workflow_id
+        if status is not None:
+            conditions.append(SQL("status = %(status)s"))
+            params["status"] = status
         where = SQL("WHERE ") + SQL(" AND ").join(conditions) if conditions else SQL("")
         query = SQL(
             "SELECT * FROM email {} ORDER BY created_at DESC LIMIT %(limit)s"
@@ -2118,6 +2160,7 @@ def list_notes(
     entity_type: str,
     entity_id: str,
     limit: int = 100,
+    since: str | None = None,
 ) -> list[Note]:
     """List notes on a contact or company.
 
@@ -2126,6 +2169,7 @@ def list_notes(
         entity_type: "contact" or "company".
         entity_id: ID of the annotated entity.
         limit: Maximum number of notes to return.
+        since: ISO datetime lower bound for created_at.
 
     Returns:
         Notes ordered by created_at descending.
@@ -2135,15 +2179,26 @@ def list_notes(
         entity_type=entity_type,
         entity_id=entity_id,
         limit=limit,
+        since=since,
     ) as span:
+        params: dict[str, object] = {
+            "entity_type": entity_type,
+            "entity_id": entity_id,
+            "limit": limit,
+        }
+        since_clause = ""
+        if since is not None:
+            since_clause = "AND created_at >= %(since)s"
+            params["since"] = since
         rows = connection.execute(
-            """\
+            f"""\
             SELECT * FROM note
             WHERE entity_type = %(entity_type)s AND entity_id = %(entity_id)s
+            {since_clause}
             ORDER BY created_at DESC
             LIMIT %(limit)s
             """,
-            {"entity_type": entity_type, "entity_id": entity_id, "limit": limit},
+            params,
         ).fetchall()
         notes = [Note.model_validate(row) for row in rows]
         span.set_attribute("note_count", len(notes))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -914,7 +914,23 @@ def test_contact_list_with_filters(
 
     assert result.exit_code == 0
     mock_list.assert_called_once_with(
-        mock_connection, limit=5, domain="example.com", company_id="cid-1"
+        mock_connection, limit=5, domain="example.com", company_id="cid-1", status=None
+    )
+
+
+def test_contact_list_with_status(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_contacts", return_value=[]) as mock_list,
+    ):
+        result = runner.invoke(main, ["contact", "list", "--status", "bounced"])
+
+    assert result.exit_code == 0
+    mock_list.assert_called_once_with(
+        mock_connection, limit=100, domain=None, company_id=None, status="bounced"
     )
 
 
@@ -1093,7 +1109,15 @@ def test_email_list(runner: CliRunner, mock_connection: MagicMock) -> None:
     assert data["ok"] is True
     assert len(data["emails"]) == 1
     mock_list.assert_called_once_with(
-        mock_connection, limit=100, contact_id=None, account_id=None
+        mock_connection,
+        limit=100,
+        contact_id=None,
+        account_id=None,
+        since=None,
+        thread_id=None,
+        direction=None,
+        workflow_id=None,
+        status=None,
     )
 
 
@@ -1134,8 +1158,73 @@ def test_email_list_with_filters(runner: CliRunner, mock_connection: MagicMock) 
         )
     assert result.exit_code == 0
     mock_list.assert_called_once_with(
-        mock_connection, limit=5, contact_id="cid", account_id="aid"
+        mock_connection,
+        limit=5,
+        contact_id="cid",
+        account_id="aid",
+        since=None,
+        thread_id=None,
+        direction=None,
+        workflow_id=None,
+        status=None,
     )
+
+
+def test_email_list_with_new_filters(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    workflow = _make_workflow()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_workflow", return_value=workflow),
+        patch("mailpilot.database.list_emails", return_value=[]) as mock_list,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "email",
+                "list",
+                "--since",
+                "2024-01-01T00:00:00Z",
+                "--thread-id",
+                "thread_abc",
+                "--direction",
+                "inbound",
+                "--workflow-id",
+                _WORKFLOW_ID,
+                "--status",
+                "received",
+            ],
+        )
+    assert result.exit_code == 0
+    mock_list.assert_called_once_with(
+        mock_connection,
+        limit=100,
+        contact_id=None,
+        account_id=None,
+        since="2024-01-01T00:00:00Z",
+        thread_id="thread_abc",
+        direction="inbound",
+        workflow_id=_WORKFLOW_ID,
+        status="received",
+    )
+
+
+def test_email_list_workflow_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_workflow", return_value=None),
+    ):
+        result = runner.invoke(main, ["email", "list", "--workflow-id", "wf-missing"])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "not_found"
+    assert "workflow" in data["message"]
 
 
 def test_email_view(runner: CliRunner, mock_connection: MagicMock) -> None:
@@ -1629,7 +1718,9 @@ def test_workflow_list(runner: CliRunner, mock_connection: MagicMock) -> None:
         result = runner.invoke(main, ["workflow", "list"])
 
     assert result.exit_code == 0
-    mock_list.assert_called_once_with(mock_connection, account_id=None)
+    mock_list.assert_called_once_with(
+        mock_connection, account_id=None, status=None, workflow_type=None
+    )
     data = json.loads(result.output)
     assert len(data["workflows"]) == 2
 
@@ -1647,7 +1738,9 @@ def test_workflow_list_by_account(
         result = runner.invoke(main, ["workflow", "list", "--account-id", _ACCOUNT_ID])
 
     assert result.exit_code == 0
-    mock_list.assert_called_once_with(mock_connection, account_id=_ACCOUNT_ID)
+    mock_list.assert_called_once_with(
+        mock_connection, account_id=_ACCOUNT_ID, status=None, workflow_type=None
+    )
 
 
 def test_workflow_list_account_not_found(
@@ -1666,6 +1759,25 @@ def test_workflow_list_account_not_found(
     data = json.loads(result.output)
     assert data["error"] == "not_found"
     assert "account" in data["message"]
+
+
+def test_workflow_list_with_filters(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_workflows", return_value=[]) as mock_list,
+    ):
+        result = runner.invoke(
+            main,
+            ["workflow", "list", "--status", "active", "--type", "outbound"],
+        )
+
+    assert result.exit_code == 0
+    mock_list.assert_called_once_with(
+        mock_connection, account_id=None, status="active", workflow_type="outbound"
+    )
 
 
 def test_workflow_view(runner: CliRunner, mock_connection: MagicMock) -> None:
@@ -2974,7 +3086,37 @@ def test_note_list_with_limit(runner: CliRunner, mock_connection: MagicMock) -> 
 
     assert result.exit_code == 0
     mock_list.assert_called_once_with(
-        mock_connection, entity_type="contact", entity_id="cid-1", limit=5
+        mock_connection, entity_type="contact", entity_id="cid-1", limit=5, since=None
+    )
+
+
+def test_note_list_with_since(runner: CliRunner, mock_connection: MagicMock) -> None:
+    contact = _make_contact()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=contact),
+        patch("mailpilot.database.list_notes", return_value=[]) as mock_list,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "note",
+                "list",
+                "--contact-id",
+                "cid-1",
+                "--since",
+                "2024-01-01T00:00:00Z",
+            ],
+        )
+
+    assert result.exit_code == 0
+    mock_list.assert_called_once_with(
+        mock_connection,
+        entity_type="contact",
+        entity_id="cid-1",
+        limit=100,
+        since="2024-01-01T00:00:00Z",
     )
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -176,6 +176,22 @@ def test_list_contacts_by_domain(
     assert results[0].domain == "foo.com"
 
 
+def test_list_contacts_by_status(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    c1 = make_test_contact(database_connection, email="a@foo.com", domain="foo.com")
+    c2 = make_test_contact(database_connection, email="b@bar.com", domain="bar.com")
+    from mailpilot.database import update_contact
+
+    update_contact(database_connection, c2.id, status="bounced")
+    active = list_contacts(database_connection, status="active")
+    assert len(active) == 1
+    assert active[0].id == c1.id
+    bounced = list_contacts(database_connection, status="bounced")
+    assert len(bounced) == 1
+    assert bounced[0].id == c2.id
+
+
 def test_search_contacts(database_connection: psycopg.Connection[dict[str, Any]]):
     make_test_contact(database_connection, email="alice@test.com", domain="test.com")
     make_test_contact(database_connection, email="bob@test.com", domain="test.com")
@@ -546,6 +562,30 @@ def test_list_workflows_by_status(
     assert len(all_workflows) == 2
 
 
+def test_list_workflows_by_type(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    make_test_workflow(
+        database_connection,
+        account_id=account.id,
+        name="Outreach",
+        workflow_type="outbound",
+    )
+    make_test_workflow(
+        database_connection,
+        account_id=account.id,
+        name="Auto-reply",
+        workflow_type="inbound",
+    )
+    outbound = list_workflows(database_connection, workflow_type="outbound")
+    assert len(outbound) == 1
+    assert outbound[0].name == "Outreach"
+    inbound = list_workflows(database_connection, workflow_type="inbound")
+    assert len(inbound) == 1
+    assert inbound[0].name == "Auto-reply"
+
+
 def test_search_workflows_by_name(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
@@ -801,6 +841,136 @@ def test_create_email_concurrent_same_gmail_message_id_is_safe(
     ).fetchone()
     assert row is not None
     assert row["n"] == 1
+
+
+def test_list_emails_since(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    from datetime import datetime, timedelta
+
+    account = make_test_account(database_connection)
+    old = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Old",
+        gmail_message_id="msg_old",
+        received_at=datetime.now(UTC) - timedelta(days=3),
+    )
+    assert old is not None
+    recent = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Recent",
+        gmail_message_id="msg_recent",
+        received_at=datetime.now(UTC),
+    )
+    assert recent is not None
+    since = (datetime.now(UTC) - timedelta(days=1)).isoformat()
+    results = list_emails(database_connection, since=since)
+    assert len(results) == 1
+    assert results[0].subject == "Recent"
+
+
+def test_list_emails_by_thread_id(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        gmail_message_id="msg_t1",
+        gmail_thread_id="thread_a",
+        subject="Thread A",
+    )
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        gmail_message_id="msg_t2",
+        gmail_thread_id="thread_b",
+        subject="Thread B",
+    )
+    results = list_emails(database_connection, thread_id="thread_a")
+    assert len(results) == 1
+    assert results[0].subject == "Thread A"
+
+
+def test_list_emails_by_direction(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        gmail_message_id="msg_in",
+        subject="Inbound",
+    )
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        gmail_message_id="msg_out",
+        subject="Outbound",
+        status="sent",
+    )
+    results = list_emails(database_connection, direction="outbound")
+    assert len(results) == 1
+    assert results[0].subject == "Outbound"
+
+
+def test_list_emails_by_workflow_id(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        gmail_message_id="msg_wf",
+        workflow_id=workflow.id,
+        subject="Campaign",
+        status="sent",
+    )
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        gmail_message_id="msg_no_wf",
+        subject="No workflow",
+    )
+    results = list_emails(database_connection, workflow_id=workflow.id)
+    assert len(results) == 1
+    assert results[0].subject == "Campaign"
+
+
+def test_list_emails_by_status(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        gmail_message_id="msg_recv",
+        subject="Received",
+        status="received",
+    )
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        gmail_message_id="msg_sent",
+        subject="Sent",
+        status="sent",
+    )
+    results = list_emails(database_connection, status="sent")
+    assert len(results) == 1
+    assert results[0].subject == "Sent"
 
 
 # -- get_company_by_domain ----------------------------------------------------
@@ -1389,6 +1559,31 @@ def test_list_notes_with_limit(
         database_connection, entity_type="contact", entity_id=contact.id, limit=1
     )
     assert len(notes) == 1
+
+
+def test_list_notes_since(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    from datetime import datetime, timedelta
+
+    contact = make_test_contact(database_connection)
+    make_test_note(
+        database_connection, entity_type="contact", entity_id=contact.id, body="old"
+    )
+    database_connection.execute(
+        "UPDATE note SET created_at = CURRENT_TIMESTAMP - interval '2 days' "
+        "WHERE body = 'old'"
+    )
+    database_connection.commit()
+    make_test_note(
+        database_connection, entity_type="contact", entity_id=contact.id, body="recent"
+    )
+    since = (datetime.now(UTC) - timedelta(days=1)).isoformat()
+    results = list_notes(
+        database_connection, entity_type="contact", entity_id=contact.id, since=since
+    )
+    assert len(results) == 1
+    assert results[0].body == "recent"
 
 
 def test_get_note(


### PR DESCRIPTION
## Summary

Add 9 missing filters across 4 CLI list commands, following the existing `activity list` pattern:

- **email list**: `--since`, `--thread-id`, `--direction`, `--workflow-id`, `--status`
- **workflow list**: `--status`, `--type`
- **contact list**: `--status`
- **note list**: `--since`

FK filters validate entity existence before querying. `--since` passes ISO datetime strings to the DB layer, consistent with `activity list --since`.

Also includes:
- Refactor `list_notes` from f-string SQL to `psycopg.sql` dynamic query building
- Design spec for future `workflow contact` CLI subcommands (`docs/superpowers/specs/`)

Resolves #53

## Changes

- Add 9 new `click.Option` filters with `click.Choice` validation for enum values
- Add `--workflow-id` FK validation in `email list` (consistent with existing `--contact-id`/`--account-id`)
- Extend `list_contacts`, `list_workflows`, `list_emails`, `list_notes` with new filter parameters
- Refactor `list_notes` to use `psycopg.sql` conditions list (removes last f-string SQL)
- Update CLAUDE.md CLI reference with new filter options
- Add database-level and CLI-level tests for all new filters