### PR TITLE
perf(sync): skip historical email classification and batch Gmail fetches

### DIFF
--- a/src/mailpilot/gmail.py
+++ b/src/mailpilot/gmail.py
@@ -414,6 +414,85 @@ class GmailClient:
         )
         return result
 
+    _BATCH_SIZE = 100
+    """Maximum messages per ``new_batch_http_request()`` call."""
+
+    @_retry_on_transient
+    def get_messages_batch(
+        self,
+        message_ids: list[str],
+        user_id: str = "me",
+        format_: str = "full",
+    ) -> list[dict[str, Any]]:
+        """Fetch multiple messages in batched HTTP requests.
+
+        Uses ``new_batch_http_request()`` to multiplex up to 100 individual
+        gets into a single HTTP round-trip.  Deleted/404 messages are
+        silently skipped (same semantics as ``get_message`` returning None).
+
+        Args:
+            message_ids: Gmail message IDs to fetch.
+            user_id: Gmail user ID.
+            format_: Message format (full, metadata, minimal, raw).
+
+        Returns:
+            List of successfully fetched message dicts (order not guaranteed).
+        """
+        if not message_ids:
+            return []
+
+        results: list[dict[str, Any]] = []
+        failed_ids: list[str] = []
+        total_batches = (len(message_ids) + self._BATCH_SIZE - 1) // self._BATCH_SIZE
+
+        def _callback(
+            request_id: str,
+            response: dict[str, Any] | None,
+            exception: Exception | None,
+        ) -> None:
+            if exception is not None:
+                from googleapiclient.errors import HttpError
+
+                if isinstance(exception, HttpError) and exception.resp.status == 404:
+                    logfire.debug(
+                        "gmail message not found (deleted)",
+                        message_id=request_id,
+                    )
+                    return
+                logfire.warn(
+                    "gmail batch message error",
+                    message_id=request_id,
+                    error=str(exception),
+                )
+                failed_ids.append(request_id)
+                return
+            if response is not None:
+                results.append(response)
+
+        for batch_index, start in enumerate(
+            range(0, len(message_ids), self._BATCH_SIZE)
+        ):
+            chunk = message_ids[start : start + self._BATCH_SIZE]
+            with logfire.span(
+                "gmail.get_messages_batch.chunk",
+                count=len(chunk),
+                batch_index=batch_index,
+                total_batches=total_batches,
+                user_id=user_id,
+            ) as span:
+                batch = self._service.new_batch_http_request()
+                for msg_id in chunk:
+                    request = (
+                        self._service.users()
+                        .messages()
+                        .get(userId=user_id, id=msg_id, format=format_)
+                    )
+                    batch.add(request, callback=_callback, request_id=msg_id)
+                batch.execute()
+                span.set_attribute("failed_count", len(failed_ids))
+
+        return results
+
     def create_label_if_not_exists(
         self,
         label_name: str,

--- a/src/mailpilot/sync.py
+++ b/src/mailpilot/sync.py
@@ -191,19 +191,17 @@ def sync_account(
             message_ids, mode = _collect_new_message_ids(account, gmail_client)
             span.set_attribute("mode", mode)
             span.set_attribute("fetched_count", len(message_ids))
-            # Fetch message payloads once, skipping IDs already stored. We
-            # need the full message for sender parsing, text extraction, and
-            # the final insert, so caching here avoids a second Gmail fetch.
-            fresh_messages: list[dict[str, Any]] = []
+            # Filter out message IDs already stored, then batch-fetch the
+            # remaining payloads.  Scales with 1-2 HTTP round-trips instead
+            # of N individual get_message calls (#68).
+            new_ids: list[str] = []
             duplicate_skipped_count = 0
             for message_id in message_ids:
                 if get_email_by_gmail_message_id(connection, message_id) is not None:
                     duplicate_skipped_count += 1
-                    continue
-                message = gmail_client.get_message(message_id)
-                if message is None:
-                    continue
-                fresh_messages.append(message)
+                else:
+                    new_ids.append(message_id)
+            fresh_messages = gmail_client.get_messages_batch(new_ids)
             span.set_attribute("duplicate_skipped_count", duplicate_skipped_count)
             # Resolve every distinct sender in one pair of round-trips,
             # regardless of message count. Scales with unique senders, not
@@ -211,9 +209,19 @@ def sync_account(
             contacts_by_email = _resolve_contacts_for_messages(
                 connection, fresh_messages
             )
-            has_active_workflows = bool(
-                list_workflows(connection, account_id=account.id, status="active")
+            active_workflows = list_workflows(
+                connection, account_id=account.id, status="active"
             )
+            has_active_workflows = bool(active_workflows)
+            # Compute the earliest created_at among active inbound
+            # workflows. Emails received before this timestamp can never
+            # produce tasks (create_tasks_for_routed_emails filters on
+            # received_at >= w.created_at), so classifying them via LLM
+            # is pure waste.
+            inbound_created = [
+                w.created_at for w in active_workflows if w.type == "inbound"
+            ]
+            earliest_workflow_at = min(inbound_created) if inbound_created else None
             stored = 0
             for message in fresh_messages:
                 if (
@@ -224,6 +232,7 @@ def sync_account(
                         contacts_by_email,
                         settings,
                         has_active_workflows=has_active_workflows,
+                        earliest_workflow_at=earliest_workflow_at,
                     )
                     is None
                 ):
@@ -381,6 +390,7 @@ def _store_inbound_message(  # noqa: PLR0913
     settings: Settings,
     *,
     has_active_workflows: bool,
+    earliest_workflow_at: datetime | None = None,
 ) -> Email | None:
     """Persist a Gmail message as an inbound email and route when fresh.
 
@@ -423,7 +433,15 @@ def _store_inbound_message(  # noqa: PLR0913
         1,
         attributes={"within_recency_window": within_window},
     )
-    if within_window and has_active_workflows:
+    # Skip LLM classification for emails older than the earliest active
+    # inbound workflow -- they can never produce tasks and classifying
+    # them wastes tokens (#65).
+    predates_workflows = (
+        earliest_workflow_at is not None
+        and received_at is not None
+        and received_at < earliest_workflow_at
+    )
+    if within_window and has_active_workflows and not predates_workflows:
         email = route_email(
             connection, email, sender_email=sender_email, settings=settings
         )

--- a/tests/test_gmail_utils.py
+++ b/tests/test_gmail_utils.py
@@ -216,3 +216,171 @@ def test_resolve_credentials_path_missing(monkeypatch: pytest.MonkeyPatch):
         pytest.raises(SystemExit, match="No service account credentials"),
     ):
         gmail._resolve_credentials_path()  # pyright: ignore[reportPrivateUsage]
+
+
+# -- get_messages_batch --------------------------------------------------------
+
+
+def test_get_messages_batch_returns_fetched_messages():
+    from unittest.mock import MagicMock
+
+    from mailpilot.gmail import GmailClient
+
+    service = MagicMock()
+    client = GmailClient.from_service("test@example.com", service)
+
+    msg1 = {"id": "m1", "threadId": "t1", "payload": {}}
+    msg2 = {"id": "m2", "threadId": "t2", "payload": {}}
+
+    # Simulate new_batch_http_request: capture callbacks, invoke them.
+    callbacks: list[tuple[str, object, object]] = []
+
+    def fake_add(request: object, callback: object, request_id: str) -> None:
+        callbacks.append((request_id, request, callback))
+
+    batch = MagicMock()
+    batch.add = fake_add
+
+    def fake_execute() -> None:
+        for request_id, _request, callback in callbacks:
+            data = msg1 if request_id == "m1" else msg2
+            callback(request_id, data, None)  # type: ignore[operator]
+
+    batch.execute = fake_execute
+    service.new_batch_http_request.return_value = batch
+
+    results = client.get_messages_batch(["m1", "m2"])
+
+    assert len(results) == 2
+    assert results[0]["id"] == "m1"
+    assert results[1]["id"] == "m2"
+
+
+def test_get_messages_batch_skips_404_errors():
+    from unittest.mock import MagicMock
+
+    from googleapiclient.errors import HttpError
+
+    from mailpilot.gmail import GmailClient
+
+    service = MagicMock()
+    client = GmailClient.from_service("test@example.com", service)
+
+    msg1 = {"id": "m1", "threadId": "t1", "payload": {}}
+    resp_404 = MagicMock()
+    resp_404.status = 404
+    error_404 = HttpError(resp=resp_404, content=b"Not Found")
+
+    callbacks: list[tuple[str, object, object]] = []
+
+    def fake_add(request: object, callback: object, request_id: str) -> None:
+        callbacks.append((request_id, request, callback))
+
+    batch = MagicMock()
+    batch.add = fake_add
+
+    def fake_execute() -> None:
+        for request_id, _request, callback in callbacks:
+            if request_id == "m1":
+                callback(request_id, msg1, None)  # type: ignore[operator]
+            else:
+                callback(request_id, None, error_404)  # type: ignore[operator]
+
+    batch.execute = fake_execute
+    service.new_batch_http_request.return_value = batch
+
+    results = client.get_messages_batch(["m1", "m2"])
+
+    assert len(results) == 1
+    assert results[0]["id"] == "m1"
+
+
+def test_get_messages_batch_empty_list():
+    from unittest.mock import MagicMock
+
+    from mailpilot.gmail import GmailClient
+
+    service = MagicMock()
+    client = GmailClient.from_service("test@example.com", service)
+
+    results = client.get_messages_batch([])
+
+    assert results == []
+    service.new_batch_http_request.assert_not_called()
+
+
+def test_get_messages_batch_skips_non_404_errors():
+    from unittest.mock import MagicMock
+
+    from googleapiclient.errors import HttpError
+
+    from mailpilot.gmail import GmailClient
+
+    service = MagicMock()
+    client = GmailClient.from_service("test@example.com", service)
+
+    msg1 = {"id": "m1", "threadId": "t1", "payload": {}}
+    resp_403 = MagicMock()
+    resp_403.status = 403
+    error_403 = HttpError(resp=resp_403, content=b"Forbidden")
+
+    callbacks: list[tuple[str, object, object]] = []
+
+    def fake_add(request: object, callback: object, request_id: str) -> None:
+        callbacks.append((request_id, request, callback))
+
+    batch = MagicMock()
+    batch.add = fake_add
+
+    def fake_execute() -> None:
+        for request_id, _request, callback in callbacks:
+            if request_id == "m1":
+                callback(request_id, msg1, None)  # type: ignore[operator]
+            else:
+                callback(request_id, None, error_403)  # type: ignore[operator]
+
+    batch.execute = fake_execute
+    service.new_batch_http_request.return_value = batch
+
+    results = client.get_messages_batch(["m1", "m2"])
+
+    assert len(results) == 1
+    assert results[0]["id"] == "m1"
+
+
+def test_get_messages_batch_chunks_large_lists():
+    from unittest.mock import MagicMock
+
+    from mailpilot.gmail import GmailClient
+
+    service = MagicMock()
+    client = GmailClient.from_service("test@example.com", service)
+
+    # 150 message IDs -> should produce 2 batches (100 + 50).
+    message_ids = [f"m{i}" for i in range(150)]
+
+    batch_execute_count = 0
+
+    def make_batch() -> MagicMock:
+        batch_callbacks: list[tuple[str, object, object]] = []
+
+        def fake_add(request: object, callback: object, request_id: str) -> None:
+            batch_callbacks.append((request_id, request, callback))
+
+        def fake_execute() -> None:
+            nonlocal batch_execute_count
+            batch_execute_count += 1
+            for request_id, _request, callback in batch_callbacks:
+                callback(request_id, {"id": request_id, "payload": {}}, None)  # type: ignore[operator]
+
+        batch = MagicMock()
+        batch.add = fake_add
+        batch.execute = fake_execute
+        return batch
+
+    service.new_batch_http_request.side_effect = [make_batch(), make_batch()]
+
+    results = client.get_messages_batch(message_ids)
+
+    assert len(results) == 150
+    assert batch_execute_count == 2

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -154,10 +154,31 @@ def _set_list_messages(service: MagicMock, stubs: list[dict[str, str]]) -> None:
     }
 
 
-def _set_get_messages(
-    service: MagicMock, messages: list[dict[str, Any] | None]
-) -> None:
-    service.users.return_value.messages.return_value.get.return_value.execute.side_effect = messages
+def _set_get_messages(service: MagicMock, messages: list[dict[str, Any]]) -> None:
+    """Mock get_messages_batch by simulating new_batch_http_request.
+
+    Builds an id-keyed lookup from the supplied messages so the batch
+    callback returns the right payload for each request_id.
+    """
+    by_id: dict[str, dict[str, Any]] = {m["id"]: m for m in messages}
+
+    def _make_batch() -> MagicMock:
+        callbacks: list[tuple[str, object, object]] = []
+
+        def fake_add(request: object, callback: object, request_id: str) -> None:
+            callbacks.append((request_id, request, callback))
+
+        def fake_execute() -> None:
+            for request_id, _request, callback in callbacks:
+                data = by_id.get(request_id)
+                callback(request_id, data, None)  # type: ignore[operator]
+
+        batch = MagicMock()
+        batch.add = fake_add
+        batch.execute = fake_execute
+        return batch
+
+    service.new_batch_http_request.side_effect = _make_batch
 
 
 def _set_history(
@@ -269,13 +290,14 @@ def test_sync_account_skips_duplicate_messages(
     )
     client, service = _make_mock_client(account.email)
     _set_list_messages(service, [{"id": "m1", "threadId": "t1"}])
-    # get_message should NOT be called for the duplicate; supply nothing.
+    # Duplicate filtered before batch fetch; supply no batch messages.
     _set_get_messages(service, [])
 
     stored = sync_account(database_connection, account, client, make_test_settings())
 
     assert stored == 0
-    service.users.return_value.messages.return_value.get.assert_not_called()
+    # All IDs were duplicates -> batch fetch receives empty list -> no HTTP call.
+    service.new_batch_http_request.assert_not_called()
 
 
 def test_sync_account_recency_gate_marks_old_messages_routed(
@@ -334,6 +356,68 @@ def test_sync_account_skips_routing_when_no_active_workflows(
     assert email is not None
     assert email.is_routed is True
     assert email.workflow_id is None
+
+
+def test_sync_account_skips_classification_for_emails_before_earliest_workflow(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Emails older than the earliest active workflow skip LLM classification."""
+    from unittest.mock import patch
+
+    from mailpilot.database import activate_workflow, update_workflow
+
+    account = make_test_account(database_connection, email="hist@example.com")
+    workflow = make_test_workflow(
+        database_connection, account_id=account.id, workflow_type="inbound"
+    )
+    update_workflow(
+        database_connection,
+        workflow.id,
+        objective="Handle inquiries",
+        instructions="Reply helpfully",
+    )
+    activate_workflow(database_connection, workflow.id)
+
+    client, service = _make_mock_client(account.email)
+    # Email received 2 days ago (within 7-day recency window) but 1 hour
+    # before the workflow was created -- should skip classification.
+    email_time = workflow.created_at - timedelta(hours=1)
+    _set_list_messages(service, [{"id": "pre-wf", "threadId": "t-pre-wf"}])
+    _set_get_messages(
+        service,
+        [_make_gmail_message("pre-wf", "t-pre-wf", received_at=email_time)],
+    )
+
+    with patch("mailpilot.sync.route_email") as mock_route:
+        stored = sync_account(
+            database_connection, account, client, make_test_settings()
+        )
+
+    assert stored == 1
+    mock_route.assert_not_called()
+    email = get_email_by_gmail_message_id(database_connection, "pre-wf")
+    assert email is not None
+    assert email.is_routed is True
+    assert email.workflow_id is None
+
+
+def test_sync_account_uses_batch_fetch(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """sync_account fetches messages via get_messages_batch, not get_message."""
+    account = make_test_account(database_connection, email="batch@example.com")
+    client, service = _make_mock_client(account.email)
+    stubs = [{"id": f"m{i}", "threadId": f"t{i}"} for i in range(3)]
+    _set_list_messages(service, stubs)
+    _set_get_messages(
+        service, [_make_gmail_message(f"m{i}", f"t{i}") for i in range(3)]
+    )
+
+    stored = sync_account(database_connection, account, client, make_test_settings())
+
+    assert stored == 3
+    # Batch method must have been used, not per-message get.
+    service.new_batch_http_request.assert_called()
 
 
 def test_sync_account_auto_creates_contact_only_once(


### PR DESCRIPTION
## Summary

- Skip LLM classification for inbound emails older than the earliest active workflow, eliminating wasted token spend on emails that can never produce tasks
- Batch Gmail message fetches via `new_batch_http_request()` to reduce HTTP round-trips and consolidate noisy per-message spans

Resolves #65
Resolves #68

## Test plan

- [ ] Emails with `received_at` before earliest active workflow are marked routed without LLM call
- [ ] Thread matching still works for old emails in active workflow threads
- [ ] Batch fetch handles deleted/404 messages gracefully
- [ ] Full sync produces 1-2 batch spans instead of N individual spans
- [ ] `make check` passes