### PR TITLE
feat(agent): add reply-in-thread, multiple recipients, CC, and BCC support to send_email tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ mailpilot task cancel ID
 mailpilot email search QUERY [--limit N]
 mailpilot email list [--limit N] [--contact-id ID] [--account-id ID] [--since ISO] [--thread-id TEXT] [--direction inbound|outbound] [--workflow-id ID] [--status sent|received|bounced]
 mailpilot email view ID
-mailpilot email send --account-id ID --to E --subject S --body B [--contact-id ID] [--workflow-id ID] [--thread-id ID]
+mailpilot email send --account-id ID --to E [--to E2 ...] --subject S --body B [--contact-id ID] [--workflow-id ID] [--thread-id ID] [--cc E] [--bcc E]
 
 mailpilot activity list --contact-id ID [--type TYPE] [--limit N] [--since ISO]
 mailpilot activity list --company-id ID [--type TYPE] [--limit N] [--since ISO]

--- a/docs/superpowers/plans/2026-04-23-reply-email-tool.md
+++ b/docs/superpowers/plans/2026-04-23-reply-email-tool.md
@@ -1,0 +1,729 @@
+# reply_email Agent Tool Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `reply_email` agent tool that replies to an existing email in-thread, resolving recipient, subject, and thread_id automatically from the original email.
+
+**Architecture:** New `reply_email` tool function in `agent/tools.py` that takes `email_id` + `body` (+ optional `cc`/`bcc`), looks up the original email and its contact, derives `to`/`subject`/`thread_id`, then delegates to `sync.send_email`. Wrapper added to `agent/invoke.py` and registered in `_TOOLS`. Trigger prompt updated to show `Email ID` instead of `Thread ID`.
+
+**Tech Stack:** Python, Pydantic AI tools, psycopg, pytest
+
+---
+
+### Task 1: Add `reply_email` to `agent/tools.py`
+
+**Files:**
+- Modify: `src/mailpilot/agent/tools.py`
+- Test: `tests/test_agent_tools.py`
+
+- [ ] **Step 1: Write the failing test for basic reply**
+
+In `tests/test_agent_tools.py`, add after the `send_email` test section:
+
+```python
+# -- reply_email ---------------------------------------------------------------
+
+
+def test_reply_email_resolves_thread_and_recipient(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """reply_email looks up original email to resolve to, subject, and thread_id."""
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="sender@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+
+    # Create the inbound email being replied to.
+    inbound = create_email(
+        database_connection,
+        account_id=account.id,
+        contact_id=contact.id,
+        workflow_id=workflow.id,
+        direction="inbound",
+        subject="Question about pricing",
+        gmail_message_id="inbound-msg-1",
+        gmail_thread_id="thread-abc",
+        body_text="How much does it cost?",
+    )
+
+    gmail_client = _make_gmail_client(account)
+
+    result = reply_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        email_id=inbound.id,
+        body="It costs $100/month.",
+    )
+
+    assert "error" not in result
+    assert result["gmail_message_id"] == "gmail-msg-1"
+    # Verify send_message was called with resolved values.
+    gmail_client.send_message.assert_called_once()
+    call_kwargs = gmail_client.send_message.call_args.kwargs
+    assert call_kwargs["to"] == "sender@example.com"
+    assert call_kwargs["subject"] == "Re: Question about pricing"
+    assert call_kwargs["thread_id"] == "thread-abc"
+```
+
+Add `reply_email` to the imports at the top of the file:
+
+```python
+from mailpilot.agent.tools import (
+    ...
+    reply_email,
+    ...
+)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_agent_tools.py::test_reply_email_resolves_thread_and_recipient -x`
+Expected: FAIL with `ImportError: cannot import name 'reply_email'`
+
+- [ ] **Step 3: Write the `reply_email` function**
+
+In `src/mailpilot/agent/tools.py`, add after the `send_email` function (before `create_task`):
+
+```python
+def reply_email(  # noqa: PLR0913
+    connection: psycopg.Connection[dict[str, Any]],
+    account: Account,
+    gmail_client: object,
+    settings: Settings,
+    workflow_id: str,
+    email_id: str,
+    body: str,
+    cc: str | None = None,
+    bcc: str | None = None,
+) -> dict[str, Any]:
+    """Reply to an existing email in-thread.
+
+    Resolves recipient, subject, and thread_id from the original email.
+    Only checks contact status (not cooldown, since replies are always allowed).
+
+    Args:
+        connection: Open database connection.
+        account: Sending account.
+        gmail_client: Gmail client scoped to account.
+        settings: Application settings.
+        workflow_id: Current workflow FK.
+        email_id: ID of the email being replied to.
+        body: Reply body (plain text).
+        cc: CC recipient(s), comma-separated.
+        bcc: BCC recipient(s), comma-separated.
+
+    Returns:
+        Dict with sent message details (id, gmail_message_id, gmail_thread_id),
+        or error dict if email not found or contact blocked.
+    """
+    with logfire.span("agent.tool.reply_email", email_id=email_id, workflow_id=workflow_id):
+        original = database.get_email(connection, email_id)
+        if original is None:
+            return {"error": "not_found", "message": f"email not found: {email_id}"}
+
+        # Resolve recipient from the original email's contact.
+        contact_id = original.contact_id
+        if contact_id is None:
+            return {
+                "error": "no_contact",
+                "message": "original email has no linked contact",
+            }
+
+        contact = database.get_contact(connection, contact_id)
+        if contact is None:
+            return {"error": "not_found", "message": f"contact not found: {contact_id}"}
+
+        # Guard: contact status check (no cooldown -- replies always allowed).
+        if contact.status != "active":
+            return {
+                "error": "contact_disabled",
+                "message": f"contact is {contact.status}: {contact.status_reason}",
+            }
+
+        # Derive subject with Re: prefix.
+        subject = original.subject
+        if not subject.startswith("Re: "):
+            subject = f"Re: {subject}"
+
+        email = sync_send_email(
+            connection=connection,
+            account=account,
+            gmail_client=gmail_client,  # type: ignore[arg-type]
+            settings=settings,
+            to=contact.email,
+            subject=subject,
+            body=body,
+            contact_id=contact.id,
+            workflow_id=workflow_id,
+            thread_id=original.gmail_thread_id,
+            cc=cc,
+            bcc=bcc,
+        )
+        return {
+            "id": email.id,
+            "gmail_message_id": email.gmail_message_id,
+            "gmail_thread_id": email.gmail_thread_id,
+        }
+```
+
+Update the module docstring tool list to include `reply_email`:
+
+```python
+#    - ``reply_email`` -- reply to an existing email in-thread
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_agent_tools.py::test_reply_email_resolves_thread_and_recipient -x`
+Expected: PASS
+
+- [ ] **Step 5: Write test for email not found**
+
+```python
+def test_reply_email_not_found(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+    gmail_client = _make_gmail_client(account)
+
+    result = reply_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        email_id="nonexistent-id",
+        body="Reply body",
+    )
+
+    assert result["error"] == "not_found"
+    gmail_client.send_message.assert_not_called()
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_agent_tools.py::test_reply_email_not_found -x`
+Expected: PASS
+
+- [ ] **Step 7: Write test for blocked contact**
+
+```python
+def test_reply_email_blocked_contact(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    from mailpilot.database import disable_contact as db_disable_contact
+
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="bounced@example.com", domain="example.com"
+    )
+    db_disable_contact(database_connection, contact.id, "bounced", "hard bounce")
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+
+    inbound = create_email(
+        database_connection,
+        account_id=account.id,
+        contact_id=contact.id,
+        workflow_id=workflow.id,
+        direction="inbound",
+        subject="Hello",
+        gmail_message_id="inbound-blocked",
+        gmail_thread_id="thread-blocked",
+    )
+
+    gmail_client = _make_gmail_client(account)
+
+    result = reply_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        email_id=inbound.id,
+        body="Reply",
+    )
+
+    assert result["error"] == "contact_disabled"
+    gmail_client.send_message.assert_not_called()
+```
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_agent_tools.py::test_reply_email_blocked_contact -x`
+Expected: PASS
+
+- [ ] **Step 9: Write test for Re: prefix idempotency**
+
+```python
+def test_reply_email_preserves_existing_re_prefix(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """reply_email does not double-add Re: prefix."""
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="sender@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+
+    inbound = create_email(
+        database_connection,
+        account_id=account.id,
+        contact_id=contact.id,
+        workflow_id=workflow.id,
+        direction="inbound",
+        subject="Re: Original topic",
+        gmail_message_id="inbound-re",
+        gmail_thread_id="thread-re",
+    )
+
+    gmail_client = _make_gmail_client(account)
+
+    reply_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        email_id=inbound.id,
+        body="Follow up",
+    )
+
+    call_kwargs = gmail_client.send_message.call_args.kwargs
+    assert call_kwargs["subject"] == "Re: Original topic"
+```
+
+- [ ] **Step 10: Run all reply_email tests**
+
+Run: `uv run pytest tests/test_agent_tools.py -k reply_email -v`
+Expected: 4 PASS
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/mailpilot/agent/tools.py tests/test_agent_tools.py
+git commit -m "feat(agent): add reply_email tool with auto-resolved threading (#59)"
+```
+
+---
+
+### Task 2: Add `reply_email` wrapper to `agent/invoke.py` and register in `_TOOLS`
+
+**Files:**
+- Modify: `src/mailpilot/agent/invoke.py`
+- Test: `tests/test_agent_invoke.py`
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/test_agent_invoke.py`, add a test that invokes the agent with a FunctionModel that calls the `reply_email` tool:
+
+```python
+def test_agent_calls_reply_email(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """Agent can call reply_email tool to reply in-thread."""
+    account, contact, workflow = _setup(database_connection)
+    update_workflow(database_connection, workflow.id, type="inbound")
+    settings = make_test_settings(
+        anthropic_api_key="sk-test", anthropic_model="test-model"
+    )
+
+    from mailpilot.database import create_email
+
+    inbound = create_email(
+        database_connection,
+        gmail_message_id="msg-reply-invoke",
+        gmail_thread_id="thread-reply-invoke",
+        account_id=account.id,
+        contact_id=contact.id,
+        workflow_id=workflow.id,
+        direction="inbound",
+        subject="Need help",
+        body_text="Can you assist?",
+    )
+
+    model = _model_that_calls_tool(
+        "reply_email",
+        {"email_id": inbound.id, "body": "Sure, happy to help!"},
+    )
+    with patch("mailpilot.agent.invoke.GmailClient") as mock_cls:
+        mock_client = MagicMock()
+        mock_client.send_message.return_value = {
+            "id": "sent-1",
+            "threadId": "thread-reply-invoke",
+            "labelIds": ["SENT"],
+        }
+        mock_cls.return_value = mock_client
+        result = invoke_workflow_agent(
+            database_connection,
+            settings,
+            workflow,
+            contact,
+            email=inbound,
+            model_override=model,
+        )
+
+    assert result is not None
+    mock_client.send_message.assert_called_once()
+    call_kwargs = mock_client.send_message.call_args.kwargs
+    assert call_kwargs["to"] == contact.email
+    assert call_kwargs["subject"] == "Re: Need help"
+    assert call_kwargs["thread_id"] == "thread-reply-invoke"
+```
+
+Add `MagicMock` to the imports if not already present:
+
+```python
+from unittest.mock import MagicMock, patch
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_agent_invoke.py::test_agent_calls_reply_email -x`
+Expected: FAIL (tool `reply_email` not registered)
+
+- [ ] **Step 3: Add the wrapper and register the tool**
+
+In `src/mailpilot/agent/invoke.py`, add the wrapper after `_wrap_send_email`:
+
+```python
+def _wrap_reply_email(
+    ctx: RunContext[AgentDeps],
+    email_id: str,
+    body: str,
+    cc: str | None = None,
+    bcc: str | None = None,
+) -> dict[str, Any]:
+    """Reply to an existing email in-thread."""
+    return agent_tools.reply_email(
+        connection=ctx.deps.connection,
+        account=ctx.deps.account,
+        gmail_client=ctx.deps.gmail_client,
+        settings=ctx.deps.settings,
+        workflow_id=ctx.deps.workflow_id,
+        email_id=email_id,
+        body=body,
+        cc=cc,
+        bcc=bcc,
+    )
+```
+
+Add to `_TOOLS` list after the `send_email` entry:
+
+```python
+Tool(_wrap_reply_email, name="reply_email"),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_agent_invoke.py::test_agent_calls_reply_email -x`
+Expected: PASS
+
+- [ ] **Step 5: Run all invoke tests**
+
+Run: `uv run pytest tests/test_agent_invoke.py -v`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/mailpilot/agent/invoke.py tests/test_agent_invoke.py
+git commit -m "feat(agent): register reply_email tool in agent invoke (#59)"
+```
+
+---
+
+### Task 3: Update trigger prompt to show Email ID instead of Thread ID
+
+**Files:**
+- Modify: `src/mailpilot/agent/invoke.py` (lines 300-308, `_format_trigger`)
+- Test: `tests/test_agent_invoke.py`
+
+- [ ] **Step 1: Update the existing `test_inbound_email_trigger_includes_thread_id` test**
+
+Rename the test and change assertion to check for email ID and sender instead of thread ID:
+
+```python
+def test_inbound_email_trigger_includes_email_id_and_sender(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """Inbound email trigger includes email ID and sender so agent can reply."""
+    account, contact, workflow = _setup(database_connection)
+    update_workflow(database_connection, workflow.id, type="inbound")
+    settings = make_test_settings(
+        anthropic_api_key="sk-test", anthropic_model="test-model"
+    )
+
+    from mailpilot.database import create_email
+
+    email = create_email(
+        database_connection,
+        gmail_message_id="msg-thread-test",
+        gmail_thread_id="thread-abc-123",
+        account_id=account.id,
+        contact_id=contact.id,
+        direction="inbound",
+        subject="Re: proposal",
+        body_text="Looks good, let's proceed.",
+    )
+
+    captured_messages: list[ModelMessage] = []
+    with patch("mailpilot.agent.invoke.GmailClient"):
+        invoke_workflow_agent(
+            database_connection,
+            settings,
+            workflow,
+            contact,
+            email=email,
+            model_override=_capturing_model(captured_messages),
+        )
+
+    all_text = str(captured_messages)
+    assert email.id in all_text
+    assert "lead@acme.com" in all_text
+    # Thread ID should NOT be exposed -- reply_email resolves it internally.
+    assert "thread-abc-123" not in all_text
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_agent_invoke.py::test_inbound_email_trigger_includes_email_id_and_sender -x`
+Expected: FAIL (prompt still shows Thread ID, not Email ID)
+
+- [ ] **Step 3: Update `_format_trigger`**
+
+In `src/mailpilot/agent/invoke.py`, replace the `_format_trigger` email branch:
+
+```python
+def _format_trigger(
+    email: Email | None,
+    task_description: str,
+    task_context: dict[str, Any] | None,
+    contact_email: str = "",
+) -> str:
+    """Format the trigger context section of the prompt."""
+    if email is not None:
+        header = f"\nNew inbound email:\nEmail ID: {email.id}\nFrom: {contact_email}"
+        return f"{header}\nSubject: {email.subject}\nBody:\n{email.body_text}"
+    if task_description:
+        lines = ["\nDeferred task:", f"Description: {task_description}"]
+        if task_context:
+            lines.append(f"Context: {task_context}")
+        return "\n".join(lines)
+    return (
+        "\nThis is an outbound invocation. "
+        "Review the contact and email history, then take appropriate action."
+    )
+```
+
+Update the call site in `_build_user_prompt` to pass `contact_email`:
+
+```python
+sections.append(_format_trigger(email, task_description, task_context, contact_email=contact.email))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_agent_invoke.py::test_inbound_email_trigger_includes_email_id_and_sender -x`
+Expected: PASS
+
+- [ ] **Step 5: Run all invoke tests to verify no regressions**
+
+Run: `uv run pytest tests/test_agent_invoke.py -v`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/mailpilot/agent/invoke.py tests/test_agent_invoke.py
+git commit -m "refactor(agent): show Email ID and sender in trigger prompt (#59)"
+```
+
+---
+
+### Task 4: Remove `thread_id` from `send_email` agent tool and clean up
+
+The `send_email` agent tool should be for new conversations only. The `thread_id` parameter is no longer needed there -- replies go through `reply_email`.
+
+**Files:**
+- Modify: `src/mailpilot/agent/tools.py`
+- Modify: `src/mailpilot/agent/invoke.py`
+- Test: `tests/test_agent_tools.py`
+- Test: `tests/test_agent_invoke.py`
+
+- [ ] **Step 1: Remove `thread_id` from agent `send_email` in `tools.py`**
+
+Remove the `thread_id` parameter from the `send_email` function signature and the cooldown guard's `if thread_id is None:` branch (cooldown now always applies for `send_email`). Update the docstring to remove thread_id references and note that replies should use `reply_email`.
+
+Updated `send_email` in `agent/tools.py`:
+
+```python
+def send_email(  # noqa: PLR0913
+    connection: psycopg.Connection[dict[str, Any]],
+    account: Account,
+    gmail_client: object,
+    settings: Settings,
+    workflow_id: str,
+    to: str,
+    subject: str,
+    body: str,
+    cc: str | None = None,
+    bcc: str | None = None,
+) -> dict[str, Any]:
+    """Send a new outbound email via Gmail API.
+
+    For replies to existing emails, use ``reply_email`` instead.
+
+    Guards:
+    1. Contact must be active (not bounced/unsubscribed) -- hard block
+    2. Cooldown: blocked if last unsolicited outbound to this contact from
+       this account was within cooldown period (30 days)
+
+    Args:
+        connection: Open database connection.
+        account: Sending account.
+        gmail_client: Gmail client scoped to account.
+        settings: Application settings.
+        workflow_id: Current workflow FK.
+        to: Recipient email address.
+        subject: Email subject.
+        body: Email body (plain text).
+        cc: CC recipient(s), comma-separated.
+        bcc: BCC recipient(s), comma-separated.
+
+    Returns:
+        Dict with sent message details (id, gmail_message_id, gmail_thread_id),
+        or error dict if blocked by guard.
+    """
+    with logfire.span("agent.tool.send_email", to=to, workflow_id=workflow_id):
+        # Guard 1: contact status check.
+        contact = database.get_contact_by_email(connection, to)
+        contact_id: str | None = None
+        if contact is not None:
+            contact_id = contact.id
+            if contact.status != "active":
+                return {
+                    "error": "contact_disabled",
+                    "message": f"contact is {contact.status}: {contact.status_reason}",
+                }
+
+            # Guard 2: cooldown.
+            last = database.get_last_cold_outbound(
+                connection, account.id, contact.id, workflow_id
+            )
+            if last is not None and last.created_at > datetime.now(UTC) - timedelta(
+                days=_COOLDOWN_DAYS
+            ):
+                sent_at = last.created_at.isoformat()
+                return {
+                    "error": "cooldown",
+                    "message": (
+                        f"last unsolicited email sent {sent_at}; "
+                        f"cooldown is {_COOLDOWN_DAYS} days"
+                    ),
+                }
+
+        email = sync_send_email(
+            connection=connection,
+            account=account,
+            gmail_client=gmail_client,  # type: ignore[arg-type]
+            settings=settings,
+            to=to,
+            subject=subject,
+            body=body,
+            contact_id=contact_id,
+            workflow_id=workflow_id,
+            cc=cc,
+            bcc=bcc,
+        )
+        return {
+            "id": email.id,
+            "gmail_message_id": email.gmail_message_id,
+            "gmail_thread_id": email.gmail_thread_id,
+        }
+```
+
+- [ ] **Step 2: Remove `thread_id` from `_wrap_send_email` in `invoke.py`**
+
+```python
+def _wrap_send_email(
+    ctx: RunContext[AgentDeps],
+    to: str,
+    subject: str,
+    body: str,
+    cc: str | None = None,
+    bcc: str | None = None,
+) -> dict[str, Any]:
+    """Send a new outbound email. For replies, use reply_email instead."""
+    return agent_tools.send_email(
+        connection=ctx.deps.connection,
+        account=ctx.deps.account,
+        gmail_client=ctx.deps.gmail_client,
+        settings=ctx.deps.settings,
+        workflow_id=ctx.deps.workflow_id,
+        to=to,
+        subject=subject,
+        body=body,
+        cc=cc,
+        bcc=bcc,
+    )
+```
+
+- [ ] **Step 3: Update tests**
+
+In `tests/test_agent_tools.py`:
+- Remove `test_send_email_reply_bypasses_cooldown` (this behavior moved to `reply_email`)
+- Remove the `thread_id` parameter from `test_send_email_passes_cc_and_bcc` if it had one (it doesn't)
+
+In `tests/test_agent_invoke.py`:
+- No changes needed (invoke tests don't pass thread_id to send_email)
+
+- [ ] **Step 4: Run all agent tests**
+
+Run: `uv run pytest tests/test_agent_tools.py tests/test_agent_invoke.py -v`
+Expected: all PASS
+
+- [ ] **Step 5: Run lint and type check**
+
+Run: `uv run ruff check --fix && uv run basedpyright`
+Expected: 0 errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/mailpilot/agent/tools.py src/mailpilot/agent/invoke.py tests/test_agent_tools.py
+git commit -m "refactor(agent): remove thread_id from send_email, replies use reply_email (#59)"
+```
+
+---
+
+### Task 5: Full verification and CLAUDE.md update
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Update CLAUDE.md tool list**
+
+In the `Tools per ADR-03` or agent tools documentation section, add `reply_email` to the tool list if it appears in CLAUDE.md.
+
+No CLI changes needed -- `reply_email` is an agent-only tool, not a CLI command. The CLI `email send` retains `--thread-id` for direct use.
+
+- [ ] **Step 2: Run full verification**
+
+Run: `make check`
+Expected: all lint, types, and tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add reply_email to agent tool documentation (#59)"
+```

--- a/src/mailpilot/agent/invoke.py
+++ b/src/mailpilot/agent/invoke.py
@@ -106,11 +106,10 @@ def _wrap_send_email(  # noqa: PLR0913
     to: str,
     subject: str,
     body: str,
-    thread_id: str | None = None,
     cc: str | None = None,
     bcc: str | None = None,
 ) -> dict[str, Any]:
-    """Send an email via Gmail API."""
+    """Send a new outbound email. For replies, use reply_email instead."""
     return agent_tools.send_email(
         connection=ctx.deps.connection,
         account=ctx.deps.account,
@@ -120,7 +119,6 @@ def _wrap_send_email(  # noqa: PLR0913
         to=to,
         subject=subject,
         body=body,
-        thread_id=thread_id,
         cc=cc,
         bcc=bcc,
     )

--- a/src/mailpilot/agent/invoke.py
+++ b/src/mailpilot/agent/invoke.py
@@ -101,12 +101,14 @@ def _release_advisory_lock(
 # standalone tool functions in agent/tools.py.
 
 
-def _wrap_send_email(
+def _wrap_send_email(  # noqa: PLR0913
     ctx: RunContext[AgentDeps],
     to: str,
     subject: str,
     body: str,
     thread_id: str | None = None,
+    cc: str | None = None,
+    bcc: str | None = None,
 ) -> dict[str, Any]:
     """Send an email via Gmail API."""
     return agent_tools.send_email(
@@ -119,6 +121,8 @@ def _wrap_send_email(
         subject=subject,
         body=body,
         thread_id=thread_id,
+        cc=cc,
+        bcc=bcc,
     )
 
 

--- a/src/mailpilot/agent/invoke.py
+++ b/src/mailpilot/agent/invoke.py
@@ -323,10 +323,11 @@ def _format_trigger(
     email: Email | None,
     task_description: str,
     task_context: dict[str, Any] | None,
+    contact_email: str = "",
 ) -> str:
     """Format the trigger context section of the prompt."""
     if email is not None:
-        header = f"\nNew inbound email:\nThread ID: {email.gmail_thread_id}"
+        header = f"\nNew inbound email:\nEmail ID: {email.id}\nFrom: {contact_email}"
         return f"{header}\nSubject: {email.subject}\nBody:\n{email.body_text}"
     if task_description:
         lines = ["\nDeferred task:", f"Description: {task_description}"]
@@ -364,7 +365,11 @@ def _build_user_prompt(  # noqa: PLR0913
         sections.append(f"Domain: {contact.domain}")
 
     sections.append(_format_email_history(email_history))
-    sections.append(_format_trigger(email, task_description, task_context))
+    sections.append(
+        _format_trigger(
+            email, task_description, task_context, contact_email=contact.email
+        )
+    )
 
     return "\n".join(sections)
 

--- a/src/mailpilot/agent/invoke.py
+++ b/src/mailpilot/agent/invoke.py
@@ -304,9 +304,8 @@ def _format_trigger(
 ) -> str:
     """Format the trigger context section of the prompt."""
     if email is not None:
-        return (
-            f"\nNew inbound email:\nSubject: {email.subject}\nBody:\n{email.body_text}"
-        )
+        header = f"\nNew inbound email:\nThread ID: {email.gmail_thread_id}"
+        return f"{header}\nSubject: {email.subject}\nBody:\n{email.body_text}"
     if task_description:
         lines = ["\nDeferred task:", f"Description: {task_description}"]
         if task_context:

--- a/src/mailpilot/agent/invoke.py
+++ b/src/mailpilot/agent/invoke.py
@@ -126,6 +126,27 @@ def _wrap_send_email(  # noqa: PLR0913
     )
 
 
+def _wrap_reply_email(
+    ctx: RunContext[AgentDeps],
+    email_id: str,
+    body: str,
+    cc: str | None = None,
+    bcc: str | None = None,
+) -> dict[str, Any]:
+    """Reply to an existing email in-thread."""
+    return agent_tools.reply_email(
+        connection=ctx.deps.connection,
+        account=ctx.deps.account,
+        gmail_client=ctx.deps.gmail_client,
+        settings=ctx.deps.settings,
+        workflow_id=ctx.deps.workflow_id,
+        email_id=email_id,
+        body=body,
+        cc=cc,
+        bcc=bcc,
+    )
+
+
 def _wrap_create_task(  # noqa: PLR0913
     ctx: RunContext[AgentDeps],
     contact_id: str,
@@ -250,6 +271,7 @@ def _wrap_noop(
 
 _TOOLS: list[Tool[AgentDeps]] = [
     Tool(_wrap_send_email, name="send_email"),
+    Tool(_wrap_reply_email, name="reply_email"),
     Tool(_wrap_create_task, name="create_task"),
     Tool(_wrap_cancel_task, name="cancel_task"),
     Tool(_wrap_update_contact_status, name="update_contact_status"),

--- a/src/mailpilot/agent/tools.py
+++ b/src/mailpilot/agent/tools.py
@@ -46,6 +46,8 @@ def send_email(  # noqa: PLR0913
     subject: str,
     body: str,
     thread_id: str | None = None,
+    cc: str | None = None,
+    bcc: str | None = None,
 ) -> dict[str, Any]:
     """Send an email via Gmail API.
 
@@ -66,6 +68,8 @@ def send_email(  # noqa: PLR0913
         subject: Email subject.
         body: Email body (plain text).
         thread_id: Gmail thread ID for threading replies.
+        cc: CC recipient(s), comma-separated.
+        bcc: BCC recipient(s), comma-separated.
 
     Returns:
         Dict with sent message details (id, gmail_message_id, gmail_thread_id),
@@ -111,6 +115,8 @@ def send_email(  # noqa: PLR0913
             contact_id=contact_id,
             workflow_id=workflow_id,
             thread_id=thread_id,
+            cc=cc,
+            bcc=bcc,
         )
         return {
             "id": email.id,

--- a/src/mailpilot/agent/tools.py
+++ b/src/mailpilot/agent/tools.py
@@ -46,18 +46,17 @@ def send_email(  # noqa: PLR0913
     to: str,
     subject: str,
     body: str,
-    thread_id: str | None = None,
     cc: str | None = None,
     bcc: str | None = None,
 ) -> dict[str, Any]:
-    """Send an email via Gmail API.
+    """Send a new outbound email via Gmail API.
+
+    For replies to existing emails, use ``reply_email`` instead.
 
     Guards:
     1. Contact must be active (not bounced/unsubscribed) -- hard block
-    2. Cooldown on unsolicited outreach only:
-       - Reply (thread_id provided): always allowed
-       - New conversation (no thread_id): blocked if last unsolicited outbound
-         to this contact from this account was within cooldown period (30 days)
+    2. Cooldown: blocked if last unsolicited outbound to this contact from
+       this account was within cooldown period (30 days)
 
     Args:
         connection: Open database connection.
@@ -68,7 +67,6 @@ def send_email(  # noqa: PLR0913
         to: Recipient email address.
         subject: Email subject.
         body: Email body (plain text).
-        thread_id: Gmail thread ID for threading replies.
         cc: CC recipient(s), comma-separated.
         bcc: BCC recipient(s), comma-separated.
 
@@ -88,22 +86,21 @@ def send_email(  # noqa: PLR0913
                     "message": f"contact is {contact.status}: {contact.status_reason}",
                 }
 
-            # Guard 2: cooldown (new conversations only).
-            if thread_id is None:
-                last = database.get_last_cold_outbound(
-                    connection, account.id, contact.id, workflow_id
-                )
-                if last is not None and last.created_at > datetime.now(UTC) - timedelta(
-                    days=_COOLDOWN_DAYS
-                ):
-                    sent_at = last.created_at.isoformat()
-                    return {
-                        "error": "cooldown",
-                        "message": (
-                            f"last unsolicited email sent {sent_at}; "
-                            f"cooldown is {_COOLDOWN_DAYS} days"
-                        ),
-                    }
+            # Guard 2: cooldown.
+            last = database.get_last_cold_outbound(
+                connection, account.id, contact.id, workflow_id
+            )
+            if last is not None and last.created_at > datetime.now(UTC) - timedelta(
+                days=_COOLDOWN_DAYS
+            ):
+                sent_at = last.created_at.isoformat()
+                return {
+                    "error": "cooldown",
+                    "message": (
+                        f"last unsolicited email sent {sent_at}; "
+                        f"cooldown is {_COOLDOWN_DAYS} days"
+                    ),
+                }
 
         email = sync_send_email(
             connection=connection,
@@ -115,7 +112,6 @@ def send_email(  # noqa: PLR0913
             body=body,
             contact_id=contact_id,
             workflow_id=workflow_id,
-            thread_id=thread_id,
             cc=cc,
             bcc=bcc,
         )

--- a/src/mailpilot/agent/tools.py
+++ b/src/mailpilot/agent/tools.py
@@ -10,6 +10,7 @@ wire from ``RunContext[AgentDeps]``.
 
 Tools per ADR-03:
     - ``send_email`` -- send via Gmail API with contact status + cooldown guards
+    - ``reply_email`` -- reply in-thread with auto-resolved recipient and subject
     - ``create_task`` -- schedule deferred work
     - ``cancel_task`` -- cancel a pending task
     - ``update_contact_status`` -- report per-workflow outcome
@@ -115,6 +116,110 @@ def send_email(  # noqa: PLR0913
             contact_id=contact_id,
             workflow_id=workflow_id,
             thread_id=thread_id,
+            cc=cc,
+            bcc=bcc,
+        )
+        return {
+            "id": email.id,
+            "gmail_message_id": email.gmail_message_id,
+            "gmail_thread_id": email.gmail_thread_id,
+        }
+
+
+def reply_email(  # noqa: PLR0913
+    connection: psycopg.Connection[dict[str, Any]],
+    account: Account,
+    gmail_client: object,
+    settings: Settings,
+    workflow_id: str,
+    email_id: str,
+    body: str,
+    cc: str | None = None,
+    bcc: str | None = None,
+) -> dict[str, Any]:
+    """Reply to an existing email in-thread.
+
+    Resolves recipient, subject, and thread_id automatically from the
+    original email. No cooldown check -- replies are always allowed.
+
+    Guards:
+    1. Original email must exist
+    2. Original email must have a gmail_thread_id
+    3. Original email must have a contact_id
+    4. Contact must exist
+    5. Contact must be active (not bounced/unsubscribed)
+
+    Args:
+        connection: Open database connection.
+        account: Sending account.
+        gmail_client: Gmail client scoped to account.
+        settings: Application settings.
+        workflow_id: Current workflow FK.
+        email_id: ID of the email being replied to.
+        body: Reply body (plain text).
+        cc: CC recipient(s), comma-separated.
+        bcc: BCC recipient(s), comma-separated.
+
+    Returns:
+        Dict with sent message details (id, gmail_message_id, gmail_thread_id),
+        or error dict if blocked by guard.
+    """
+    with logfire.span(
+        "agent.tool.reply_email", email_id=email_id, workflow_id=workflow_id
+    ):
+        # Guard 1: original email must exist.
+        original = database.get_email(connection, email_id)
+        if original is None:
+            return {
+                "error": "not_found",
+                "message": f"email not found: {email_id}",
+            }
+
+        # Guard 2: original email must have a gmail_thread_id.
+        if original.gmail_thread_id is None:
+            return {
+                "error": "no_thread",
+                "message": f"email has no gmail_thread_id: {email_id}",
+            }
+
+        # Guard 3: original email must have a contact.
+        if original.contact_id is None:
+            return {
+                "error": "no_contact",
+                "message": f"email has no contact_id: {email_id}",
+            }
+
+        # Guard 4: contact must exist.
+        contact = database.get_contact(connection, original.contact_id)
+        if contact is None:
+            return {
+                "error": "not_found",
+                "message": f"contact not found: {original.contact_id}",
+            }
+
+        # Guard 5: contact must be active.
+        if contact.status != "active":
+            return {
+                "error": "contact_disabled",
+                "message": f"contact is {contact.status}: {contact.status_reason}",
+            }
+
+        # Derive subject: prepend "Re: " unless already prefixed.
+        subject = original.subject
+        if not subject.lower().startswith("re: "):
+            subject = f"Re: {subject}"
+
+        email = sync_send_email(
+            connection=connection,
+            account=account,
+            gmail_client=gmail_client,  # type: ignore[arg-type]
+            settings=settings,
+            to=contact.email,
+            subject=subject,
+            body=body,
+            contact_id=contact.id,
+            workflow_id=workflow_id,
+            thread_id=original.gmail_thread_id,
             cc=cc,
             bcc=bcc,
         )

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -781,20 +781,30 @@ def email_view(email_id: str) -> None:
 
 @email.command("send")
 @click.option("--account-id", required=True, help="Sending account ID.")
-@click.option("--to", "to", required=True, help="Recipient email address.")
+@click.option(
+    "--to",
+    "to",
+    required=True,
+    multiple=True,
+    help="Recipient email address (repeatable).",
+)
 @click.option("--subject", required=True, help="Email subject.")
 @click.option("--body", required=True, help="Plain text body.")
 @click.option("--contact-id", default=None, help="Link to an existing contact.")
 @click.option("--workflow-id", default=None, help="Link to a workflow.")
 @click.option("--thread-id", default=None, help="Gmail thread ID for replies.")
+@click.option("--cc", default=None, help="CC recipient(s), comma-separated.")
+@click.option("--bcc", default=None, help="BCC recipient(s), comma-separated.")
 def email_send(
     account_id: str,
-    to: str,
+    to: tuple[str, ...],
     subject: str,
     body: str,
     contact_id: str | None,
     workflow_id: str | None,
     thread_id: str | None,
+    cc: str | None,
+    bcc: str | None,
 ) -> None:
     """Send an outbound email via the given account's Gmail mailbox."""
     import logfire
@@ -804,6 +814,7 @@ def email_send(
     from mailpilot.settings import get_settings
     from mailpilot.sync import send_email
 
+    to_joined = ",".join(to)
     settings = get_settings()
     connection = initialize_database(_database_url())
     try:
@@ -817,12 +828,14 @@ def email_send(
                 account=account,
                 gmail_client=client,
                 settings=settings,
-                to=to,
+                to=to_joined,
                 subject=subject,
                 body=body,
                 contact_id=contact_id,
                 workflow_id=workflow_id,
                 thread_id=thread_id,
+                cc=cc,
+                bcc=bcc,
             )
         except Exception as exc:
             logfire.exception(

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -1686,6 +1686,11 @@ def create_tasks_for_routed_emails(
     Finds inbound emails with workflow_id set but no corresponding task
     row, and creates a task with scheduled_at=now() for each.
 
+    Uses ``e.created_at`` (DB insert time) rather than ``e.received_at``
+    (Gmail timestamp) to filter historical emails. An email can be received
+    by Gmail before a workflow exists but synced into our DB after -- using
+    ``received_at`` would incorrectly skip such emails.
+
     Args:
         connection: Open database connection.
 
@@ -1698,7 +1703,7 @@ def create_tasks_for_routed_emails(
         JOIN workflow w ON w.id = e.workflow_id
         WHERE e.direction = 'inbound'
           AND e.contact_id IS NOT NULL
-          AND e.received_at >= w.created_at
+          AND e.created_at >= w.created_at
           AND NOT EXISTS (SELECT 1 FROM task t WHERE t.email_id = e.id)
         ORDER BY e.created_at
         """

--- a/src/mailpilot/gmail.py
+++ b/src/mailpilot/gmail.py
@@ -270,17 +270,21 @@ class GmailClient:
         from_email: str = "",
         thread_id: str | None = None,
         account_id: str = "",
+        cc: str | None = None,
+        bcc: str | None = None,
         user_id: str = "me",
     ) -> dict[str, Any]:
         """Send an email message via Gmail API.
 
         Args:
-            to: Recipient email address.
+            to: Recipient email address(es), comma-separated for multiple.
             subject: Email subject.
             body: Email body (plain text).
             from_email: Sender email (for From header).
             thread_id: Gmail thread ID for threading replies.
             account_id: MailPilot account ID for traceability header.
+            cc: CC recipient(s), comma-separated.
+            bcc: BCC recipient(s), comma-separated.
             user_id: Gmail user ID.
 
         Returns:
@@ -291,6 +295,10 @@ class GmailClient:
         message["Subject"] = subject
         if from_email:
             message["From"] = from_email
+        if cc:
+            message["Cc"] = cc
+        if bcc:
+            message["Bcc"] = bcc
         message["X-MailPilot-Version"] = _MAILPILOT_VERSION
         if account_id:
             message["X-MailPilot-Account-Id"] = account_id

--- a/src/mailpilot/sync.py
+++ b/src/mailpilot/sync.py
@@ -460,6 +460,8 @@ def send_email(  # noqa: PLR0913
     contact_id: str | None = None,
     workflow_id: str | None = None,
     thread_id: str | None = None,
+    cc: str | None = None,
+    bcc: str | None = None,
 ) -> Email:
     """Send an outbound email through Gmail and record the DB row.
 
@@ -474,12 +476,14 @@ def send_email(  # noqa: PLR0913
         account: Sending account (used for service-account delegation).
         gmail_client: Gmail client scoped to ``account``.
         settings: Application settings (reserved for future tuning).
-        to: Recipient email address.
+        to: Recipient email address(es), comma-separated for multiple.
         subject: Email subject.
         body: Plain text body.
         contact_id: Optional contact FK.
         workflow_id: Optional workflow FK.
         thread_id: Optional Gmail thread ID for replies.
+        cc: Optional CC recipient(s), comma-separated.
+        bcc: Optional BCC recipient(s), comma-separated.
 
     Returns:
         The created ``Email`` row with ``direction="outbound"`` and
@@ -509,6 +513,8 @@ def send_email(  # noqa: PLR0913
             from_email=from_header,
             thread_id=thread_id,
             account_id=account.id,
+            cc=cc,
+            bcc=bcc,
         )
         gmail_message_id = result.get("id")
         gmail_thread_id = result.get("threadId")

--- a/tests/test_agent_invoke.py
+++ b/tests/test_agent_invoke.py
@@ -366,10 +366,10 @@ def test_inbound_email_trigger(
     assert "How much does your product cost?" in all_text
 
 
-def test_inbound_email_trigger_includes_thread_id(
+def test_inbound_email_trigger_includes_email_id_and_sender(
     database_connection: psycopg.Connection[dict[str, Any]],
 ) -> None:
-    """Inbound email trigger includes gmail_thread_id so agent can reply in-thread."""
+    """Inbound email trigger includes email ID and sender so agent can reply."""
     account, contact, workflow = _setup(database_connection)
     update_workflow(database_connection, workflow.id, type="inbound")
     settings = make_test_settings(
@@ -388,6 +388,7 @@ def test_inbound_email_trigger_includes_thread_id(
         subject="Re: proposal",
         body_text="Looks good, let's proceed.",
     )
+    assert email is not None
 
     captured_messages: list[ModelMessage] = []
     with patch("mailpilot.agent.invoke.GmailClient"):
@@ -401,7 +402,10 @@ def test_inbound_email_trigger_includes_thread_id(
         )
 
     all_text = str(captured_messages)
-    assert "thread-abc-123" in all_text
+    assert email.id in all_text
+    assert "lead@acme.com" in all_text
+    # Thread ID should NOT be exposed -- reply_email resolves it internally.
+    assert "thread-abc-123" not in all_text
 
 
 def test_deferred_task_trigger(

--- a/tests/test_agent_invoke.py
+++ b/tests/test_agent_invoke.py
@@ -366,6 +366,44 @@ def test_inbound_email_trigger(
     assert "How much does your product cost?" in all_text
 
 
+def test_inbound_email_trigger_includes_thread_id(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """Inbound email trigger includes gmail_thread_id so agent can reply in-thread."""
+    account, contact, workflow = _setup(database_connection)
+    update_workflow(database_connection, workflow.id, type="inbound")
+    settings = make_test_settings(
+        anthropic_api_key="sk-test", anthropic_model="test-model"
+    )
+
+    from mailpilot.database import create_email
+
+    email = create_email(
+        database_connection,
+        gmail_message_id="msg-thread-test",
+        gmail_thread_id="thread-abc-123",
+        account_id=account.id,
+        contact_id=contact.id,
+        direction="inbound",
+        subject="Re: proposal",
+        body_text="Looks good, let's proceed.",
+    )
+
+    captured_messages: list[ModelMessage] = []
+    with patch("mailpilot.agent.invoke.GmailClient"):
+        invoke_workflow_agent(
+            database_connection,
+            settings,
+            workflow,
+            contact,
+            email=email,
+            model_override=_capturing_model(captured_messages),
+        )
+
+    all_text = str(captured_messages)
+    assert "thread-abc-123" in all_text
+
+
 def test_deferred_task_trigger(
     database_connection: psycopg.Connection[dict[str, Any]],
 ) -> None:

--- a/tests/test_agent_invoke.py
+++ b/tests/test_agent_invoke.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import psycopg
 import pytest
@@ -510,3 +510,60 @@ def test_invoke_span_has_usage_attributes(
     assert attrs["input_tokens"] >= 0
     assert attrs["output_tokens"] >= 0
     assert attrs["llm_requests"] >= 1
+
+
+# -- Tests: reply_email tool ---------------------------------------------------
+
+
+def test_agent_calls_reply_email(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """Agent can call reply_email tool to reply in-thread."""
+    account, contact, workflow = _setup(database_connection)
+    update_workflow(database_connection, workflow.id, type="inbound")
+    settings = make_test_settings(
+        anthropic_api_key="sk-test", anthropic_model="test-model"
+    )
+
+    from mailpilot.database import create_email
+
+    inbound = create_email(
+        database_connection,
+        gmail_message_id="msg-reply-invoke",
+        gmail_thread_id="thread-reply-invoke",
+        account_id=account.id,
+        contact_id=contact.id,
+        workflow_id=workflow.id,
+        direction="inbound",
+        subject="Need help",
+        body_text="Can you assist?",
+    )
+    assert inbound is not None
+
+    model = _model_that_calls_tool(
+        "reply_email",
+        {"email_id": inbound.id, "body": "Sure, happy to help!"},
+    )
+    with patch("mailpilot.agent.invoke.GmailClient") as mock_cls:
+        mock_client = MagicMock()
+        mock_client.send_message.return_value = {
+            "id": "sent-1",
+            "threadId": "thread-reply-invoke",
+            "labelIds": ["SENT"],
+        }
+        mock_cls.return_value = mock_client
+        result = invoke_workflow_agent(
+            database_connection,
+            settings,
+            workflow,
+            contact,
+            email=inbound,
+            model_override=model,
+        )
+
+    assert result is not None
+    mock_client.send_message.assert_called_once()
+    call_kwargs = mock_client.send_message.call_args.kwargs
+    assert call_kwargs["to"] == contact.email
+    assert call_kwargs["subject"] == "Re: Need help"
+    assert call_kwargs["thread_id"] == "thread-reply-invoke"

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -23,6 +23,7 @@ from mailpilot.agent.tools import (
     noop,
     read_company,
     read_contact,
+    reply_email,
     search_emails,
     send_email,
     update_contact_status,
@@ -268,6 +269,236 @@ def test_send_email_passes_cc_and_bcc(
     call_kwargs = gmail_client.send_message.call_args.kwargs
     assert call_kwargs["cc"] == "cc@example.com"
     assert call_kwargs["bcc"] == "bcc@example.com"
+
+
+# -- reply_email ---------------------------------------------------------------
+
+
+def test_reply_email_resolves_thread_and_recipient(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="sender@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+
+    # Simulate an inbound email that the agent wants to reply to.
+    inbound = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Question about pricing",
+        contact_id=contact.id,
+        workflow_id=workflow.id,
+        gmail_message_id="inbound-msg-1",
+        gmail_thread_id="thread-abc",
+    )
+    assert inbound is not None
+
+    gmail_client = _make_gmail_client(account)
+
+    result = reply_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        email_id=inbound.id,
+        body="Here is the pricing info.",
+    )
+
+    assert "error" not in result
+    assert result["gmail_message_id"] == "gmail-msg-1"
+    assert result["gmail_thread_id"] == "gmail-thread-1"
+    assert "id" in result
+
+    # Verify send_message was called with resolved values.
+    gmail_client.send_message.assert_called_once()
+    call_kwargs = gmail_client.send_message.call_args.kwargs
+    assert call_kwargs["to"] == "sender@example.com"
+    assert call_kwargs["subject"] == "Re: Question about pricing"
+    assert call_kwargs["thread_id"] == "thread-abc"
+
+
+def test_reply_email_not_found(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+    gmail_client = _make_gmail_client(account)
+
+    result = reply_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        email_id="nonexistent-email-id",
+        body="Hello",
+    )
+
+    assert result["error"] == "not_found"
+    gmail_client.send_message.assert_not_called()
+
+
+def test_reply_email_blocked_contact(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    from mailpilot.database import disable_contact as db_disable_contact
+
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="bounced@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+
+    inbound = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Hello",
+        contact_id=contact.id,
+        gmail_message_id="inbound-bounced",
+        gmail_thread_id="thread-bounced",
+    )
+    assert inbound is not None
+
+    # Disable the contact after the email was received.
+    db_disable_contact(database_connection, contact.id, "bounced", "hard bounce")
+
+    gmail_client = _make_gmail_client(account)
+
+    result = reply_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        email_id=inbound.id,
+        body="Reply text",
+    )
+
+    assert result["error"] == "contact_disabled"
+    assert "bounced" in result["message"]
+    gmail_client.send_message.assert_not_called()
+
+
+def test_reply_email_preserves_existing_re_prefix(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="thread@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+
+    inbound = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Re: Original topic",
+        contact_id=contact.id,
+        gmail_message_id="inbound-re",
+        gmail_thread_id="thread-re",
+    )
+    assert inbound is not None
+
+    gmail_client = _make_gmail_client(account)
+
+    result = reply_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        email_id=inbound.id,
+        body="Continuing the thread.",
+    )
+
+    assert "error" not in result
+    call_kwargs = gmail_client.send_message.call_args.kwargs
+    # Should NOT double-prefix to "Re: Re: Original topic".
+    assert call_kwargs["subject"] == "Re: Original topic"
+
+
+def test_reply_email_no_thread_id(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Reply should fail when the original email has no gmail_thread_id."""
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="nothreadid@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+
+    # Create an inbound email without a gmail_thread_id.
+    inbound = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="No thread",
+        contact_id=contact.id,
+        gmail_message_id="inbound-no-thread",
+        gmail_thread_id=None,
+    )
+    assert inbound is not None
+
+    gmail_client = _make_gmail_client(account)
+
+    result = reply_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        email_id=inbound.id,
+        body="Attempting reply",
+    )
+
+    assert result["error"] == "no_thread"
+    gmail_client.send_message.assert_not_called()
+
+
+def test_reply_email_no_contact(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Reply should fail when the original email has no contact_id."""
+    account = make_test_account(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+
+    # Create an inbound email without a contact_id.
+    inbound = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="No contact",
+        contact_id=None,
+        gmail_message_id="inbound-no-contact",
+        gmail_thread_id="thread-no-contact",
+    )
+    assert inbound is not None
+
+    gmail_client = _make_gmail_client(account)
+
+    result = reply_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        email_id=inbound.id,
+        body="Attempting reply",
+    )
+
+    assert result["error"] == "no_contact"
+    gmail_client.send_message.assert_not_called()
 
 
 # -- create_task ---------------------------------------------------------------

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -237,6 +237,39 @@ def test_send_email_unknown_contact_succeeds(
     assert result["gmail_message_id"] == "gmail-msg-1"
 
 
+def test_send_email_passes_cc_and_bcc(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    make_test_contact(
+        database_connection, email="recipient@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+    gmail_client = _make_gmail_client(account)
+
+    result = send_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        to="recipient@example.com",
+        subject="Hello",
+        body="Hi there",
+        cc="cc@example.com",
+        bcc="bcc@example.com",
+    )
+
+    assert "error" not in result
+    assert result["gmail_message_id"] == "gmail-msg-1"
+    # Verify cc and bcc were passed through to sync.send_email.
+    gmail_client.send_message.assert_called_once()
+    call_kwargs = gmail_client.send_message.call_args.kwargs
+    assert call_kwargs["cc"] == "cc@example.com"
+    assert call_kwargs["bcc"] == "bcc@example.com"
+
+
 # -- create_task ---------------------------------------------------------------
 
 

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -171,49 +171,6 @@ def test_send_email_blocked_by_cooldown(
     gmail_client.send_message.assert_not_called()
 
 
-def test_send_email_reply_bypasses_cooldown(
-    database_connection: psycopg.Connection[dict[str, Any]],
-):
-    account = make_test_account(database_connection)
-    contact = make_test_contact(
-        database_connection, email="reply@example.com", domain="example.com"
-    )
-    workflow = make_test_workflow(database_connection, account_id=account.id)
-    _activate(database_connection, workflow.id)
-
-    # Recent cold outbound (first in its thread).
-    create_email(
-        database_connection,
-        account_id=account.id,
-        direction="outbound",
-        subject="cold pitch",
-        contact_id=contact.id,
-        workflow_id=workflow.id,
-        gmail_message_id="cold-msg",
-        gmail_thread_id="cold-thread",
-        status="sent",
-        sent_at=datetime.now(UTC) - timedelta(days=5),
-    )
-
-    gmail_client = _make_gmail_client(account)
-
-    result = send_email(
-        connection=database_connection,
-        account=account,
-        gmail_client=gmail_client,
-        settings=make_test_settings(),
-        workflow_id=workflow.id,
-        to="reply@example.com",
-        subject="Re: your question",
-        body="Here's the answer",
-        thread_id="existing-thread",
-    )
-
-    # Reply with thread_id should bypass cooldown.
-    assert "error" not in result
-    assert result["gmail_message_id"] == "gmail-msg-1"
-
-
 def test_send_email_unknown_contact_succeeds(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1455,6 +1455,87 @@ def test_email_send_gmail_failure_returns_error(
     assert "gmail 500" in data["message"]
 
 
+def test_email_send_with_cc_and_bcc(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    account = _make_account()
+    sent = _make_email(
+        direction="outbound",
+        status="sent",
+        sent_at=_NOW,
+    )
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_account", return_value=account),
+        patch("mailpilot.gmail.GmailClient"),
+        patch("mailpilot.sync.send_email", return_value=sent) as mock_send,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "email",
+                "send",
+                "--account-id",
+                account.id,
+                "--to",
+                "recipient@example.com",
+                "--subject",
+                "Hello",
+                "--body",
+                "Body",
+                "--cc",
+                "cc@example.com",
+                "--bcc",
+                "bcc@example.com",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    kwargs = mock_send.call_args.kwargs
+    assert kwargs["cc"] == "cc@example.com"
+    assert kwargs["bcc"] == "bcc@example.com"
+
+
+def test_email_send_with_multiple_to(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    account = _make_account()
+    sent = _make_email(
+        direction="outbound",
+        status="sent",
+        sent_at=_NOW,
+    )
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_account", return_value=account),
+        patch("mailpilot.gmail.GmailClient"),
+        patch("mailpilot.sync.send_email", return_value=sent) as mock_send,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "email",
+                "send",
+                "--account-id",
+                account.id,
+                "--to",
+                "a@example.com",
+                "--to",
+                "b@example.com",
+                "--subject",
+                "Hello",
+                "--body",
+                "Body",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    kwargs = mock_send.call_args.kwargs
+    assert kwargs["to"] == "a@example.com,b@example.com"
+
+
 # -- workflow helpers ----------------------------------------------------------
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1893,16 +1893,14 @@ def test_create_tasks_for_routed_emails_skips_outbound(
 def test_create_tasks_for_routed_emails_skips_historical(
     database_connection: psycopg.Connection[dict[str, Any]],
 ) -> None:
-    """Emails received before the workflow was created should not be bridged."""
-    from datetime import timedelta
+    """Emails stored in DB before the workflow was created should not be bridged."""
+    from datetime import datetime, timedelta
 
     account = make_test_account(database_connection)
-    workflow = make_test_workflow(database_connection, account_id=account.id)
-
     contact = make_test_contact(database_connection)
 
-    # Email received BEFORE the workflow was created -- should be skipped.
-    historical_email = create_email(
+    # Create email FIRST (simulates full sync storing historical email).
+    pre_existing_email = create_email(
         database_connection,
         gmail_message_id="msg-hist",
         gmail_thread_id="thread-hist",
@@ -1911,13 +1909,22 @@ def test_create_tasks_for_routed_emails_skips_historical(
         subject="Old message",
         body_text="From last month",
         labels=["INBOX"],
-        received_at=workflow.created_at - timedelta(days=30),
+        received_at=datetime.now(UTC) - timedelta(days=30),
         contact_id=contact.id,
-        workflow_id=workflow.id,
     )
-    assert historical_email is not None
+    assert pre_existing_email is not None
 
-    # Email received AFTER the workflow was created -- should be bridged.
+    # Create workflow AFTER the email was stored.
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+
+    # Simulate routing: set workflow_id on the pre-existing email.
+    database_connection.execute(
+        "UPDATE email SET workflow_id = %s WHERE id = %s",
+        (workflow.id, pre_existing_email.id),
+    )
+    database_connection.commit()
+
+    # Email stored AFTER the workflow was created -- should be bridged.
     recent_email = create_email(
         database_connection,
         gmail_message_id="msg-recent",
@@ -1927,7 +1934,7 @@ def test_create_tasks_for_routed_emails_skips_historical(
         subject="New message",
         body_text="Just now",
         labels=["INBOX"],
-        received_at=workflow.created_at + timedelta(minutes=5),
+        received_at=datetime.now(UTC),
         contact_id=contact.id,
         workflow_id=workflow.id,
     )
@@ -1936,6 +1943,44 @@ def test_create_tasks_for_routed_emails_skips_historical(
     created = create_tasks_for_routed_emails(database_connection)
     assert len(created) == 1
     assert created[0].email_id == recent_email.id
+
+
+def test_create_tasks_for_routed_emails_bridges_email_synced_after_workflow(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """Email received by Gmail before workflow but synced after should be bridged.
+
+    This is the race condition from the smoke test: outbound sends email,
+    then inbound workflow is created, then sync stores the email. The email's
+    received_at (Gmail timestamp) predates the workflow, but created_at
+    (DB insert time) is after the workflow.
+    """
+    from datetime import timedelta
+
+    account = make_test_account(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    contact = make_test_contact(database_connection)
+
+    # Email received by Gmail BEFORE workflow, but synced/stored AFTER.
+    # created_at is auto-set to now() which is after workflow.created_at.
+    email = create_email(
+        database_connection,
+        gmail_message_id="msg-race",
+        gmail_thread_id="thread-race",
+        account_id=account.id,
+        direction="inbound",
+        subject="Recent email with old Gmail timestamp",
+        body_text="Arrived just before workflow was created",
+        labels=["INBOX"],
+        received_at=workflow.created_at - timedelta(seconds=17),
+        contact_id=contact.id,
+        workflow_id=workflow.id,
+    )
+    assert email is not None
+
+    created = create_tasks_for_routed_emails(database_connection)
+    assert len(created) == 1
+    assert created[0].email_id == email.id
 
 
 def test_complete_task_stores_result(

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -642,3 +642,59 @@ def test_send_email_propagates_gmail_errors(
         )
     # No DB row must have been created when Gmail fails.
     assert list_emails(database_connection, account_id=account.id) == []
+
+
+def test_send_email_passes_cc_and_bcc(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection, email="sender@example.com")
+    client, service = _make_send_client(account.email)
+
+    send_email(
+        database_connection,
+        account=account,
+        gmail_client=client,
+        settings=make_test_settings(),
+        to="recipient@example.com",
+        subject="Hello",
+        body="Body text",
+        cc="cc1@example.com,cc2@example.com",
+        bcc="bcc@example.com",
+    )
+
+    # Decode MIME payload and verify Cc and Bcc headers.
+    from email import message_from_bytes
+
+    send_body = service.users.return_value.messages.return_value.send.call_args.kwargs[
+        "body"
+    ]
+    raw = base64.urlsafe_b64decode(send_body["raw"])
+    msg = message_from_bytes(raw)
+    assert msg["cc"] == "cc1@example.com,cc2@example.com"
+    assert msg["bcc"] == "bcc@example.com"
+
+
+def test_send_email_passes_multiple_to_recipients(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection, email="sender@example.com")
+    client, service = _make_send_client(account.email)
+
+    send_email(
+        database_connection,
+        account=account,
+        gmail_client=client,
+        settings=make_test_settings(),
+        to="a@example.com,b@example.com",
+        subject="Group email",
+        body="Body",
+    )
+
+    from email import message_from_bytes
+
+    send_body = service.users.return_value.messages.return_value.send.call_args.kwargs[
+        "body"
+    ]
+    raw = base64.urlsafe_b64decode(send_body["raw"])
+    msg = message_from_bytes(raw)
+    assert msg["to"] == "a@example.com,b@example.com"


### PR DESCRIPTION
## Summary

- Add `reply_email` agent tool that auto-resolves recipient, subject, and `thread_id` from the original email ID — no cooldown check, replies always allowed
- Add CC and BCC support throughout the stack: `gmail.py` -> `sync.py` -> `agent/tools.py` -> `agent/invoke.py` -> `cli.py`
- Support multiple `--to` recipients in `email send` CLI command (repeatable flag)
- Enrich inbound trigger prompt with Email ID and sender address so the agent can invoke `reply_email`
- Remove `thread_id` from `send_email` tool (replies use dedicated `reply_email` instead); simplify cooldown guard
- Fix: `create_tasks_for_routed_emails` uses `e.created_at` (DB insert time) instead of `e.received_at` (Gmail timestamp) to avoid skipping emails synced after workflow creation

Resolves #59