### PR TITLE
feat(agent): auto-update workflow_contact status on email send

### DIFF
--- a/src/mailpilot/agent/tools.py
+++ b/src/mailpilot/agent/tools.py
@@ -37,6 +37,37 @@ from mailpilot.sync import send_email as sync_send_email
 _COOLDOWN_DAYS = 30
 
 
+def _activate_contact_if_pending(
+    connection: psycopg.Connection[dict[str, Any]],
+    workflow_id: str,
+    contact_id: str,
+) -> None:
+    """Transition workflow_contact from pending to active after successful send.
+
+    No-op if the workflow_contact row does not exist, or if the current status
+    is anything other than ``pending``.
+
+    Args:
+        connection: Open database connection.
+        workflow_id: Current workflow FK.
+        contact_id: Contact FK.
+    """
+    with logfire.span(
+        "agent.auto_activate_contact",
+        workflow_id=workflow_id,
+        contact_id=contact_id,
+    ):
+        wc = database.get_workflow_contact(connection, workflow_id, contact_id)
+        if wc is not None and wc.status == "pending":
+            database.update_workflow_contact(
+                connection,
+                workflow_id,
+                contact_id,
+                status="active",
+                reason="email sent",
+            )
+
+
 def send_email(  # noqa: PLR0913
     connection: psycopg.Connection[dict[str, Any]],
     account: Account,
@@ -115,6 +146,10 @@ def send_email(  # noqa: PLR0913
             cc=cc,
             bcc=bcc,
         )
+
+        if contact_id is not None:
+            _activate_contact_if_pending(connection, workflow_id, contact_id)
+
         return {
             "id": email.id,
             "gmail_message_id": email.gmail_message_id,
@@ -219,6 +254,9 @@ def reply_email(  # noqa: PLR0913
             cc=cc,
             bcc=bcc,
         )
+
+        _activate_contact_if_pending(connection, workflow_id, contact.id)
+
         return {
             "id": email.id,
             "gmail_message_id": email.gmail_message_id,

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -228,6 +228,104 @@ def test_send_email_passes_cc_and_bcc(
     assert call_kwargs["bcc"] == "bcc@example.com"
 
 
+def test_send_email_activates_pending_contact(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Successful send transitions workflow_contact from pending to active."""
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="recipient@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+    create_workflow_contact(database_connection, workflow.id, contact.id)
+    gmail_client = _make_gmail_client(account)
+
+    result = send_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        to="recipient@example.com",
+        subject="Hello",
+        body="Hi there",
+    )
+
+    assert "error" not in result
+    wc = get_workflow_contact(database_connection, workflow.id, contact.id)
+    assert wc is not None
+    assert wc.status == "active"
+    assert wc.reason == "email sent"
+
+
+def test_send_email_does_not_change_non_pending_status(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Send does not overwrite active/completed/failed status."""
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="recipient@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+    create_workflow_contact(database_connection, workflow.id, contact.id)
+    # Set to completed before send.
+    update_contact_status(
+        connection=database_connection,
+        workflow_id=workflow.id,
+        contact_id=contact.id,
+        status="completed",
+        reason="meeting booked",
+    )
+    gmail_client = _make_gmail_client(account)
+
+    result = send_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        to="recipient@example.com",
+        subject="Follow up",
+        body="Checking in",
+    )
+
+    assert "error" not in result
+    wc = get_workflow_contact(database_connection, workflow.id, contact.id)
+    assert wc is not None
+    assert wc.status == "completed"
+    assert wc.reason == "meeting booked"
+
+
+def test_send_email_no_error_without_workflow_contact(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Send succeeds even if contact has no workflow_contact row."""
+    account = make_test_account(database_connection)
+    make_test_contact(
+        database_connection, email="recipient@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+    # No create_workflow_contact call -- ad-hoc send.
+    gmail_client = _make_gmail_client(account)
+
+    result = send_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        to="recipient@example.com",
+        subject="Hello",
+        body="Hi",
+    )
+
+    assert "error" not in result
+    assert result["gmail_message_id"] == "gmail-msg-1"
+
+
 # -- reply_email ---------------------------------------------------------------
 
 
@@ -456,6 +554,138 @@ def test_reply_email_no_contact(
 
     assert result["error"] == "no_contact"
     gmail_client.send_message.assert_not_called()
+
+
+def test_reply_email_activates_pending_contact(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Successful reply transitions workflow_contact from pending to active."""
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="sender@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+    create_workflow_contact(database_connection, workflow.id, contact.id)
+
+    inbound = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Question",
+        contact_id=contact.id,
+        workflow_id=workflow.id,
+        gmail_message_id="inbound-activate",
+        gmail_thread_id="thread-activate",
+    )
+    assert inbound is not None
+
+    gmail_client = _make_gmail_client(account)
+
+    result = reply_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        email_id=inbound.id,
+        body="Here is the answer.",
+    )
+
+    assert "error" not in result
+    wc = get_workflow_contact(database_connection, workflow.id, contact.id)
+    assert wc is not None
+    assert wc.status == "active"
+    assert wc.reason == "email sent"
+
+
+def test_reply_email_does_not_change_non_pending_status(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Reply does not overwrite active/completed/failed status."""
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="sender@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+    create_workflow_contact(database_connection, workflow.id, contact.id)
+    update_contact_status(
+        connection=database_connection,
+        workflow_id=workflow.id,
+        contact_id=contact.id,
+        status="failed",
+        reason="no response",
+    )
+
+    inbound = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Late reply",
+        contact_id=contact.id,
+        workflow_id=workflow.id,
+        gmail_message_id="inbound-noop",
+        gmail_thread_id="thread-noop",
+    )
+    assert inbound is not None
+
+    gmail_client = _make_gmail_client(account)
+
+    result = reply_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        email_id=inbound.id,
+        body="Follow up.",
+    )
+
+    assert "error" not in result
+    wc = get_workflow_contact(database_connection, workflow.id, contact.id)
+    assert wc is not None
+    assert wc.status == "failed"
+    assert wc.reason == "no response"
+
+
+def test_reply_email_no_error_without_workflow_contact(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Reply succeeds even if contact has no workflow_contact row."""
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="sender@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+    # No create_workflow_contact -- ad-hoc reply.
+
+    inbound = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Ad hoc",
+        contact_id=contact.id,
+        gmail_message_id="inbound-adhoc",
+        gmail_thread_id="thread-adhoc",
+    )
+    assert inbound is not None
+
+    gmail_client = _make_gmail_client(account)
+
+    result = reply_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        email_id=inbound.id,
+        body="Quick reply.",
+    )
+
+    assert "error" not in result
+    assert result["gmail_message_id"] == "gmail-msg-1"
 
 
 # -- create_task ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Automatically transition `workflow_contact.status` from `pending` to `active` when `send_email` or `reply_email` succeed, instead of relying on the LLM agent to call `update_contact_status` explicitly.

- Add `_activate_contact_if_pending()` helper in `agent/tools.py` to handle the transition
- Call it from both `send_email` and `reply_email` after successful send
- No-op when contact is already `active`/`completed`/`failed` or has no workflow_contact row
- Logfire span for observability on automatic transitions
- `update_contact_status` tool remains for terminal states (`completed`, `failed`)

Resolves #67

## Test Plan

- [ ] Unit tests: `send_email` transitions `pending` -> `active`
- [ ] Unit tests: `reply_email` transitions `pending` -> `active`
- [ ] Unit tests: no transition when status is not `pending`
- [ ] Unit tests: no error when contact has no workflow_contact row
- [ ] Unit tests: existing `update_contact_status` tool still works
- [ ] `make check` passes (lint + types + tests)