### PR TITLE
feat(cli): support inbound workflows in `workflow run`

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -119,6 +119,8 @@ Note: Are span attributes sufficient to debug a failure without reading code? Is
 
 **Why this works:** The inbound workflow was created in Phase 0 before the outbound agent sent the email in Phase 1. The email's `received_at` timestamp is after the workflow's `created_at`, so the `predates_workflows` check passes and LLM classification runs.
 
+**Old messages from prior tests.** Email messages are never deleted from Gmail -- `make clean` only resets the database, not the mailboxes. Sync will store messages from prior smoke test runs alongside the current run's email. This is expected and intentional: old messages exercise the routing flow (they should route as `unrouted` or `thread_match` to prior workflows that no longer exist in the DB). Use the `--since` filter and unique `[ST-HHMMSS]` subject prefix to isolate the current run's email from prior test messages.
+
 1. Enroll the outbound contact in the inbound workflow:
    ```
    mailpilot workflow contact add --workflow-id <INBOUND_WORKFLOW_ID> --contact-id <OUTBOUND_CONTACT_ID>
@@ -207,6 +209,8 @@ Note: Is the task lifecycle (create -> execute -> complete) fully traceable from
 - Note whether the reply `thread_id` matches the original outbound email's `thread_id`. Gmail assigns different thread IDs per account, so a mismatch here is expected Gmail behavior, not a bug.
 
 **On failure:** Report "reply not received after 3 sync attempts." Phases 1-3 passed, so this is a delivery or sync issue on the return path.
+
+**Expected: old messages route as `unrouted`.** The outbound account sync will store messages from prior smoke test runs. These old messages will appear as `unrouted` in routing spans because their original workflows no longer exist in the clean database. This is correct behavior -- the routing flow correctly identifies them as unroutable. Do not flag these as deficiencies in the report.
 
 ### Logfire: Phase 4
 

--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -19,7 +19,9 @@ All commands below use `uv run mailpilot`. Parse JSON output from every command 
 
 ## Phase 0: Clean Slate
 
-**Goal:** Deterministic starting state.
+**Goal:** Deterministic starting state with all entities and both workflows created upfront.
+
+**Why workflows are created here:** The `predates_workflows` optimization in sync skips LLM classification for emails whose `received_at` predates the inbound workflow's `created_at`. Creating the inbound workflow before the outbound agent sends the email guarantees the email's `received_at` will be after the workflow's `created_at`, so routing works correctly.
 
 1. Run `make clean` to drop and re-apply the schema.
 2. Create accounts:
@@ -39,12 +41,33 @@ All commands below use `uv run mailpilot`. Parse JSON output from every command 
    mailpilot contact create --email outbound@lab5.ca --first-name Outbound --last-name Smoke --company-id <COMPANY_ID>
    ```
    Save both contact IDs. The "inbound contact" is the recipient of outbound email. The "outbound contact" lets the inbound workflow track the sender.
+5. Create outbound workflow (creates in `active` status automatically -- no separate `start` needed):
+   ```
+   mailpilot workflow create \
+     --name "Outbound Smoke Test" \
+     --type outbound \
+     --account-id <OUTBOUND_ACCOUNT_ID> \
+     --objective "Send an email to the contact about <RANDOM_TOPIC>" \
+     --instructions "You are a sales representative for Lab5. Send a brief email to the contact about <RANDOM_TOPIC>. Keep it under 3 sentences. Subject line MUST be exactly '<SUBJECT>' (the unique subject you generated for this run). Do not create follow-up tasks."
+   ```
+   Replace `<SUBJECT>` and `<RANDOM_TOPIC>` with the unique subject and topic you invented for this run. Save the workflow ID.
+6. Create inbound workflow:
+   ```
+   mailpilot workflow create \
+     --name "Inbound Smoke Test" \
+     --type inbound \
+     --account-id <INBOUND_ACCOUNT_ID> \
+     --objective "Respond to incoming emails professionally" \
+     --instructions "You are a professional assistant for Lab5. Reply to the incoming email about the same topic they raised, acknowledging receipt and expressing interest. Keep it under 3 sentences. Subject line must preserve the existing thread subject exactly. Do not create follow-up tasks."
+   ```
+   Save the workflow ID.
 
 ### Gate 0
 
 - `mailpilot account list` returns exactly 2 accounts.
 - `mailpilot contact list` returns exactly 2 contacts.
 - `mailpilot company list` returns exactly 1 company.
+- `mailpilot workflow list` returns exactly 2 workflows (both `active`).
 
 **On failure:** Stop. Report which entity failed to create and the error message.
 
@@ -58,21 +81,11 @@ Query spans for `db.status.counts` and any errors. Note whether entity creation 
 
 **Goal:** The outbound agent composes and sends an email from `outbound@lab5.ca` to `inbound@lab5.ca`.
 
-1. Create outbound workflow (creates in `active` status automatically -- no separate `start` needed):
-   ```
-   mailpilot workflow create \
-     --name "Outbound Smoke Test" \
-     --type outbound \
-     --account-id <OUTBOUND_ACCOUNT_ID> \
-     --objective "Send an email to the contact about <RANDOM_TOPIC>" \
-     --instructions "You are a sales representative for Lab5. Send a brief email to the contact about <RANDOM_TOPIC>. Keep it under 3 sentences. Subject line MUST be exactly '<SUBJECT>' (the unique subject you generated for this run). Do not create follow-up tasks."
-   ```
-   Replace `<SUBJECT>` and `<RANDOM_TOPIC>` with the unique subject and topic you invented for this run. Save the workflow ID.
-2. Enroll the inbound contact:
+1. Enroll the inbound contact in the outbound workflow:
    ```
    mailpilot workflow contact add --workflow-id <OUTBOUND_WORKFLOW_ID> --contact-id <INBOUND_CONTACT_ID>
    ```
-3. Run the agent:
+2. Run the agent:
    ```
    mailpilot workflow run --workflow-id <OUTBOUND_WORKFLOW_ID> --contact-id <INBOUND_CONTACT_ID>
    ```
@@ -100,22 +113,16 @@ Note: Are span attributes sufficient to debug a failure without reading code? Is
 
 ---
 
-## Phase 2: Inbound Workflow Setup + Sync + Routing
+## Phase 2: Inbound Sync + Routing
 
-**Goal:** Create the inbound workflow before syncing so the LLM classifier can route the email, then sync and verify routing.
+**Goal:** Sync the inbound account and verify the email is routed to the inbound workflow.
 
-**Why this ordering matters:** `route_email` during sync classifies emails against active workflows only. If no active inbound workflow exists at sync time, the email is stored as unrouted (`workflow_id=NULL`) and will never be bridged to a task.
+**Why this works:** The inbound workflow was created in Phase 0 before the outbound agent sent the email in Phase 1. The email's `received_at` timestamp is after the workflow's `created_at`, so the `predates_workflows` check passes and LLM classification runs.
 
-1. Create inbound workflow (creates in `active` status automatically -- no separate `start` needed):
+1. Enroll the outbound contact in the inbound workflow:
    ```
-   mailpilot workflow create \
-     --name "Inbound Smoke Test" \
-     --type inbound \
-     --account-id <INBOUND_ACCOUNT_ID> \
-     --objective "Respond to incoming emails professionally" \
-     --instructions "You are a professional assistant for Lab5. Reply to the incoming email about the same topic they raised, acknowledging receipt and expressing interest. Keep it under 3 sentences. Subject line must preserve the existing thread subject exactly. Do not create follow-up tasks."
+   mailpilot workflow contact add --workflow-id <INBOUND_WORKFLOW_ID> --contact-id <OUTBOUND_CONTACT_ID>
    ```
-   Save the workflow ID.
 2. **Time-boxed sync retry loop** (up to 3 attempts, 15 seconds apart):
    ```
    mailpilot account sync --account-id <INBOUND_ACCOUNT_ID>
@@ -152,46 +159,34 @@ Note: Can you reconstruct the full sync-to-route pipeline from spans alone? What
 
 ## Phase 3: Inbound Agent Response
 
-**Goal:** The execution loop bridges the routed email to a task and the inbound agent sends a reply.
+**Goal:** The inbound agent replies to the routed email.
 
-1. Set a short run interval:
+1. Run the inbound agent directly:
    ```
-   mailpilot config set run_interval 5
+   mailpilot workflow run --workflow-id <INBOUND_WORKFLOW_ID> --contact-id <OUTBOUND_CONTACT_ID>
    ```
-2. Run the execution loop with a timeout (30 seconds is enough for multiple iterations):
-   ```
-   timeout 30 mailpilot run
-   ```
-   This command will exit with code 124 (timeout) -- that is expected and not an error.
-3. Restore the default run interval:
-   ```
-   mailpilot config set run_interval 30
-   ```
-
-**Note:** Unlike outbound (`workflow run`), inbound agent invocation only happens through the execution loop (`mailpilot run`). The loop syncs accounts, bridges routed emails to tasks via `create_tasks_for_routed_emails`, and executes pending tasks.
+   This uses the `workflow run` inbound support to find the unprocessed inbound email via `get_unprocessed_inbound_email`, create a task with the email attached, and execute the agent.
 
 ### Gate 3
 
-- `mailpilot task list --workflow-id <INBOUND_WORKFLOW_ID>` shows at least 1 task with `"status": "completed"`.
+- The `workflow run` output shows `"status": "completed"` and `"tool_calls"` >= 1.
+- The task has `email_id` set (the unprocessed email was found and attached).
 - `mailpilot email list --account-id <INBOUND_ACCOUNT_ID> --direction outbound` shows at least 1 reply email.
-- Note the reply email's `thread_id`. **Known limitation:** the `send_email` agent tool currently cannot reply in-thread (no `thread_id` / `In-Reply-To` / `References` support), so the reply will be sent as a new Gmail thread. Record the mismatch but do not fail the gate on this.
-- Note how many total tasks were created. **Known issue:** `create_tasks_for_routed_emails` may bridge old historical emails to tasks (not just the smoke test email). Record the count of stale pending tasks.
+- The reply email's `thread_id` matches the inbound email's `thread_id` (agent used `reply_email` to reply in-thread).
 
-**On failure:** Stop. Check `mailpilot task list --workflow-id <INBOUND_WORKFLOW_ID> --status failed` for agent errors. If no tasks exist at all, the email-to-task bridge did not fire -- verify the email has `workflow_id` set via `mailpilot email view <EMAIL_ID>`.
+**On failure:** Stop. Check the `workflow run` output for errors. If `email_id` is null, the email was not found by `get_unprocessed_inbound_email` -- verify the email has `workflow_id` set via `mailpilot email view <EMAIL_ID>` and that the contact is enrolled in the workflow.
 
 ### Logfire: Phase 3
 
 Query for these span families and review:
 
-- `run.loop.iteration` -- How many iterations ran? Duration of each.
 - `run.execute_task` -- Task execution: `task_id`, `workflow_id`, `contact_id`. Did it complete or fail?
 - `agent.invoke` -- Inbound agent invocation: `trigger` should be `email`. Check `tool_call_count`, `agent_reasoning`, token usage.
-- `agent.tool.send_email` -- Reply sent: check `to`. Note: `thread_id` will be missing (known limitation -- `send_email` does not support in-thread replies yet).
+- `agent.tool.reply_email` -- Reply sent: check `email_id`, `workflow_id`. Verify the agent used `reply_email` (in-thread) rather than `send_email` (new thread).
 - `agent.tool.update_contact_status` -- Did the agent update the contact's workflow status?
 - `agent.tool.noop` -- If called, why? The agent should have replied, not nooped.
-- `run.sync.account_failed` -- Any sync errors during the loop?
 
-Note: Is the task lifecycle (bridge -> execute -> complete) fully traceable from spans? Are error paths well-instrumented?
+Note: Is the task lifecycle (create -> execute -> complete) fully traceable from spans? Are error paths well-instrumented?
 
 ---
 
@@ -209,7 +204,7 @@ Note: Is the task lifecycle (bridge -> execute -> complete) fully traceable from
 ### Gate 4
 
 - The reply email appears in `email list` for the outbound account matching the unique subject.
-- Note whether the reply `thread_id` matches the original outbound email's `thread_id`. **Expected mismatch** due to the same `send_email` threading limitation noted in Gate 3.
+- Note whether the reply `thread_id` matches the original outbound email's `thread_id`. Gmail assigns different thread IDs per account, so a mismatch here is expected Gmail behavior, not a bug.
 
 **On failure:** Report "reply not received after 3 sync attempts." Phases 1-3 passed, so this is a delivery or sync issue on the return path.
 
@@ -245,12 +240,12 @@ Entities:
 Emails:
   Outbound sent:     <id> | subject: <unique subject>
   Inbound received:  <id> | routed to: <inbound_workflow_id>
-  Inbound reply:     <id> | thread: <thread_id> (MISMATCH expected)
-  Outbound received: <id> | thread: <thread_id> (MISMATCH expected)
+  Inbound reply:     <id> | thread: <thread_id> (in-thread via reply_email)
+  Outbound received: <id> | thread: <thread_id>
 
 Tasks:
   Outbound task: <id> (completed)
-  Inbound task:  <id> (completed)
+  Inbound task:  <id> (completed, email_id set)
 
 All data left in database for inspection.
 ```
@@ -370,9 +365,9 @@ Before running this smoke test, verify:
 
 Expected total duration: 2-3 minutes.
 
-- Phase 0: ~5 seconds
-- Phase 1: ~10 seconds
+- Phase 0: ~10 seconds (entities + workflows)
+- Phase 1: ~10 seconds (outbound agent)
 - Phase 2: ~15-60 seconds (Gmail delivery + sync retries)
-- Phase 3: ~30 seconds (execution loop timeout)
+- Phase 3: ~10 seconds (inbound agent via workflow run)
 - Phase 4: ~15-60 seconds (reply delivery + sync retries)
 - Phase 5: ~1 second

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 **/__pycache__/
-.venv/
-.env
 *.egg-info/
+.claude/ralph-loop.local.md
+.env
+.firecrawl/
+.superpowers/
+.venv/
 build/
 dist/
-.claude/ralph-loop.local.md
-.firecrawl/

--- a/docs/superpowers/plans/2026-04-23-html-email.md
+++ b/docs/superpowers/plans/2026-04-23-html-email.md
@@ -1,0 +1,1286 @@
+# HTML Email Rendering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert agent-generated Markdown email bodies into themed HTML emails with tables, readable fonts, and workflow-based color schemes.
+
+**Architecture:** `sync.send_email()` converts Markdown to HTML via a custom mistune renderer with inline styles, strips Markdown to plain text for DB storage, and sends `multipart/alternative` MIME. `GmailClient.send_message()` changes to accept a pre-built MIME message. A `theme` column on the workflow table selects one of 6 predefined color palettes.
+
+**Tech Stack:** mistune (Markdown parser), Python email.mime (MIME construction), dataclasses (EmailTheme)
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/mailpilot/email_renderer.py` | Create | `EmailTheme`, `THEMES`, `EmailRenderer`, `PlainTextRenderer`, `render_email_html()`, `strip_markdown()` |
+| `tests/test_email_renderer.py` | Create | Unit tests for rendering and stripping |
+| `src/mailpilot/schema.sql` | Modify | Add `theme` column to `workflow` table |
+| `src/mailpilot/models.py` | Modify | Add `theme` field to `Workflow` model |
+| `src/mailpilot/database.py` | Modify | Accept `theme` in `create_workflow()` and `update_workflow()` |
+| `tests/test_cli.py` | Modify | Update workflow create/update tests for `--theme` |
+| `src/mailpilot/cli.py` | Modify | Add `--theme` option to workflow create/update |
+| `src/mailpilot/gmail.py` | Modify | Change `send_message()` to accept `MIMEBase` |
+| `tests/test_sync.py` | Modify | Update all `send_email` tests for MIME changes |
+| `src/mailpilot/sync.py` | Modify | Build multipart MIME, render HTML, strip to plain text |
+| `tests/test_agent_tools.py` | Modify | Verify agent tools pass body correctly through new pipeline |
+
+---
+
+### Task 1: Add mistune dependency
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Add mistune to dependencies**
+
+```toml
+# In [project] dependencies, add after the last entry:
+    "mistune>=3.1.0,<4.0.0",
+```
+
+- [ ] **Step 2: Install and verify**
+
+Run: `uv sync`
+Expected: Clean install, no conflicts.
+
+Run: `uv run python -c "import mistune; print(mistune.__version__)"`
+Expected: Prints version >= 3.1.0
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "chore: add mistune dependency for Markdown email rendering"
+```
+
+---
+
+### Task 2: EmailTheme and renderers
+
+**Files:**
+- Create: `src/mailpilot/email_renderer.py`
+- Create: `tests/test_email_renderer.py`
+
+- [ ] **Step 1: Write failing tests for EmailTheme and THEMES**
+
+```python
+# tests/test_email_renderer.py
+"""Tests for Markdown-to-HTML email rendering."""
+
+from mailpilot.email_renderer import (
+    EmailTheme,
+    THEMES,
+    get_theme,
+)
+
+
+def test_themes_contains_six_palettes():
+    assert len(THEMES) == 6
+    assert set(THEMES.keys()) == {"blue", "green", "orange", "purple", "red", "slate"}
+
+
+def test_each_theme_has_three_hex_colors():
+    for name, theme in THEMES.items():
+        for field in ("primary", "accent", "border"):
+            value = getattr(theme, field)
+            assert value.startswith("#"), f"{name}.{field} = {value}"
+            assert len(value) == 7, f"{name}.{field} = {value}"
+
+
+def test_get_theme_returns_named_theme():
+    theme = get_theme("green")
+    assert theme.primary == "#16a34a"
+
+
+def test_get_theme_falls_back_to_blue():
+    theme = get_theme("nonexistent")
+    assert theme == THEMES["blue"]
+
+
+def test_get_theme_none_falls_back_to_blue():
+    theme = get_theme(None)
+    assert theme == THEMES["blue"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_email_renderer.py -v`
+Expected: FAIL with import errors.
+
+- [ ] **Step 3: Implement EmailTheme and THEMES**
+
+```python
+# src/mailpilot/email_renderer.py
+"""Markdown-to-HTML email rendering with inline styles and theme support."""
+
+from __future__ import annotations
+
+import dataclasses
+
+
+@dataclasses.dataclass(frozen=True)
+class EmailTheme:
+    """Color palette for themed email rendering."""
+
+    primary: str  # headings, links
+    accent: str  # table header background
+    border: str  # table/hr borders
+
+
+THEMES: dict[str, EmailTheme] = {
+    "blue": EmailTheme(primary="#2563eb", accent="#dbeafe", border="#bfdbfe"),
+    "green": EmailTheme(primary="#16a34a", accent="#dcfce7", border="#bbf7d0"),
+    "orange": EmailTheme(primary="#ea580c", accent="#ffedd5", border="#fed7aa"),
+    "purple": EmailTheme(primary="#7c3aed", accent="#ede9fe", border="#ddd6fe"),
+    "red": EmailTheme(primary="#dc2626", accent="#fee2e2", border="#fecaca"),
+    "slate": EmailTheme(primary="#475569", accent="#f1f5f9", border="#e2e8f0"),
+}
+
+THEME_NAMES: set[str] = set(THEMES.keys())
+
+DEFAULT_THEME = "blue"
+
+
+def get_theme(name: str | None) -> EmailTheme:
+    """Look up a theme by name, falling back to blue."""
+    if name is None:
+        return THEMES[DEFAULT_THEME]
+    return THEMES.get(name, THEMES[DEFAULT_THEME])
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_email_renderer.py -v`
+Expected: All PASS.
+
+- [ ] **Step 5: Write failing tests for EmailRenderer (render_email_html)**
+
+Add to `tests/test_email_renderer.py`:
+
+```python
+from mailpilot.email_renderer import render_email_html
+
+
+def test_render_wraps_in_container_div():
+    html = render_email_html("Hello", get_theme("blue"))
+    assert html.startswith('<div style="')
+    assert "max-width:600px" in html
+    assert html.endswith("</div>")
+
+
+def test_render_heading_uses_primary_color():
+    theme = get_theme("blue")
+    html = render_email_html("## Title", theme)
+    assert f"color:{theme.primary}" in html
+    assert "<h2" in html
+    assert "Title" in html
+
+
+def test_render_paragraph_uses_body_styles():
+    html = render_email_html("Hello world", get_theme("blue"))
+    assert "<p" in html
+    assert "font-size:16px" in html
+
+
+def test_render_table_with_themed_headers():
+    md = "| Model | Flow |\n|-------|------|\n| WS48 | 150 |"
+    theme = get_theme("green")
+    html = render_email_html(md, theme)
+    assert "<table" in html
+    assert "<th" in html
+    assert f"background-color:{theme.accent}" in html
+    assert "WS48" in html
+    assert "150" in html
+
+
+def test_render_link_uses_primary_color():
+    theme = get_theme("orange")
+    html = render_email_html("[Lab5](https://lab5.ca)", theme)
+    assert f"color:{theme.primary}" in html
+    assert 'href="https://lab5.ca"' in html
+
+
+def test_render_bold_and_italic():
+    html = render_email_html("**bold** and *italic*", get_theme("blue"))
+    assert "<strong>" in html
+    assert "<em>" in html
+
+
+def test_render_unordered_list():
+    html = render_email_html("- one\n- two", get_theme("blue"))
+    assert "<ul" in html
+    assert "<li" in html
+
+
+def test_render_ordered_list():
+    html = render_email_html("1. first\n2. second", get_theme("blue"))
+    assert "<ol" in html
+
+
+def test_render_horizontal_rule():
+    theme = get_theme("blue")
+    html = render_email_html("---", theme)
+    assert "<hr" in html
+    assert f"border-top:1px solid {theme.border}" in html
+
+
+def test_render_inline_code():
+    html = render_email_html("Use `cmd` here", get_theme("blue"))
+    assert "<code" in html
+    assert "cmd" in html
+```
+
+- [ ] **Step 6: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_email_renderer.py -v`
+Expected: FAIL with `ImportError` for `render_email_html`.
+
+- [ ] **Step 7: Implement EmailRenderer and render_email_html**
+
+Add to `src/mailpilot/email_renderer.py`:
+
+```python
+import mistune
+
+
+class EmailRenderer(mistune.HTMLRenderer):  # type: ignore[misc]
+    """Custom HTML renderer that injects inline styles for email clients."""
+
+    def __init__(self, theme: EmailTheme) -> None:
+        super().__init__()
+        self.theme = theme
+
+    def heading(self, text: str, level: int, **attrs: object) -> str:
+        sizes = {1: "24px", 2: "20px", 3: "18px"}
+        size = sizes.get(level, "16px")
+        color = self.theme.primary if level <= 3 else "#333333"
+        style = (
+            f"color:{color}; font-size:{size}; font-weight:bold; "
+            f"line-height:1.3; margin:16px 0 8px 0"
+        )
+        return f'<h{level} style="{style}">{text}</h{level}>\n'
+
+    def paragraph(self, text: str) -> str:
+        style = "font-size:16px; line-height:1.5; color:#333333; margin:0 0 16px 0"
+        return f'<p style="{style}">{text}</p>\n'
+
+    def link(self, text: str, url: str, title: str | None = None) -> str:
+        style = f"color:{self.theme.primary}; text-decoration:underline"
+        title_attr = f' title="{title}"' if title else ""
+        return f'<a href="{url}" style="{style}"{title_attr}>{text}</a>'
+
+    def strong(self, text: str) -> str:
+        return f"<strong>{text}</strong>"
+
+    def emphasis(self, text: str) -> str:
+        return f"<em>{text}</em>"
+
+    def codespan(self, text: str) -> str:
+        style = (
+            "background-color:#f3f4f6; padding:2px 6px; border-radius:3px; "
+            "font-family:'Courier New',Courier,monospace; font-size:14px"
+        )
+        return f'<code style="{style}">{text}</code>'
+
+    def thematic_break(self) -> str:
+        style = (
+            f"border:none; border-top:1px solid {self.theme.border}; "
+            f"margin:24px 0"
+        )
+        return f'<hr style="{style}">\n'
+
+    def list(self, text: str, ordered: bool, **attrs: object) -> str:
+        tag = "ol" if ordered else "ul"
+        style = "padding-left:24px; margin:0 0 16px 0; font-size:16px; line-height:1.5; color:#333333"
+        return f'<{tag} style="{style}">{text}</{tag}>\n'
+
+    def list_item(self, text: str, **attrs: object) -> str:
+        return f'<li style="margin:4px 0">{text}</li>\n'
+
+    def table(self, text: str) -> str:
+        style = "width:100%; border-collapse:collapse; font-size:14px; margin:0 0 16px 0"
+        return f'<table style="{style}">{text}</table>\n'
+
+    def table_head(self, text: str) -> str:
+        return f"<thead>{text}</thead>\n"
+
+    def table_body(self, text: str) -> str:
+        return f"<tbody>{text}</tbody>\n"
+
+    def table_row(self, text: str) -> str:
+        return f"<tr>{text}</tr>\n"
+
+    def table_cell(
+        self, text: str, head: bool = False, align: str | None = None, **attrs: object
+    ) -> str:
+        tag = "th" if head else "td"
+        text_align = f"text-align:{align}; " if align else "text-align:left; "
+        if head:
+            style = (
+                f"background-color:{self.theme.accent}; color:#1a1a1a; "
+                f"font-weight:bold; padding:8px 12px; {text_align}"
+                f"border-bottom:2px solid {self.theme.border}"
+            )
+        else:
+            style = (
+                f"padding:8px 12px; {text_align}"
+                f"border-bottom:1px solid {self.theme.border}"
+            )
+        return f'<{tag} style="{style}">{text}</{tag}>\n'
+
+
+_CONTAINER_STYLE = (
+    "font-family:Arial,'Helvetica Neue',Helvetica,sans-serif; "
+    "font-size:16px; line-height:1.5; color:#333333; max-width:600px"
+)
+
+
+def render_email_html(markdown_body: str, theme: EmailTheme) -> str:
+    """Convert Markdown to email-safe HTML with inline styles.
+
+    Args:
+        markdown_body: Markdown source from the LLM agent.
+        theme: Color palette for headings, tables, links.
+
+    Returns:
+        Complete HTML string with inline styles, wrapped in a container div.
+    """
+    renderer = EmailRenderer(theme)
+    md = mistune.create_markdown(renderer=renderer, plugins=["table"])
+    content = md(markdown_body)
+    return f'<div style="{_CONTAINER_STYLE}">{content}</div>'
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_email_renderer.py -v`
+Expected: All PASS.
+
+- [ ] **Step 9: Write failing tests for PlainTextRenderer (strip_markdown)**
+
+Add to `tests/test_email_renderer.py`:
+
+```python
+from mailpilot.email_renderer import strip_markdown
+
+
+def test_strip_removes_bold_markers():
+    assert "bold" in strip_markdown("**bold** text")
+    assert "**" not in strip_markdown("**bold** text")
+
+
+def test_strip_removes_italic_markers():
+    assert "italic" in strip_markdown("*italic* text")
+    result = strip_markdown("*italic* text")
+    assert result.startswith("italic")
+
+
+def test_strip_removes_heading_markers():
+    result = strip_markdown("## Title\n\nBody")
+    assert "##" not in result
+    assert "TITLE" in result  # uppercased
+
+
+def test_strip_renders_link_with_url():
+    result = strip_markdown("[Lab5](https://lab5.ca)")
+    assert "Lab5" in result
+    assert "https://lab5.ca" in result
+
+
+def test_strip_renders_table_rows():
+    md = "| Model | Flow |\n|-------|------|\n| WS48 | 150 |"
+    result = strip_markdown(md)
+    assert "Model" in result
+    assert "WS48" in result
+    assert "150" in result
+
+
+def test_strip_removes_hr_markers():
+    result = strip_markdown("above\n\n---\n\nbelow")
+    assert "---" not in result
+    assert "above" in result
+    assert "below" in result
+
+
+def test_strip_removes_code_backticks():
+    result = strip_markdown("Use `cmd` here")
+    assert "`" not in result
+    assert "cmd" in result
+
+
+def test_strip_preserves_list_format():
+    result = strip_markdown("- one\n- two")
+    assert "one" in result
+    assert "two" in result
+```
+
+- [ ] **Step 10: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_email_renderer.py::test_strip_removes_bold_markers -v`
+Expected: FAIL with `ImportError`.
+
+- [ ] **Step 11: Implement PlainTextRenderer and strip_markdown**
+
+Add to `src/mailpilot/email_renderer.py`:
+
+```python
+class PlainTextRenderer(mistune.HTMLRenderer):  # type: ignore[misc]
+    """Renderer that outputs clean plain text with no Markdown syntax."""
+
+    def text(self, text: str) -> str:
+        return text
+
+    def heading(self, text: str, level: int, **attrs: object) -> str:
+        return f"\n{text.upper()}\n\n"
+
+    def paragraph(self, text: str) -> str:
+        return f"{text}\n\n"
+
+    def link(self, text: str, url: str, title: str | None = None) -> str:
+        if text == url:
+            return url
+        return f"{text} ({url})"
+
+    def strong(self, text: str) -> str:
+        return text
+
+    def emphasis(self, text: str) -> str:
+        return text
+
+    def codespan(self, text: str) -> str:
+        return text
+
+    def thematic_break(self) -> str:
+        return "\n"
+
+    def list(self, text: str, ordered: bool, **attrs: object) -> str:
+        return f"{text}\n"
+
+    def list_item(self, text: str, **attrs: object) -> str:
+        return f"- {text}\n"
+
+    def table(self, text: str) -> str:
+        return f"{text}\n"
+
+    def table_head(self, text: str) -> str:
+        return text
+
+    def table_body(self, text: str) -> str:
+        return text
+
+    def table_row(self, text: str) -> str:
+        return f"{text}\n"
+
+    def table_cell(
+        self, text: str, head: bool = False, align: str | None = None, **attrs: object
+    ) -> str:
+        return f"{text}\t"
+
+    def linebreak(self) -> str:
+        return "\n"
+
+
+def strip_markdown(markdown_body: str) -> str:
+    """Convert Markdown to clean plain text with no formatting syntax.
+
+    Args:
+        markdown_body: Markdown source from the LLM agent.
+
+    Returns:
+        Plain text with headings uppercased, links expanded, tables
+        tab-separated, and all Markdown markers removed.
+    """
+    renderer = PlainTextRenderer()
+    md = mistune.create_markdown(renderer=renderer, plugins=["table"])
+    return md(markdown_body).strip()
+```
+
+- [ ] **Step 12: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_email_renderer.py -v`
+Expected: All PASS.
+
+- [ ] **Step 13: Run lint and type check**
+
+Run: `uv run ruff check --fix && uv run basedpyright`
+Expected: Clean.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add src/mailpilot/email_renderer.py tests/test_email_renderer.py
+git commit -m "feat(email): add Markdown-to-HTML renderer with theme support"
+```
+
+---
+
+### Task 3: Add theme column to workflow
+
+**Files:**
+- Modify: `src/mailpilot/schema.sql:51-63`
+- Modify: `src/mailpilot/models.py:70-82`
+- Modify: `src/mailpilot/database.py:731-763` (create_workflow)
+- Modify: `src/mailpilot/database.py:850-879` (update_workflow)
+- Modify: `tests/conftest.py:114-126` (make_test_workflow)
+
+- [ ] **Step 1: Write failing test for workflow theme in DB**
+
+Add a new test file `tests/test_workflow_theme.py`:
+
+```python
+"""Tests for workflow theme support."""
+
+from typing import Any
+
+import psycopg
+
+from mailpilot.database import create_workflow, get_workflow, update_workflow
+from tests.conftest import make_test_account
+
+
+def test_create_workflow_default_theme(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    workflow = create_workflow(
+        database_connection, name="Test", workflow_type="outbound", account_id=account.id
+    )
+    assert workflow.theme == "blue"
+
+
+def test_create_workflow_custom_theme(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    workflow = create_workflow(
+        database_connection,
+        name="Themed",
+        workflow_type="outbound",
+        account_id=account.id,
+        theme="green",
+    )
+    assert workflow.theme == "green"
+
+
+def test_update_workflow_theme(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    workflow = create_workflow(
+        database_connection, name="W", workflow_type="outbound", account_id=account.id
+    )
+    updated = update_workflow(database_connection, workflow.id, theme="orange")
+    assert updated is not None
+    assert updated.theme == "orange"
+
+
+def test_get_workflow_includes_theme(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    created = create_workflow(
+        database_connection,
+        name="Get",
+        workflow_type="inbound",
+        account_id=account.id,
+        theme="purple",
+    )
+    fetched = get_workflow(database_connection, created.id)
+    assert fetched is not None
+    assert fetched.theme == "purple"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_workflow_theme.py -v`
+Expected: FAIL -- `Workflow` model has no `theme` field.
+
+- [ ] **Step 3: Add theme column to schema.sql**
+
+In `src/mailpilot/schema.sql`, add after the `instructions` line in the workflow table:
+
+```sql
+    theme             TEXT NOT NULL DEFAULT 'blue',
+```
+
+- [ ] **Step 4: Add theme field to Workflow model**
+
+In `src/mailpilot/models.py`, add to the `Workflow` class after `instructions`:
+
+```python
+    theme: str = "blue"
+```
+
+- [ ] **Step 5: Update create_workflow to accept theme**
+
+In `src/mailpilot/database.py`, modify `create_workflow`:
+
+```python
+def create_workflow(
+    connection: psycopg.Connection[dict[str, Any]],
+    name: str,
+    workflow_type: str,
+    account_id: str,
+    theme: str = "blue",
+) -> Workflow:
+```
+
+Update the INSERT query:
+
+```python
+    row = connection.execute(
+        """\
+        INSERT INTO workflow (id, name, type, account_id, theme)
+        VALUES (%(id)s, %(name)s, %(type)s, %(account_id)s, %(theme)s)
+        RETURNING *
+        """,
+        {
+            "id": _new_id(),
+            "name": name,
+            "type": workflow_type,
+            "account_id": account_id,
+            "theme": theme,
+        },
+    ).fetchone()
+```
+
+- [ ] **Step 6: Update update_workflow to allow theme**
+
+In `src/mailpilot/database.py`, modify `update_workflow` to add `"theme"` to the `allowed` set:
+
+```python
+    allowed = {"name", "objective", "instructions", "theme"}
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_workflow_theme.py -v`
+Expected: All PASS.
+
+- [ ] **Step 8: Run full test suite to check for regressions**
+
+Run: `uv run pytest -x`
+Expected: All PASS. Existing tests should not break because `theme` defaults to `"blue"`.
+
+- [ ] **Step 9: Run lint and type check**
+
+Run: `uv run ruff check --fix && uv run basedpyright`
+Expected: Clean.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/mailpilot/schema.sql src/mailpilot/models.py src/mailpilot/database.py tests/test_workflow_theme.py
+git commit -m "feat(schema): add theme column to workflow table"
+```
+
+---
+
+### Task 4: CLI --theme option
+
+**Files:**
+- Modify: `src/mailpilot/cli.py:1260-1345` (workflow create)
+- Modify: `src/mailpilot/cli.py:1364-1400` (workflow update)
+- Modify: `tests/test_cli.py` (workflow create/update tests)
+
+- [ ] **Step 1: Write failing test for workflow create --theme**
+
+Add to `tests/test_cli.py` near the other workflow create tests:
+
+```python
+def test_workflow_create_with_theme(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    mock_connection.execute.return_value.fetchone.side_effect = [
+        _MOCK_ACCOUNT_ROW,  # get_account
+        {**_MOCK_WORKFLOW_ROW, "theme": "green"},  # create_workflow
+        {**_MOCK_WORKFLOW_ROW, "theme": "green"},  # activate_workflow
+    ]
+    result = runner.invoke(
+        main,
+        [
+            "workflow", "create",
+            "--name", "Themed",
+            "--type", "outbound",
+            "--account-id", MOCK_ID,
+            "--theme", "green",
+        ],
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["theme"] == "green"
+
+
+def test_workflow_create_invalid_theme(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    mock_connection.execute.return_value.fetchone.return_value = _MOCK_ACCOUNT_ROW
+    result = runner.invoke(
+        main,
+        [
+            "workflow", "create",
+            "--name", "Bad",
+            "--type", "outbound",
+            "--account-id", MOCK_ID,
+            "--theme", "rainbow",
+        ],
+    )
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "validation_error"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_cli.py::test_workflow_create_with_theme -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Add --theme option to workflow create in cli.py**
+
+Add a new `@click.option` before the `workflow_create` function, after the `--draft` option:
+
+```python
+@click.option(
+    "--theme",
+    default=None,
+    help="Email color theme (blue, green, orange, purple, red, slate).",
+)
+```
+
+Add `theme: str | None` to the function signature.
+
+Inside the function body, after the empty-name validation, add theme validation:
+
+```python
+    if theme is not None:
+        from mailpilot.email_renderer import THEME_NAMES
+
+        if theme not in THEME_NAMES:
+            output_error(
+                f"invalid theme '{theme}', must be one of: {', '.join(sorted(THEME_NAMES))}",
+                "validation_error",
+            )
+```
+
+Pass `theme` to `create_workflow()`:
+
+```python
+    workflow = create_workflow(
+        connection,
+        name=name,
+        workflow_type=workflow_type,
+        account_id=account_id,
+        theme=theme or "blue",
+    )
+```
+
+- [ ] **Step 4: Add --theme option to workflow update in cli.py**
+
+Add the same `@click.option` before `workflow_update`.
+
+Add `theme: str | None` to the function signature.
+
+Inside the function body, add theme validation and field assignment:
+
+```python
+    if theme is not None:
+        from mailpilot.email_renderer import THEME_NAMES
+
+        if theme not in THEME_NAMES:
+            output_error(
+                f"invalid theme '{theme}', must be one of: {', '.join(sorted(THEME_NAMES))}",
+                "validation_error",
+            )
+        fields["theme"] = theme
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_cli.py -k "workflow_create_with_theme or workflow_create_invalid_theme" -v`
+Expected: All PASS.
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `uv run pytest -x`
+Expected: All PASS. Existing workflow tests should not break -- `theme` is optional and defaults.
+
+- [ ] **Step 7: Run lint and type check**
+
+Run: `uv run ruff check --fix && uv run basedpyright`
+Expected: Clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/mailpilot/cli.py tests/test_cli.py
+git commit -m "feat(cli): add --theme option to workflow create/update"
+```
+
+---
+
+### Task 5: Change GmailClient.send_message() to accept MIMEBase
+
+**Files:**
+- Modify: `src/mailpilot/gmail.py:264-324`
+- Modify: `tests/test_sync.py` (all send_email tests that inspect MIME)
+
+- [ ] **Step 1: Write failing test for new send_message signature**
+
+Add to `tests/test_sync.py`:
+
+```python
+def test_send_message_accepts_mime_message(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """GmailClient.send_message() accepts a pre-built MIMEBase message."""
+    from email.mime.text import MIMEText as MIMETextClass
+
+    account = make_test_account(database_connection, email="mime@example.com")
+    client, service = _make_send_client(account.email)
+
+    mime_msg = MIMETextClass("Hello", _charset="utf-8")
+    client.send_message(
+        message=mime_msg,
+        to="recipient@example.com",
+        subject="Test",
+        from_email=account.email,
+        account_id=account.id,
+    )
+
+    send_call = service.users.return_value.messages.return_value.send
+    assert send_call.call_count == 1
+    call_body = send_call.call_args.kwargs["body"]
+    raw = base64.urlsafe_b64decode(call_body["raw"])
+    msg = message_from_bytes(raw)
+    assert msg["To"] == "recipient@example.com"
+    assert msg["Subject"] == "Test"
+    assert msg["X-MailPilot-Version"] is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_sync.py::test_send_message_accepts_mime_message -v`
+Expected: FAIL -- `send_message()` does not have a `message` parameter.
+
+- [ ] **Step 3: Refactor GmailClient.send_message()**
+
+Replace the `send_message` method in `src/mailpilot/gmail.py`. The new version accepts a `message: MIMEBase` parameter instead of `body: str`. It adds headers to the pre-built MIME message and sends it.
+
+```python
+    @_retry_on_transient
+    def send_message(
+        self,
+        message: MIMEBase,
+        to: str,
+        subject: str,
+        from_email: str = "",
+        thread_id: str | None = None,
+        account_id: str = "",
+        cc: str | None = None,
+        bcc: str | None = None,
+        in_reply_to: str | None = None,
+        user_id: str = "me",
+    ) -> dict[str, Any]:
+        """Send an email message via Gmail API.
+
+        Args:
+            message: Pre-built MIME message (text/plain, text/html,
+                or multipart/alternative).
+            to: Recipient email address(es), comma-separated for multiple.
+            subject: Email subject.
+            from_email: Sender email (for From header).
+            thread_id: Gmail thread ID for threading replies.
+            account_id: MailPilot account ID for traceability header.
+            cc: CC recipient(s), comma-separated.
+            bcc: BCC recipient(s), comma-separated.
+            in_reply_to: RFC 2822 Message-ID of the email being replied to.
+                Sets In-Reply-To and References headers for cross-client
+                thread grouping.
+            user_id: Gmail user ID.
+
+        Returns:
+            Sent message dict with id, threadId, labelIds.
+        """
+        message["To"] = to
+        message["Subject"] = subject
+        if from_email:
+            message["From"] = from_email
+        if cc:
+            message["Cc"] = cc
+        if bcc:
+            message["Bcc"] = bcc
+        if in_reply_to:
+            message["In-Reply-To"] = in_reply_to
+            message["References"] = in_reply_to
+        message["X-MailPilot-Version"] = _MAILPILOT_VERSION
+        if account_id:
+            message["X-MailPilot-Account-Id"] = account_id
+
+        raw = base64.urlsafe_b64encode(message.as_bytes()).decode()
+        send_body: dict[str, Any] = {"raw": raw}
+        if thread_id:
+            send_body["threadId"] = thread_id
+
+        result: dict[str, Any] = (
+            self._service.users()
+            .messages()
+            .send(userId=user_id, body=send_body)
+            .execute()
+        )
+        return result
+```
+
+Update the imports at the top of `gmail.py` -- add `from email.mime.base import MIMEBase`. Remove the `from email.mime.text import MIMEText` import if it's no longer used elsewhere in the file (check first).
+
+- [ ] **Step 4: Run new test to verify it passes**
+
+Run: `uv run pytest tests/test_sync.py::test_send_message_accepts_mime_message -v`
+Expected: PASS.
+
+- [ ] **Step 5: Fix existing sync tests**
+
+The existing `send_email` tests in `test_sync.py` call `sync.send_email()` which still builds the MIME message itself (will be updated in Task 6). For now, existing tests will break because `sync.send_email()` still passes `body=` to `GmailClient.send_message()`. This is expected -- they will be fixed in Task 6.
+
+Run: `uv run ruff check --fix && uv run basedpyright`
+Expected: Type check clean on gmail.py changes. Some test failures expected until Task 6.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/mailpilot/gmail.py
+git commit -m "refactor(gmail): accept pre-built MIMEBase in send_message"
+```
+
+---
+
+### Task 6: Update sync.send_email() to build multipart MIME
+
+**Files:**
+- Modify: `src/mailpilot/sync.py:475-560`
+- Modify: `tests/test_sync.py` (update existing send_email tests)
+
+- [ ] **Step 1: Write failing test for multipart MIME output**
+
+Add to `tests/test_sync.py`:
+
+```python
+def test_send_email_produces_multipart_alternative(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """send_email builds multipart/alternative with plain text and HTML parts."""
+    from email import message_from_bytes
+
+    account = make_test_account(database_connection, email="mp@example.com")
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    client, service = _make_send_client(account.email)
+
+    send_email(
+        database_connection,
+        account=account,
+        gmail_client=client,
+        settings=make_test_settings(),
+        to="recipient@example.com",
+        subject="Hello",
+        body="**Bold** and a [link](https://lab5.ca)",
+        workflow_id=workflow.id,
+    )
+
+    send_body = service.users.return_value.messages.return_value.send.call_args.kwargs[
+        "body"
+    ]
+    raw = base64.urlsafe_b64decode(send_body["raw"])
+    msg = message_from_bytes(raw)
+    assert msg.get_content_type() == "multipart/alternative"
+    parts = msg.get_payload()
+    assert len(parts) == 2
+    plain_part = parts[0]
+    html_part = parts[1]
+    assert plain_part.get_content_type() == "text/plain"
+    assert html_part.get_content_type() == "text/html"
+    # HTML part has styled content
+    html_body = html_part.get_payload(decode=True).decode()
+    assert "<strong>" in html_body or "<b>" in html_body
+    assert "lab5.ca" in html_body
+    # Plain text part has no markdown markers
+    plain_body = plain_part.get_payload(decode=True).decode()
+    assert "**" not in plain_body
+    assert "Bold" in plain_body
+
+
+def test_send_email_stores_plain_text_in_db(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """body_text in DB contains stripped plain text, not Markdown."""
+    account = make_test_account(database_connection, email="db@example.com")
+    client, _service = _make_send_client(account.email)
+
+    email = send_email(
+        database_connection,
+        account=account,
+        gmail_client=client,
+        settings=make_test_settings(),
+        to="recipient@example.com",
+        subject="Hello",
+        body="**Bold** text",
+    )
+
+    assert "**" not in email.body_text
+    assert "Bold" in email.body_text
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_sync.py::test_send_email_produces_multipart_alternative -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Update sync.send_email() to build multipart MIME**
+
+In `src/mailpilot/sync.py`, modify the `send_email` function. Key changes:
+
+1. Import `render_email_html`, `strip_markdown`, `get_theme` from `email_renderer`.
+2. Import `MIMEMultipart` and `MIMEText` from `email.mime`.
+3. Look up the workflow to get the theme (if `workflow_id` is provided).
+4. Render HTML and strip plain text from the Markdown body.
+5. Build a `MIMEMultipart("alternative")` with both parts.
+6. Pass the MIME message to `gmail_client.send_message()`.
+7. Store the stripped plain text in the DB.
+
+```python
+    # At top of function body, after the settings delete:
+    from email.mime.multipart import MIMEMultipart
+    from email.mime.text import MIMEText
+
+    from mailpilot.email_renderer import get_theme, render_email_html, strip_markdown
+
+    # Look up theme from workflow
+    theme_name: str | None = None
+    if workflow_id is not None:
+        workflow = get_workflow(connection, workflow_id)
+        if workflow is not None:
+            theme_name = workflow.theme
+    theme = get_theme(theme_name)
+
+    # Render HTML and strip to plain text
+    html_body = render_email_html(body, theme)
+    plain_body = strip_markdown(body)
+
+    # Build multipart/alternative MIME
+    mime_message = MIMEMultipart("alternative")
+    mime_message.attach(MIMEText(plain_body, "plain", "utf-8"))
+    mime_message.attach(MIMEText(html_body, "html", "utf-8"))
+```
+
+Update the `gmail_client.send_message()` call to pass `message=mime_message` instead of `body=body`.
+
+Update the `create_email()` call to pass `body_text=plain_body` instead of `body_text=body`.
+
+Add `from mailpilot.database import get_workflow` to the imports inside the span block.
+
+- [ ] **Step 4: Run new tests to verify they pass**
+
+Run: `uv run pytest tests/test_sync.py::test_send_email_produces_multipart_alternative tests/test_sync.py::test_send_email_stores_plain_text_in_db -v`
+Expected: PASS.
+
+- [ ] **Step 5: Fix existing send_email tests**
+
+Existing tests that inspect the raw MIME payload need updates because:
+- The message is now `multipart/alternative` instead of `text/plain`
+- To inspect headers, parse the multipart message
+- The `body_text` assertion for `"Body text"` stays valid since plain ASCII without Markdown markers strips identically
+
+Tests that check `email.body_text == "Body text"` should still pass (no Markdown markers in "Body text"). Tests that decode the raw MIME need to handle multipart. Tests that check `Content-Transfer-Encoding` need updating.
+
+Update `test_send_email_always_uses_utf8_base64_encoding` -- this test becomes obsolete since the encoding is now per-part in a multipart message. Replace it with a test verifying both parts exist and use UTF-8:
+
+```python
+def test_send_email_always_uses_utf8_base64_encoding(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Both MIME parts use UTF-8 charset."""
+    from email import message_from_bytes
+
+    account = make_test_account(database_connection, email="enc@example.com")
+    client, service = _make_send_client(account.email)
+
+    send_email(
+        database_connection,
+        account=account,
+        gmail_client=client,
+        settings=make_test_settings(),
+        to="recipient@example.com",
+        subject="Hello",
+        body="Plain ASCII body with no special characters.",
+    )
+
+    send_body = service.users.return_value.messages.return_value.send.call_args.kwargs[
+        "body"
+    ]
+    raw = base64.urlsafe_b64decode(send_body["raw"])
+    msg = message_from_bytes(raw)
+    assert msg.get_content_type() == "multipart/alternative"
+    parts = msg.get_payload()
+    for part in parts:
+        assert part.get_content_charset() == "utf-8"
+```
+
+Update other tests that decode `raw` to handle the multipart structure. The pattern:
+
+```python
+    msg = message_from_bytes(raw)
+    # For multipart, get the plain text part (first) to check content:
+    if msg.get_content_type() == "multipart/alternative":
+        plain_part = msg.get_payload()[0]
+        body_text = plain_part.get_payload(decode=True).decode()
+    else:
+        body_text = msg.get_payload(decode=True).decode()
+```
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `uv run pytest -x`
+Expected: All PASS.
+
+- [ ] **Step 7: Run lint and type check**
+
+Run: `uv run ruff check --fix && uv run basedpyright`
+Expected: Clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/mailpilot/sync.py tests/test_sync.py
+git commit -m "feat(sync): render Markdown to HTML and send multipart MIME"
+```
+
+---
+
+### Task 7: Verify agent tools work through new pipeline
+
+**Files:**
+- Modify: `tests/test_agent_tools.py`
+
+- [ ] **Step 1: Write test verifying agent reply_email produces HTML**
+
+Add to `tests/test_agent_tools.py`:
+
+```python
+def test_reply_email_sends_multipart_html(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """reply_email body goes through Markdown->HTML pipeline in sync.send_email."""
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="sender@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+
+    inbound = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Question",
+        contact_id=contact.id,
+        workflow_id=workflow.id,
+        gmail_message_id="inbound-html",
+        gmail_thread_id="thread-html",
+    )
+    assert inbound is not None
+
+    gmail_client = _make_gmail_client(account)
+
+    result = reply_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        email_id=inbound.id,
+        body="## Summary\n\n**Important** info here.",
+    )
+
+    assert "error" not in result
+    gmail_client.send_message.assert_called_once()
+    call_kwargs = gmail_client.send_message.call_args.kwargs
+    # sync.send_email now passes message= (MIMEBase), not body=
+    assert "message" in call_kwargs
+```
+
+- [ ] **Step 2: Run test to verify it fails or passes**
+
+Run: `uv run pytest tests/test_agent_tools.py::test_reply_email_sends_multipart_html -v`
+
+If it fails, investigate -- the agent tools call `sync.send_email()` which was updated in Task 6. The mock `gmail_client` should still work since `send_message` is mocked.
+
+- [ ] **Step 3: Fix any agent tool test failures**
+
+The agent tools tests mock `gmail_client.send_message`. Since `sync.send_email` now passes `message=mime_msg` instead of `body=text`, update any assertions that check `call_kwargs["body"]` to check `call_kwargs["message"]` instead.
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `uv run pytest -x`
+Expected: All PASS.
+
+- [ ] **Step 5: Run lint and type check**
+
+Run: `uv run ruff check --fix && uv run basedpyright`
+Expected: Clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_agent_tools.py
+git commit -m "test(agent): verify agent tools work with multipart HTML pipeline"
+```
+
+---
+
+### Task 8: Final integration check
+
+- [ ] **Step 1: Run make check**
+
+Run: `make check`
+Expected: All lint, type checks, and tests pass.
+
+- [ ] **Step 2: Manual verification with CLI**
+
+Test the full pipeline by sending an email with Markdown body:
+
+```bash
+uv run mailpilot workflow list
+# Pick a workflow ID, or create one:
+# uv run mailpilot workflow create --name "HTML Test" --type outbound --account-id <ID> --theme green
+
+uv run mailpilot email send \
+  --account-id <OUTBOUND_ACCOUNT_ID> \
+  --to inbound@lab5.ca \
+  --subject "HTML Email Test" \
+  --body "## Product Comparison
+
+| Model | Flow Rate | Capacity |
+|-------|-----------|----------|
+| WS48  | 150 GPM   | 48,000   |
+| WS54  | 200 GPM   | 54,000   |
+
+**Recommendation:** The WS54 is better for your needs.
+
+Visit [Lab5](https://lab5.ca) for details."
+```
+
+Check the received email in Gmail to verify:
+- Headings are colored and larger
+- Table renders with styled headers
+- Bold text renders correctly
+- Link is clickable and colored
+
+- [ ] **Step 3: Verify DB stores plain text**
+
+```bash
+uv run mailpilot email list --direction outbound --limit 1
+# Check body_text has no ** or ## markers
+uv run mailpilot email view <EMAIL_ID>
+```
+
+- [ ] **Step 4: Commit any final fixes if needed**

--- a/docs/superpowers/specs/2026-04-23-html-email-design.md
+++ b/docs/superpowers/specs/2026-04-23-html-email-design.md
@@ -1,0 +1,158 @@
+# HTML Email Rendering Design
+
+## Overview
+
+LLM agents generate email bodies in Markdown. Python converts Markdown to themed HTML for rich email rendering with tables, larger fonts, and workflow-based color schemes. Emails are sent as `multipart/alternative` (plain text + HTML).
+
+## Architecture
+
+### Pipeline
+
+```
+Agent tool (send_email / reply_email)
+  |  body = "## Product Comparison\n| Model | Flow |\n..."
+  v
+sync.send_email(body=markdown_body, workflow_id=...)
+  |  1. Look up workflow -> get theme
+  |  2. render_email_html(markdown_body, theme) -> html
+  |  3. strip_markdown(markdown_body) -> plain_text (for DB + MIME)
+  |  4. Build MIMEMultipart("alternative") with plain_text + html
+  v
+GmailClient.send_message(mime_message)  # accepts pre-built MIME object
+```
+
+### Conversion Layer: `sync.send_email()`
+
+The single choke point for all outbound email. Responsibilities:
+
+1. Receives Markdown `body` from agent tools or CLI.
+2. Looks up the workflow to get the theme (falls back to `blue` if no workflow or unknown theme).
+3. Renders Markdown to HTML via `EmailRenderer` (mistune custom renderer with inline styles).
+4. Strips Markdown to plain text via `PlainTextRenderer` (no `**`, `__`, `#`, `|---|`).
+5. Builds `MIMEMultipart("alternative")` with `MIMEText(plain_text, "plain")` + `MIMEText(html, "html")`.
+6. Passes the assembled MIME message to `GmailClient.send_message()`.
+7. Stores `plain_text` (stripped) in DB `body_text` column.
+
+### GmailClient Changes
+
+`GmailClient.send_message()` signature changes to accept a pre-built `MIMEBase` message instead of a plain text `body` string. It adds headers (To, Subject, From, In-Reply-To, X-MailPilot-*) and sends. This keeps `GmailClient` as a dumb transport.
+
+### DB Storage
+
+`body_text` stores clean plain text -- no Markdown syntax, no HTML. The Markdown source is an intermediate format that exists only during the send call. This is better for search, CLI display, and activity summaries.
+
+## Markdown Rendering
+
+### Library: mistune
+
+- Zero dependencies, 53.6 KB wheel
+- Fastest Python Markdown parser
+- Table support via plugin: `plugins=['table']`
+- Custom `HTMLRenderer` subclass for inline styles
+
+### EmailRenderer
+
+Subclass of `mistune.HTMLRenderer` that injects inline `style=""` attributes during conversion. No separate CSS inlining step needed.
+
+Styled elements:
+
+| Element | Style |
+|---------|-------|
+| `<h1>` | primary color, 24px, bold |
+| `<h2>` | primary color, 20px, bold |
+| `<h3>` | primary color, 18px, bold |
+| `<p>` | #333, 16px, line-height 1.5 |
+| `<table>` | full-width, border-collapse |
+| `<th>` | accent background, dark text, bold |
+| `<td>` | padding, bottom border |
+| `<a>` | primary color, underline |
+| `<code>` | light gray background, monospace |
+| `<ul>`, `<ol>` | standard padding |
+| `<hr>` | border color, 1px top border |
+
+### PlainTextRenderer
+
+Separate renderer that outputs clean plain text:
+
+- Headings: uppercase text with blank line
+- Tables: aligned columns (or simplified format)
+- Links: `text (url)`
+- Bold/italic: text only, no markers
+- Code: text only, no backticks
+- Lists: `- item` or `1. item`
+
+### HTML Wrapper
+
+No chrome (no bars, headers, or visual frame). Content-only styling:
+
+```html
+<div style="font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;
+            font-size:16px; line-height:1.5; color:#333333; max-width:600px;">
+  {rendered_content}
+</div>
+```
+
+Theme colors appear only on content elements the agent generates (headings, table headers, links).
+
+## Theme Model
+
+### EmailTheme
+
+```python
+@dataclasses.dataclass
+class EmailTheme:
+    primary: str    # headings, links
+    accent: str     # table header background
+    border: str     # table/hr borders
+```
+
+### Predefined Palettes
+
+| Name | Primary | Accent | Border |
+|------|---------|--------|--------|
+| `blue` | `#2563eb` | `#dbeafe` | `#bfdbfe` |
+| `green` | `#16a34a` | `#dcfce7` | `#bbf7d0` |
+| `orange` | `#ea580c` | `#ffedd5` | `#fed7aa` |
+| `purple` | `#7c3aed` | `#ede9fe` | `#ddd6fe` |
+| `red` | `#dc2626` | `#fee2e2` | `#fecaca` |
+| `slate` | `#475569` | `#f1f5f9` | `#e2e8f0` |
+
+### Schema Change
+
+```sql
+ALTER TABLE workflow ADD COLUMN theme TEXT NOT NULL DEFAULT 'blue';
+```
+
+### CLI
+
+- `workflow create --theme green`
+- `workflow update ID --theme orange`
+- Validates against palette names. Invalid theme -> error.
+- Default: `blue`.
+
+## What Doesn't Change
+
+- **Agent tools API**: `send_email(body=...)` and `reply_email(body=...)` still take `body: str`. The agent doesn't know about HTML.
+- **Agent instructions**: No changes needed. LLMs naturally produce Markdown.
+- **DB schema for email**: `body_text` stores stripped plain text. No new column.
+- **Inbound email handling**: `body_text` on inbound emails stays as plain text extracted from Gmail.
+
+## Dependencies
+
+One new dependency:
+
+- `mistune` -- Markdown parser (zero deps, 53.6 KB wheel, BSD-3-Clause)
+
+No `css-inline` needed -- the custom renderer handles inline styles directly.
+
+## Email Client Compatibility
+
+Based on research (caniemail.com, Litmus):
+
+- All CSS is inline `style=""` -- Gmail strips `<style>` tags.
+- Font stack: `Arial, 'Helvetica Neue', Helvetica, sans-serif` (web-safe).
+- Body font: 16px (industry standard, accessible).
+- Content tables use `border-collapse: collapse` with inline styles per cell.
+- Max-width 600px on container div.
+- No flex/grid/position/float. No CSS variables.
+- `border-radius` works everywhere except Outlook desktop (acceptable degradation).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "google-auth>=2.40.0,<3.0.0",
     "google-cloud-pubsub>=2.29.0,<3.0.0",
     "logfire>=4.0.0,<5.0.0",
+    "mistune>=3.1.0,<4.0.0",
     "psycopg[binary]>=3.2.0,<4.0.0",
     "pydantic-ai-slim[anthropic]>=1.10.0,<2.0.0",
     "pydantic-settings>=2.7.0,<3.0.0",

--- a/src/mailpilot/agent/classify.py
+++ b/src/mailpilot/agent/classify.py
@@ -109,8 +109,10 @@ def classify_email(
         prompt = _format_prompt(subject, body, sender, active_workflows)
         result = _AGENT.run_sync(prompt, model=model)
         usage = result.usage()
+        span.set_attribute("model", settings.anthropic_model)
         span.set_attribute("input_tokens", usage.input_tokens)
         span.set_attribute("output_tokens", usage.output_tokens)
+        span.set_attribute("total_tokens", usage.input_tokens + usage.output_tokens)
         output = result.output
         span.set_attribute("reasoning", output.reasoning)
         candidate_ids = {workflow.id for workflow in active_workflows}

--- a/src/mailpilot/agent/invoke.py
+++ b/src/mailpilot/agent/invoke.py
@@ -482,8 +482,10 @@ def invoke_workflow_agent(  # noqa: PLR0913
 
             # Usage tracking.
             usage = result.usage()
+            span.set_attribute("model", settings.anthropic_model)
             span.set_attribute("input_tokens", usage.input_tokens)
             span.set_attribute("output_tokens", usage.output_tokens)
+            span.set_attribute("total_tokens", usage.input_tokens + usage.output_tokens)
             span.set_attribute("llm_requests", usage.requests)
 
             # Tool-use enforcement.

--- a/src/mailpilot/agent/tools.py
+++ b/src/mailpilot/agent/tools.py
@@ -253,6 +253,7 @@ def reply_email(  # noqa: PLR0913
             thread_id=original.gmail_thread_id,
             cc=cc,
             bcc=bcc,
+            in_reply_to=original.rfc2822_message_id,
         )
 
         _activate_contact_if_pending(connection, workflow_id, contact.id)

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -1256,6 +1256,29 @@ def workflow() -> None:
     """Manage workflows (inbound + outbound)."""
 
 
+def _resolve_instructions(
+    instructions: str | None, instructions_file: str | None
+) -> str | None:
+    """Return final instructions text from inline or file source."""
+    import pathlib
+
+    if instructions_file is not None:
+        return pathlib.Path(instructions_file).read_text()
+    return instructions
+
+
+def _validate_theme(theme: str) -> None:
+    """Exit with validation_error if theme is not a recognized name."""
+    from mailpilot.email_renderer import THEME_NAMES
+
+    if theme not in THEME_NAMES:
+        output_error(
+            f"invalid theme '{theme}', must be one of: "
+            f"{', '.join(sorted(THEME_NAMES))}",
+            "validation_error",
+        )
+
+
 @workflow.command("create")
 @click.option("--name", required=True, help="Workflow name.")
 @click.option(
@@ -1279,6 +1302,11 @@ def workflow() -> None:
     help="Path to a file with the workflow instructions (system prompt).",
 )
 @click.option(
+    "--theme",
+    default=None,
+    help="Email color theme (blue, green, orange, purple, red, slate).",
+)
+@click.option(
     "--draft",
     is_flag=True,
     default=False,
@@ -1291,11 +1319,10 @@ def workflow_create(
     objective: str | None,
     instructions: str | None,
     instructions_file: str | None,
+    theme: str | None,
     draft: bool,
 ) -> None:
     """Create a new workflow."""
-    import pathlib
-
     from mailpilot.database import (
         activate_workflow,
         create_workflow,
@@ -1306,6 +1333,8 @@ def workflow_create(
 
     if not name.strip():
         output_error("workflow name cannot be empty", "validation_error")
+    if theme is not None:
+        _validate_theme(theme)
     if instructions is not None and instructions_file is not None:
         output_error(
             "--instructions and --instructions-file are mutually exclusive",
@@ -1319,6 +1348,7 @@ def workflow_create(
             "Use --draft to create without them.",
             "validation_error",
         )
+    resolved = _resolve_instructions(instructions, instructions_file)
     connection = initialize_database(_database_url())
     try:
         if get_account(connection, account_id) is None:
@@ -1328,15 +1358,13 @@ def workflow_create(
             name=name,
             workflow_type=workflow_type,
             account_id=account_id,
+            theme=theme or "blue",
         )
-        resolved_instructions: str | None = instructions
-        if instructions_file is not None:
-            resolved_instructions = pathlib.Path(instructions_file).read_text()
         extras: dict[str, object] = {}
         if objective is not None:
             extras["objective"] = objective
-        if resolved_instructions is not None:
-            extras["instructions"] = resolved_instructions
+        if resolved is not None:
+            extras["instructions"] = resolved
         if extras:
             created = update_workflow(connection, created.id, **extras) or created
         if not draft and has_objective and has_instructions:
@@ -1361,23 +1389,30 @@ def workflow_create(
     type=click.Path(exists=True, dir_okay=False),
     help="Path to a file with the workflow instructions (system prompt).",
 )
+@click.option(
+    "--theme",
+    default=None,
+    help="Email color theme (blue, green, orange, purple, red, slate).",
+)
 def workflow_update(
     workflow_id: str,
     name: str | None,
     objective: str | None,
     instructions: str | None,
     instructions_file: str | None,
+    theme: str | None,
 ) -> None:
     """Update a workflow."""
-    import pathlib
-
     from mailpilot.database import initialize_database, update_workflow
 
+    if theme is not None:
+        _validate_theme(theme)
     if instructions is not None and instructions_file is not None:
         output_error(
             "--instructions and --instructions-file are mutually exclusive",
             "validation_error",
         )
+    resolved = _resolve_instructions(instructions, instructions_file)
     connection = initialize_database(_database_url())
     try:
         fields: dict[str, object] = {}
@@ -1385,10 +1420,10 @@ def workflow_update(
             fields["name"] = name
         if objective is not None:
             fields["objective"] = objective
-        if instructions is not None:
-            fields["instructions"] = instructions
-        if instructions_file is not None:
-            fields["instructions"] = pathlib.Path(instructions_file).read_text()
+        if resolved is not None:
+            fields["instructions"] = resolved
+        if theme is not None:
+            fields["theme"] = theme
         updated = update_workflow(connection, workflow_id, **fields)
         if updated is None:
             output_error(f"workflow not found: {workflow_id}", "not_found")

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -1515,13 +1515,14 @@ def workflow_stop(workflow_id: str) -> None:
 @click.option("--workflow-id", required=True, help="Workflow ID.")
 @click.option("--contact-id", required=True, help="Contact ID.")
 def workflow_run(workflow_id: str, contact_id: str) -> None:
-    """Invoke the workflow agent for a single contact (outbound only)."""
+    """Invoke the workflow agent for a single contact."""
     from datetime import UTC, datetime
 
     from mailpilot.database import (
         create_task,
         get_contact,
         get_task,
+        get_unprocessed_inbound_email,
         get_workflow,
         get_workflow_contact,
         initialize_database,
@@ -1539,11 +1540,6 @@ def workflow_run(workflow_id: str, contact_id: str) -> None:
             output_error(
                 f"workflow is not active (status={wf.status})", "invalid_state"
             )
-        if wf.type != "outbound":
-            output_error(
-                f"workflow run requires type=outbound (got {wf.type})",
-                "invalid_state",
-            )
         contact = get_contact(connection, contact_id)
         if contact is None:
             output_error(f"contact not found: {contact_id}", "not_found")
@@ -1552,12 +1548,19 @@ def workflow_run(workflow_id: str, contact_id: str) -> None:
                 f"contact {contact_id} is not enrolled in workflow {workflow_id}",
                 "not_found",
             )
+        email_id: str | None = None
+        if wf.type == "inbound":
+            unprocessed = get_unprocessed_inbound_email(connection, wf.id, contact.id)
+            if unprocessed is not None:
+                email_id = unprocessed.id
+        description = f"manual {wf.type} run"
         task = create_task(
             connection,
             workflow_id=wf.id,
             contact_id=contact.id,
-            description="manual outbound run",
+            description=description,
             scheduled_at=datetime.now(UTC).isoformat(),
+            email_id=email_id,
         )
         execute_task(connection, settings, task)
         completed = get_task(connection, task.id)

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -733,6 +733,7 @@ def create_workflow(
     name: str,
     workflow_type: str,
     account_id: str,
+    theme: str = "blue",
 ) -> Workflow:
     """Create a new workflow.
 
@@ -741,14 +742,15 @@ def create_workflow(
         name: Workflow name.
         workflow_type: "inbound" or "outbound".
         account_id: Account FK.
+        theme: Email color theme (default "blue").
 
     Returns:
         Created workflow.
     """
     row = connection.execute(
         """\
-        INSERT INTO workflow (id, name, type, account_id)
-        VALUES (%(id)s, %(name)s, %(type)s, %(account_id)s)
+        INSERT INTO workflow (id, name, type, account_id, theme)
+        VALUES (%(id)s, %(name)s, %(type)s, %(account_id)s, %(theme)s)
         RETURNING *
         """,
         {
@@ -756,6 +758,7 @@ def create_workflow(
             "name": name,
             "type": workflow_type,
             "account_id": account_id,
+            "theme": theme,
         },
     ).fetchone()
     connection.commit()
@@ -866,7 +869,7 @@ def update_workflow(
     Returns:
         Updated workflow, or None if not found.
     """
-    allowed = {"name", "objective", "instructions"}
+    allowed = {"name", "objective", "instructions", "theme"}
     updates = {k: v for k, v in fields.items() if k in allowed}
     if not updates:
         return get_workflow(connection, workflow_id)

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -1678,6 +1678,43 @@ def list_tasks(
     return [Task.model_validate(row) for row in rows]
 
 
+def get_unprocessed_inbound_email(
+    connection: psycopg.Connection[dict[str, Any]],
+    workflow_id: str,
+    contact_id: str,
+) -> Email | None:
+    """Return the most recent inbound email for a contact+workflow without a task.
+
+    Uses the same filtering logic as ``create_tasks_for_routed_emails`` but
+    scoped to a single contact and returning at most one email.
+
+    Args:
+        connection: Open database connection.
+        workflow_id: Workflow FK.
+        contact_id: Contact FK.
+
+    Returns:
+        The most recent unprocessed inbound email, or None.
+    """
+    row = connection.execute(
+        """\
+        SELECT e.* FROM email e
+        JOIN workflow w ON w.id = e.workflow_id
+        WHERE e.direction = 'inbound'
+          AND e.workflow_id = %(workflow_id)s
+          AND e.contact_id = %(contact_id)s
+          AND e.created_at >= w.created_at
+          AND NOT EXISTS (SELECT 1 FROM task t WHERE t.email_id = e.id)
+        ORDER BY e.created_at DESC
+        LIMIT 1
+        """,
+        {"workflow_id": workflow_id, "contact_id": contact_id},
+    ).fetchone()
+    if row is None:
+        return None
+    return Email.model_validate(row)
+
+
 def create_tasks_for_routed_emails(
     connection: psycopg.Connection[dict[str, Any]],
 ) -> list[Task]:

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -1166,6 +1166,7 @@ def create_email(
     received_at: datetime | None = None,
     sent_at: datetime | None = None,
     labels: list[str] | None = None,
+    rfc2822_message_id: str | None = None,
 ) -> Email | None:
     """Create a new email record, or return None on gmail_message_id conflict.
 
@@ -1190,6 +1191,7 @@ def create_email(
         received_at: When Gmail reports the message arrived (UTC datetime).
         sent_at: When the outbound message was handed to Gmail (UTC datetime).
         labels: Gmail label IDs attached to the message.
+        rfc2822_message_id: RFC 2822 Message-ID header value.
 
     Returns:
         Created email, or None if another worker already stored a row with
@@ -1200,12 +1202,12 @@ def create_email(
         INSERT INTO email (id, account_id, direction, subject,
             body_text, gmail_message_id, gmail_thread_id,
             contact_id, workflow_id, status, is_routed,
-            received_at, sent_at, labels)
+            received_at, sent_at, labels, rfc2822_message_id)
         VALUES (%(id)s, %(account_id)s, %(direction)s,
             %(subject)s, %(body_text)s, %(gmail_message_id)s,
             %(gmail_thread_id)s, %(contact_id)s, %(workflow_id)s,
             %(status)s, %(is_routed)s, %(received_at)s, %(sent_at)s,
-            %(labels)s)
+            %(labels)s, %(rfc2822_message_id)s)
         ON CONFLICT (gmail_message_id) DO NOTHING
         RETURNING *
         """,
@@ -1224,6 +1226,7 @@ def create_email(
             "received_at": received_at,
             "sent_at": sent_at,
             "labels": Json(labels or []),
+            "rfc2822_message_id": rfc2822_message_id,
         },
     ).fetchone()
     connection.commit()

--- a/src/mailpilot/email_renderer.py
+++ b/src/mailpilot/email_renderer.py
@@ -1,0 +1,259 @@
+"""Markdown-to-HTML email rendering with inline styles and theme support."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import cast
+
+import mistune
+
+
+@dataclasses.dataclass(frozen=True)
+class EmailTheme:
+    """Color palette for themed email rendering."""
+
+    primary: str  # headings, links
+    accent: str  # table header background
+    border: str  # table/hr borders
+
+
+THEMES: dict[str, EmailTheme] = {
+    "blue": EmailTheme(primary="#2563eb", accent="#dbeafe", border="#bfdbfe"),
+    "green": EmailTheme(primary="#16a34a", accent="#dcfce7", border="#bbf7d0"),
+    "orange": EmailTheme(primary="#ea580c", accent="#ffedd5", border="#fed7aa"),
+    "purple": EmailTheme(primary="#7c3aed", accent="#ede9fe", border="#ddd6fe"),
+    "red": EmailTheme(primary="#dc2626", accent="#fee2e2", border="#fecaca"),
+    "slate": EmailTheme(primary="#475569", accent="#f1f5f9", border="#e2e8f0"),
+}
+
+THEME_NAMES: set[str] = set(THEMES.keys())
+
+DEFAULT_THEME = "blue"
+
+
+def get_theme(name: str | None) -> EmailTheme:
+    """Look up a theme by name, falling back to blue."""
+    if name is None:
+        return THEMES[DEFAULT_THEME]
+    return THEMES.get(name, THEMES[DEFAULT_THEME])
+
+
+class EmailRenderer(mistune.HTMLRenderer):  # type: ignore[misc]
+    """Custom HTML renderer that injects inline styles for email clients."""
+
+    def __init__(self, theme: EmailTheme) -> None:
+        super().__init__()
+        self.theme = theme
+
+    def heading(self, text: str, level: int, **attrs: object) -> str:
+        """Render heading with themed primary color."""
+        sizes = {1: "24px", 2: "20px", 3: "18px"}
+        size = sizes.get(level, "16px")
+        color = self.theme.primary if level <= 3 else "#333333"
+        style = (
+            f"color:{color}; font-size:{size}; font-weight:bold; "
+            f"line-height:1.3; margin:16px 0 8px 0"
+        )
+        return f'<h{level} style="{style}">{text}</h{level}>\n'
+
+    def paragraph(self, text: str) -> str:
+        """Render paragraph with body text styles."""
+        style = "font-size:16px; line-height:1.5; color:#333333; margin:0 0 16px 0"
+        return f'<p style="{style}">{text}</p>\n'
+
+    def link(self, text: str, url: str, title: str | None = None) -> str:
+        """Render link with themed primary color."""
+        style = f"color:{self.theme.primary}; text-decoration:underline"
+        title_attr = f' title="{title}"' if title else ""
+        return f'<a href="{url}" style="{style}"{title_attr}>{text}</a>'
+
+    def strong(self, text: str) -> str:
+        """Render bold text."""
+        return f"<strong>{text}</strong>"
+
+    def emphasis(self, text: str) -> str:
+        """Render italic text."""
+        return f"<em>{text}</em>"
+
+    def codespan(self, text: str) -> str:
+        """Render inline code with monospace background."""
+        style = (
+            "background-color:#f3f4f6; padding:2px 6px; "
+            "border-radius:3px; "
+            "font-family:'Courier New',Courier,monospace; font-size:14px"
+        )
+        return f'<code style="{style}">{text}</code>'
+
+    def thematic_break(self) -> str:
+        """Render horizontal rule with themed border color."""
+        style = f"border:none; border-top:1px solid {self.theme.border}; margin:24px 0"
+        return f'<hr style="{style}">\n'
+
+    def list(self, text: str, ordered: bool, **attrs: object) -> str:
+        """Render ordered or unordered list."""
+        tag = "ol" if ordered else "ul"
+        style = (
+            "padding-left:24px; margin:0 0 16px 0; "
+            "font-size:16px; line-height:1.5; color:#333333"
+        )
+        return f'<{tag} style="{style}">{text}</{tag}>\n'
+
+    def list_item(self, text: str, **attrs: object) -> str:
+        """Render list item with spacing."""
+        return f'<li style="margin:4px 0">{text}</li>\n'
+
+    def table(self, text: str) -> str:
+        """Render table with collapsed borders."""
+        style = (
+            "width:100%; border-collapse:collapse; font-size:14px; margin:0 0 16px 0"
+        )
+        return f'<table style="{style}">{text}</table>\n'
+
+    def table_head(self, text: str) -> str:
+        """Render table header section."""
+        return f"<thead>{text}</thead>\n"
+
+    def table_body(self, text: str) -> str:
+        """Render table body section."""
+        return f"<tbody>{text}</tbody>\n"
+
+    def table_row(self, text: str) -> str:
+        """Render table row."""
+        return f"<tr>{text}</tr>\n"
+
+    def table_cell(
+        self,
+        text: str,
+        align: str | None = None,
+        head: bool = False,
+        **attrs: object,
+    ) -> str:
+        """Render table cell with themed header background."""
+        tag = "th" if head else "td"
+        text_align = f"text-align:{align}; " if align else "text-align:left; "
+        if head:
+            style = (
+                f"background-color:{self.theme.accent}; color:#1a1a1a; "
+                f"font-weight:bold; padding:8px 12px; {text_align}"
+                f"border-bottom:2px solid {self.theme.border}"
+            )
+        else:
+            style = (
+                f"padding:8px 12px; {text_align}"
+                f"border-bottom:1px solid {self.theme.border}"
+            )
+        return f'<{tag} style="{style}">{text}</{tag}>\n'
+
+
+_CONTAINER_STYLE = (
+    "font-family:Arial,'Helvetica Neue',Helvetica,sans-serif; "
+    "font-size:16px; line-height:1.5; color:#333333; max-width:600px"
+)
+
+
+def render_email_html(markdown_body: str, theme: EmailTheme) -> str:
+    """Convert Markdown to email-safe HTML with inline styles.
+
+    Args:
+        markdown_body: Markdown source from the LLM agent.
+        theme: Color palette for headings, tables, links.
+
+    Returns:
+        Complete HTML string with inline styles, wrapped in a container div.
+    """
+    renderer = EmailRenderer(theme)
+    md = mistune.create_markdown(renderer=renderer, plugins=["table"])
+    content = cast(str, md(markdown_body))
+    return f'<div style="{_CONTAINER_STYLE}">{content}</div>'
+
+
+class PlainTextRenderer(mistune.HTMLRenderer):  # type: ignore[misc]
+    """Renderer that outputs clean plain text with no Markdown syntax."""
+
+    def text(self, text: str) -> str:
+        """Pass through raw text unchanged."""
+        return text
+
+    def heading(self, text: str, level: int, **attrs: object) -> str:
+        """Render heading as uppercased text."""
+        return f"\n{text.upper()}\n\n"
+
+    def paragraph(self, text: str) -> str:
+        """Render paragraph as plain text with trailing newline."""
+        return f"{text}\n\n"
+
+    def link(self, text: str, url: str, title: str | None = None) -> str:
+        """Render link as text with URL in parentheses."""
+        if text == url:
+            return url
+        return f"{text} ({url})"
+
+    def strong(self, text: str) -> str:
+        """Strip bold markers, return plain text."""
+        return text
+
+    def emphasis(self, text: str) -> str:
+        """Strip italic markers, return plain text."""
+        return text
+
+    def codespan(self, text: str) -> str:
+        """Strip backtick markers, return plain text."""
+        return text
+
+    def thematic_break(self) -> str:
+        """Replace horizontal rule with blank line."""
+        return "\n"
+
+    def list(self, text: str, ordered: bool, **attrs: object) -> str:
+        """Render list as plain text."""
+        return f"{text}\n"
+
+    def list_item(self, text: str, **attrs: object) -> str:
+        """Render list item with dash prefix."""
+        return f"- {text}\n"
+
+    def table(self, text: str) -> str:
+        """Render table as plain text."""
+        return f"{text}\n"
+
+    def table_head(self, text: str) -> str:
+        """Pass through table head text."""
+        return text
+
+    def table_body(self, text: str) -> str:
+        """Pass through table body text."""
+        return text
+
+    def table_row(self, text: str) -> str:
+        """Render table row as newline-terminated text."""
+        return f"{text}\n"
+
+    def table_cell(
+        self,
+        text: str,
+        align: str | None = None,
+        head: bool = False,
+        **attrs: object,
+    ) -> str:
+        """Render table cell as tab-separated text."""
+        return f"{text}\t"
+
+    def linebreak(self) -> str:
+        """Render line break as newline."""
+        return "\n"
+
+
+def strip_markdown(markdown_body: str) -> str:
+    """Convert Markdown to clean plain text with no formatting syntax.
+
+    Args:
+        markdown_body: Markdown source from the LLM agent.
+
+    Returns:
+        Plain text with headings uppercased, links expanded, tables
+        tab-separated, and all Markdown markers removed.
+    """
+    renderer = PlainTextRenderer()
+    md = mistune.create_markdown(renderer=renderer, plugins=["table"])
+    result = cast(str, md(markdown_body))
+    return result.strip()

--- a/src/mailpilot/gmail.py
+++ b/src/mailpilot/gmail.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import base64
 import time
-from email.mime.text import MIMEText
+from email.mime.base import MIMEBase
 from email.utils import parseaddr
 from functools import wraps
 from importlib.metadata import version
@@ -264,9 +264,9 @@ class GmailClient:
     @_retry_on_transient
     def send_message(
         self,
+        message: MIMEBase,
         to: str,
         subject: str,
-        body: str,
         from_email: str = "",
         thread_id: str | None = None,
         account_id: str = "",
@@ -278,9 +278,9 @@ class GmailClient:
         """Send an email message via Gmail API.
 
         Args:
+            message: Pre-built MIME message (e.g. multipart/alternative).
             to: Recipient email address(es), comma-separated for multiple.
             subject: Email subject.
-            body: Email body (plain text).
             from_email: Sender email (for From header).
             thread_id: Gmail thread ID for threading replies.
             account_id: MailPilot account ID for traceability header.
@@ -294,7 +294,6 @@ class GmailClient:
         Returns:
             Sent message dict with id, threadId, labelIds.
         """
-        message = MIMEText(body, _charset="utf-8")
         message["To"] = to
         message["Subject"] = subject
         if from_email:

--- a/src/mailpilot/gmail.py
+++ b/src/mailpilot/gmail.py
@@ -272,6 +272,7 @@ class GmailClient:
         account_id: str = "",
         cc: str | None = None,
         bcc: str | None = None,
+        in_reply_to: str | None = None,
         user_id: str = "me",
     ) -> dict[str, Any]:
         """Send an email message via Gmail API.
@@ -285,12 +286,15 @@ class GmailClient:
             account_id: MailPilot account ID for traceability header.
             cc: CC recipient(s), comma-separated.
             bcc: BCC recipient(s), comma-separated.
+            in_reply_to: RFC 2822 Message-ID of the email being replied to.
+                Sets In-Reply-To and References headers for cross-client
+                thread grouping.
             user_id: Gmail user ID.
 
         Returns:
             Sent message dict with id, threadId, labelIds.
         """
-        message = MIMEText(body)
+        message = MIMEText(body, _charset="utf-8")
         message["To"] = to
         message["Subject"] = subject
         if from_email:
@@ -299,6 +303,9 @@ class GmailClient:
             message["Cc"] = cc
         if bcc:
             message["Bcc"] = bcc
+        if in_reply_to:
+            message["In-Reply-To"] = in_reply_to
+            message["References"] = in_reply_to
         message["X-MailPilot-Version"] = _MAILPILOT_VERSION
         if account_id:
             message["X-MailPilot-Account-Id"] = account_id

--- a/src/mailpilot/models.py
+++ b/src/mailpilot/models.py
@@ -117,6 +117,7 @@ class Email(BaseModel):
     id: str
     gmail_message_id: str | None = None
     gmail_thread_id: str | None = None
+    rfc2822_message_id: str | None = None
     account_id: str
     contact_id: str | None = None
     workflow_id: str | None = None

--- a/src/mailpilot/models.py
+++ b/src/mailpilot/models.py
@@ -77,6 +77,7 @@ class Workflow(BaseModel):
     status: WorkflowStatus = "draft"
     objective: str = ""
     instructions: str = ""
+    theme: str = "blue"
     created_at: datetime
     updated_at: datetime
 

--- a/src/mailpilot/schema.sql
+++ b/src/mailpilot/schema.sql
@@ -77,6 +77,7 @@ CREATE TABLE IF NOT EXISTS email (
     id                TEXT PRIMARY KEY,
     gmail_message_id  TEXT UNIQUE,
     gmail_thread_id   TEXT,
+    rfc2822_message_id TEXT,
     account_id        TEXT NOT NULL REFERENCES account(id),
     contact_id        TEXT REFERENCES contact(id),
     workflow_id       TEXT REFERENCES workflow(id),

--- a/src/mailpilot/schema.sql
+++ b/src/mailpilot/schema.sql
@@ -55,6 +55,7 @@ CREATE TABLE IF NOT EXISTS workflow (
     name              TEXT NOT NULL,
     objective         TEXT NOT NULL DEFAULT '',
     instructions      TEXT NOT NULL DEFAULT '',
+    theme             TEXT NOT NULL DEFAULT 'blue',
     status            TEXT NOT NULL DEFAULT 'draft'
                       CHECK (status IN ('draft', 'active', 'paused')),
     created_at        TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/src/mailpilot/sync.py
+++ b/src/mailpilot/sync.py
@@ -524,15 +524,43 @@ def send_email(  # noqa: PLR0913
         workflow_id=workflow_id,
         contact_id=contact_id,
     ) as span:
+        from email.mime.multipart import MIMEMultipart
+        from email.mime.text import MIMEText
+
+        from mailpilot.database import get_workflow
+        from mailpilot.email_renderer import (
+            get_theme,
+            render_email_html,
+            strip_markdown,
+        )
+
         from_header = (
             formataddr((account.display_name, account.email))
             if account.display_name
             else account.email
         )
+
+        # Look up theme from workflow
+        theme_name: str | None = None
+        if workflow_id is not None:
+            workflow = get_workflow(connection, workflow_id)
+            if workflow is not None:
+                theme_name = workflow.theme
+        theme = get_theme(theme_name)
+
+        # Render HTML and strip to plain text
+        html_body = render_email_html(body, theme)
+        plain_body = strip_markdown(body)
+
+        # Build multipart/alternative MIME
+        mime_message = MIMEMultipart("alternative")
+        mime_message.attach(MIMEText(plain_body, "plain", "utf-8"))
+        mime_message.attach(MIMEText(html_body, "html", "utf-8"))
+
         result = gmail_client.send_message(
+            message=mime_message,
             to=to,
             subject=subject,
-            body=body,
             from_email=from_header,
             thread_id=thread_id,
             account_id=account.id,
@@ -548,7 +576,7 @@ def send_email(  # noqa: PLR0913
             account_id=account.id,
             direction="outbound",
             subject=subject,
-            body_text=body,
+            body_text=plain_body,
             gmail_message_id=gmail_message_id,
             gmail_thread_id=gmail_thread_id,
             contact_id=contact_id,

--- a/src/mailpilot/sync.py
+++ b/src/mailpilot/sync.py
@@ -426,6 +426,7 @@ def _store_inbound_message(  # noqa: PLR0913
         is_routed=not within_window,
         received_at=received_at,
         labels=list(message.get("labelIds", [])),
+        rfc2822_message_id=headers.get("message-id"),
     )
     if email is None:
         return None
@@ -480,6 +481,7 @@ def send_email(  # noqa: PLR0913
     thread_id: str | None = None,
     cc: str | None = None,
     bcc: str | None = None,
+    in_reply_to: str | None = None,
 ) -> Email:
     """Send an outbound email through Gmail and record the DB row.
 
@@ -502,6 +504,9 @@ def send_email(  # noqa: PLR0913
         thread_id: Optional Gmail thread ID for replies.
         cc: Optional CC recipient(s), comma-separated.
         bcc: Optional BCC recipient(s), comma-separated.
+        in_reply_to: RFC 2822 Message-ID of the email being replied to.
+            Sets In-Reply-To and References MIME headers for cross-client
+            thread grouping.
 
     Returns:
         The created ``Email`` row with ``direction="outbound"`` and
@@ -533,6 +538,7 @@ def send_email(  # noqa: PLR0913
             account_id=account.id,
             cc=cc,
             bcc=bcc,
+            in_reply_to=in_reply_to,
         )
         gmail_message_id = result.get("id")
         gmail_thread_id = result.get("threadId")

--- a/tests/test_agent_invoke.py
+++ b/tests/test_agent_invoke.py
@@ -508,11 +508,14 @@ def test_invoke_span_has_usage_attributes(
     ]
     assert len(invoke_spans) == 1
     attrs = invoke_spans[0]["attributes"]
+    assert "model" in attrs
     assert "input_tokens" in attrs
     assert "output_tokens" in attrs
+    assert "total_tokens" in attrs
     assert "llm_requests" in attrs
     assert attrs["input_tokens"] >= 0
     assert attrs["output_tokens"] >= 0
+    assert attrs["total_tokens"] == attrs["input_tokens"] + attrs["output_tokens"]
     assert attrs["llm_requests"] >= 1
 
 

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -688,6 +688,89 @@ def test_reply_email_no_error_without_workflow_contact(
     assert result["gmail_message_id"] == "gmail-msg-1"
 
 
+def test_reply_email_passes_in_reply_to_from_original(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """reply_email looks up the original email's message_id and passes it
+    as in_reply_to so the MIME message gets In-Reply-To/References headers."""
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="sender@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+
+    original_mid = "<CABx-orig@mail.gmail.com>"
+    inbound = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Question",
+        contact_id=contact.id,
+        workflow_id=workflow.id,
+        gmail_message_id="inbound-irt",
+        gmail_thread_id="thread-irt",
+        rfc2822_message_id=original_mid,
+    )
+    assert inbound is not None
+
+    gmail_client = _make_gmail_client(account)
+
+    reply_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        email_id=inbound.id,
+        body="Here is the info.",
+    )
+
+    gmail_client.send_message.assert_called_once()
+    call_kwargs = gmail_client.send_message.call_args.kwargs
+    assert call_kwargs["in_reply_to"] == original_mid
+
+
+def test_reply_email_omits_in_reply_to_when_original_has_no_message_id(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """When the original email has no message_id, in_reply_to is not passed."""
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="sender@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+
+    inbound = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="No MID",
+        contact_id=contact.id,
+        workflow_id=workflow.id,
+        gmail_message_id="inbound-no-mid",
+        gmail_thread_id="thread-no-mid",
+    )
+    assert inbound is not None
+
+    gmail_client = _make_gmail_client(account)
+
+    reply_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        workflow_id=workflow.id,
+        email_id=inbound.id,
+        body="Reply without MID.",
+    )
+
+    gmail_client.send_message.assert_called_once()
+    call_kwargs = gmail_client.send_message.call_args.kwargs
+    assert call_kwargs.get("in_reply_to") is None
+
+
 # -- create_task ---------------------------------------------------------------
 
 

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -201,7 +201,10 @@ def test_classify_span_has_usage_attributes(capfire: CaptureLogfire) -> None:
     ]
     assert len(classify_spans) == 1
     attrs = classify_spans[0]["attributes"]
+    assert "model" in attrs
     assert "input_tokens" in attrs
     assert "output_tokens" in attrs
+    assert "total_tokens" in attrs
     assert attrs["input_tokens"] >= 0
     assert attrs["output_tokens"] >= 0
+    assert attrs["total_tokens"] == attrs["input_tokens"] + attrs["output_tokens"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1553,6 +1553,7 @@ def _make_workflow(**overrides: Any) -> Workflow:
         "status": "draft",
         "objective": "",
         "instructions": "",
+        "theme": "blue",
         "created_at": _NOW,
         "updated_at": _NOW,
     }
@@ -1594,6 +1595,7 @@ def test_workflow_create(runner: CliRunner, mock_connection: MagicMock) -> None:
         name="Demo outreach",
         workflow_type="outbound",
         account_id=_ACCOUNT_ID,
+        theme="blue",
     )
     data = json.loads(result.output)
     assert data["ok"] is True
@@ -1917,6 +1919,78 @@ def test_workflow_create_missing_fields_without_draft(
     assert "--draft" in data["message"]
 
 
+def test_workflow_create_with_theme(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    workflow = _make_workflow(theme="green")
+    account = _make_account()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_account", return_value=account),
+        patch(
+            "mailpilot.database.create_workflow", return_value=workflow
+        ) as mock_create,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "workflow",
+                "create",
+                "--name",
+                "Themed",
+                "--type",
+                "outbound",
+                "--account-id",
+                _ACCOUNT_ID,
+                "--theme",
+                "green",
+                "--draft",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_create.assert_called_once_with(
+        mock_connection,
+        name="Themed",
+        workflow_type="outbound",
+        account_id=_ACCOUNT_ID,
+        theme="green",
+    )
+    data = json.loads(result.output)
+    assert data["theme"] == "green"
+
+
+def test_workflow_create_invalid_theme(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "workflow",
+                "create",
+                "--name",
+                "Bad",
+                "--type",
+                "outbound",
+                "--account-id",
+                _ACCOUNT_ID,
+                "--theme",
+                "rainbow",
+                "--draft",
+            ],
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "validation_error"
+    assert "rainbow" in data["message"]
+
+
 # -- workflow update -----------------------------------------------------------
 
 
@@ -2037,6 +2111,42 @@ def test_workflow_update_not_found(
     assert result.exit_code == 1
     data = json.loads(result.output)
     assert data["error"] == "not_found"
+
+
+def test_workflow_update_theme(runner: CliRunner, mock_connection: MagicMock) -> None:
+    updated = _make_workflow(theme="orange")
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch(
+            "mailpilot.database.update_workflow", return_value=updated
+        ) as mock_update,
+    ):
+        result = runner.invoke(
+            main, ["workflow", "update", _WORKFLOW_ID, "--theme", "orange"]
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_update.assert_called_once_with(mock_connection, _WORKFLOW_ID, theme="orange")
+    data = json.loads(result.output)
+    assert data["theme"] == "orange"
+
+
+def test_workflow_update_invalid_theme(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+    ):
+        result = runner.invoke(
+            main, ["workflow", "update", _WORKFLOW_ID, "--theme", "rainbow"]
+        )
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error"] == "validation_error"
+    assert "rainbow" in data["message"]
 
 
 # -- workflow list / view / search ---------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2367,7 +2367,7 @@ def test_workflow_run_requires_active(
     assert data["error"] == "invalid_state"
 
 
-def test_workflow_run_requires_outbound(
+def test_workflow_run_inbound_with_email(
     runner: CliRunner, mock_connection: MagicMock
 ) -> None:
     workflow = _make_workflow(type="inbound", status="active")
@@ -2378,11 +2378,36 @@ def test_workflow_run_requires_outbound(
         created_at=_NOW,
         updated_at=_NOW,
     )
+    wc = WorkflowContact(
+        workflow_id=_WORKFLOW_ID,
+        contact_id=_CONTACT_ID,
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    inbound_email = _make_email(
+        contact_id=_CONTACT_ID,
+        workflow_id=_WORKFLOW_ID,
+        direction="inbound",
+    )
+    task = _make_task(email_id=inbound_email.id)
+    completed_task = _make_task(
+        status="completed",
+        email_id=inbound_email.id,
+        result={"reasoning": "Replied to inquiry.", "tool_calls": 1},
+    )
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
         patch("mailpilot.database.get_workflow", return_value=workflow),
         patch("mailpilot.database.get_contact", return_value=contact),
+        patch("mailpilot.database.get_workflow_contact", return_value=wc),
+        patch(
+            "mailpilot.database.get_unprocessed_inbound_email",
+            return_value=inbound_email,
+        ),
+        patch("mailpilot.database.create_task", return_value=task) as mock_create,
+        patch("mailpilot.run.execute_task") as mock_exec,
+        patch("mailpilot.database.get_task", return_value=completed_task),
     ):
         result = runner.invoke(
             main,
@@ -2395,9 +2420,72 @@ def test_workflow_run_requires_outbound(
                 _CONTACT_ID,
             ],
         )
-    assert result.exit_code == 1
+
+    assert result.exit_code == 0, result.output
+    mock_exec.assert_called_once()
+    # Task created with email_id from the unprocessed inbound email
+    call_kwargs = mock_create.call_args[1]
+    assert call_kwargs["email_id"] == inbound_email.id
+    assert call_kwargs["description"] == "manual inbound run"
     data = json.loads(result.output)
-    assert data["error"] == "invalid_state"
+    assert data["ok"] is True
+    assert data["status"] == "completed"
+
+
+def test_workflow_run_inbound_no_email(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    workflow = _make_workflow(type="inbound", status="active")
+    contact = Contact(
+        id=_CONTACT_ID,
+        email="lead@acme.com",
+        domain="acme.com",
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    wc = WorkflowContact(
+        workflow_id=_WORKFLOW_ID,
+        contact_id=_CONTACT_ID,
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    task = _make_task()
+    completed_task = _make_task(
+        status="completed",
+        result={"reasoning": "No new email, reviewed history.", "tool_calls": 1},
+    )
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_workflow", return_value=workflow),
+        patch("mailpilot.database.get_contact", return_value=contact),
+        patch("mailpilot.database.get_workflow_contact", return_value=wc),
+        patch("mailpilot.database.get_unprocessed_inbound_email", return_value=None),
+        patch("mailpilot.database.create_task", return_value=task) as mock_create,
+        patch("mailpilot.run.execute_task") as mock_exec,
+        patch("mailpilot.database.get_task", return_value=completed_task),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "workflow",
+                "run",
+                "--workflow-id",
+                _WORKFLOW_ID,
+                "--contact-id",
+                _CONTACT_ID,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_exec.assert_called_once()
+    # Task created without email_id when no unprocessed email exists
+    call_kwargs = mock_create.call_args[1]
+    assert call_kwargs["email_id"] is None
+    assert call_kwargs["description"] == "manual inbound run"
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["status"] == "completed"
 
 
 def test_workflow_run_contact_not_found(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -44,6 +44,7 @@ from mailpilot.database import (
     get_last_cold_outbound,
     get_note,
     get_status_counts,
+    get_unprocessed_inbound_email,
     get_workflow,
     get_workflow_contact,
     list_accounts,
@@ -1981,6 +1982,98 @@ def test_create_tasks_for_routed_emails_bridges_email_synced_after_workflow(
     created = create_tasks_for_routed_emails(database_connection)
     assert len(created) == 1
     assert created[0].email_id == email.id
+
+
+def test_get_unprocessed_inbound_email(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    from datetime import timedelta
+
+    account = make_test_account(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    contact = make_test_contact(database_connection)
+
+    # No emails yet -- returns None.
+    result = get_unprocessed_inbound_email(database_connection, workflow.id, contact.id)
+    assert result is None
+
+    # Create an inbound email for this contact+workflow.
+    email = create_email(
+        database_connection,
+        gmail_message_id="msg-unproc-1",
+        gmail_thread_id="thread-unproc-1",
+        account_id=account.id,
+        direction="inbound",
+        subject="Question",
+        body_text="Can you help?",
+        labels=["INBOX"],
+        received_at=workflow.created_at + timedelta(minutes=5),
+        contact_id=contact.id,
+        workflow_id=workflow.id,
+    )
+    assert email is not None
+
+    # Now returns the email.
+    result = get_unprocessed_inbound_email(database_connection, workflow.id, contact.id)
+    assert result is not None
+    assert result.id == email.id
+
+    # Create a task for that email -- it becomes "processed".
+    create_task(
+        database_connection,
+        workflow_id=workflow.id,
+        contact_id=contact.id,
+        description="handle inbound email",
+        scheduled_at="2026-04-22T12:00:00Z",
+        email_id=email.id,
+    )
+
+    # Now returns None (email has a task).
+    result = get_unprocessed_inbound_email(database_connection, workflow.id, contact.id)
+    assert result is None
+
+
+def test_get_unprocessed_inbound_email_returns_most_recent(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    from datetime import timedelta
+
+    account = make_test_account(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    contact = make_test_contact(database_connection)
+
+    older = create_email(
+        database_connection,
+        gmail_message_id="msg-older",
+        gmail_thread_id="thread-older",
+        account_id=account.id,
+        direction="inbound",
+        subject="First",
+        body_text="First msg",
+        labels=["INBOX"],
+        received_at=workflow.created_at + timedelta(minutes=1),
+        contact_id=contact.id,
+        workflow_id=workflow.id,
+    )
+    assert older is not None
+    newer = create_email(
+        database_connection,
+        gmail_message_id="msg-newer",
+        gmail_thread_id="thread-newer",
+        account_id=account.id,
+        direction="inbound",
+        subject="Second",
+        body_text="Second msg",
+        labels=["INBOX"],
+        received_at=workflow.created_at + timedelta(minutes=10),
+        contact_id=contact.id,
+        workflow_id=workflow.id,
+    )
+    assert newer is not None
+
+    result = get_unprocessed_inbound_email(database_connection, workflow.id, contact.id)
+    assert result is not None
+    assert result.id == newer.id
 
 
 def test_complete_task_stores_result(

--- a/tests/test_email_renderer.py
+++ b/tests/test_email_renderer.py
@@ -1,0 +1,155 @@
+"""Tests for Markdown-to-HTML email rendering."""
+
+from mailpilot.email_renderer import (
+    THEMES,
+    get_theme,
+    render_email_html,
+    strip_markdown,
+)
+
+
+def test_themes_contains_six_palettes():
+    assert len(THEMES) == 6
+    assert set(THEMES.keys()) == {"blue", "green", "orange", "purple", "red", "slate"}
+
+
+def test_each_theme_has_three_hex_colors():
+    for name, theme in THEMES.items():
+        for field in ("primary", "accent", "border"):
+            value = getattr(theme, field)
+            assert value.startswith("#"), f"{name}.{field} = {value}"
+            assert len(value) == 7, f"{name}.{field} = {value}"
+
+
+def test_get_theme_returns_named_theme():
+    theme = get_theme("green")
+    assert theme.primary == "#16a34a"
+
+
+def test_get_theme_falls_back_to_blue():
+    theme = get_theme("nonexistent")
+    assert theme == THEMES["blue"]
+
+
+def test_get_theme_none_falls_back_to_blue():
+    theme = get_theme(None)
+    assert theme == THEMES["blue"]
+
+
+def test_render_wraps_in_container_div():
+    html = render_email_html("Hello", get_theme("blue"))
+    assert html.startswith('<div style="')
+    assert "max-width:600px" in html
+    assert html.endswith("</div>")
+
+
+def test_render_heading_uses_primary_color():
+    theme = get_theme("blue")
+    html = render_email_html("## Title", theme)
+    assert f"color:{theme.primary}" in html
+    assert "<h2" in html
+    assert "Title" in html
+
+
+def test_render_paragraph_uses_body_styles():
+    html = render_email_html("Hello world", get_theme("blue"))
+    assert "<p" in html
+    assert "font-size:16px" in html
+
+
+def test_render_table_with_themed_headers():
+    md = "| Model | Flow |\n|-------|------|\n| WS48 | 150 |"
+    theme = get_theme("green")
+    html = render_email_html(md, theme)
+    assert "<table" in html
+    assert "<th" in html
+    assert f"background-color:{theme.accent}" in html
+    assert "WS48" in html
+    assert "150" in html
+
+
+def test_render_link_uses_primary_color():
+    theme = get_theme("orange")
+    html = render_email_html("[Lab5](https://lab5.ca)", theme)
+    assert f"color:{theme.primary}" in html
+    assert 'href="https://lab5.ca"' in html
+
+
+def test_render_bold_and_italic():
+    html = render_email_html("**bold** and *italic*", get_theme("blue"))
+    assert "<strong>" in html
+    assert "<em>" in html
+
+
+def test_render_unordered_list():
+    html = render_email_html("- one\n- two", get_theme("blue"))
+    assert "<ul" in html
+    assert "<li" in html
+
+
+def test_render_ordered_list():
+    html = render_email_html("1. first\n2. second", get_theme("blue"))
+    assert "<ol" in html
+
+
+def test_render_horizontal_rule():
+    theme = get_theme("blue")
+    html = render_email_html("---", theme)
+    assert "<hr" in html
+    assert f"border-top:1px solid {theme.border}" in html
+
+
+def test_render_inline_code():
+    html = render_email_html("Use `cmd` here", get_theme("blue"))
+    assert "<code" in html
+    assert "cmd" in html
+
+
+def test_strip_removes_bold_markers():
+    assert "bold" in strip_markdown("**bold** text")
+    assert "**" not in strip_markdown("**bold** text")
+
+
+def test_strip_removes_italic_markers():
+    assert "italic" in strip_markdown("*italic* text")
+    result = strip_markdown("*italic* text")
+    assert result.startswith("italic")
+
+
+def test_strip_removes_heading_markers():
+    result = strip_markdown("## Title\n\nBody")
+    assert "##" not in result
+    assert "TITLE" in result
+
+
+def test_strip_renders_link_with_url():
+    result = strip_markdown("[Lab5](https://lab5.ca)")
+    assert "Lab5" in result
+    assert "https://lab5.ca" in result
+
+
+def test_strip_renders_table_rows():
+    md = "| Model | Flow |\n|-------|------|\n| WS48 | 150 |"
+    result = strip_markdown(md)
+    assert "Model" in result
+    assert "WS48" in result
+    assert "150" in result
+
+
+def test_strip_removes_hr_markers():
+    result = strip_markdown("above\n\n---\n\nbelow")
+    assert "---" not in result
+    assert "above" in result
+    assert "below" in result
+
+
+def test_strip_removes_code_backticks():
+    result = strip_markdown("Use `cmd` here")
+    assert "`" not in result
+    assert "cmd" in result
+
+
+def test_strip_preserves_list_format():
+    result = strip_markdown("- one\n- two")
+    assert "one" in result
+    assert "two" in result

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -557,6 +557,27 @@ def test_sync_account_updates_account_history_and_last_synced(
 # -- send_email ---------------------------------------------------------------
 
 
+def _get_sent_mime(
+    service: MagicMock,
+) -> tuple[Any, list[Any]]:
+    """Extract the sent MIME message and its parts from a Gmail mock.
+
+    Returns:
+        Tuple of (outer_message, parts_list). The outer message is
+        a multipart/alternative; parts_list has [plain_part, html_part].
+    """
+    from email import message_from_bytes
+
+    send_body = service.users.return_value.messages.return_value.send.call_args.kwargs[
+        "body"
+    ]
+    raw = base64.urlsafe_b64decode(send_body["raw"])
+    msg = message_from_bytes(raw)
+    payload = msg.get_payload()
+    assert isinstance(payload, list)
+    return msg, list(payload)
+
+
 def _make_send_client(
     email: str = "sender@example.com",
     send_result: dict[str, Any] | None = None,
@@ -889,17 +910,14 @@ def test_send_email_omits_threading_headers_without_in_reply_to(
     assert msg["References"] is None
 
 
-def test_send_email_always_uses_utf8_base64_encoding(
+def test_send_email_parts_use_utf8_charset(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
-    """All outbound emails use UTF-8 with base64 encoding for consistent
-    rendering across mail clients, regardless of body content."""
-    from email import message_from_bytes
-
+    """Both plain text and HTML parts use UTF-8 charset for consistent
+    rendering across mail clients."""
     account = make_test_account(database_connection, email="enc@example.com")
     client, service = _make_send_client(account.email)
 
-    # Pure ASCII body -- should still use utf-8/base64, not us-ascii/7bit.
     send_email(
         database_connection,
         account=account,
@@ -910,10 +928,66 @@ def test_send_email_always_uses_utf8_base64_encoding(
         body="Plain ASCII body with no special characters.",
     )
 
-    send_body = service.users.return_value.messages.return_value.send.call_args.kwargs[
-        "body"
-    ]
-    raw = base64.urlsafe_b64decode(send_body["raw"])
-    msg = message_from_bytes(raw)
-    assert msg.get_content_charset() == "utf-8"
-    assert msg["Content-Transfer-Encoding"] == "base64"
+    msg, parts = _get_sent_mime(service)
+    assert msg.get_content_type() == "multipart/alternative"
+    assert parts[0].get_content_charset() == "utf-8"
+    assert parts[1].get_content_charset() == "utf-8"
+
+
+def test_send_email_produces_multipart_alternative(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """send_email builds multipart/alternative with plain text and HTML parts."""
+    account = make_test_account(database_connection, email="mp@example.com")
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    client, service = _make_send_client(account.email)
+
+    send_email(
+        database_connection,
+        account=account,
+        gmail_client=client,
+        settings=make_test_settings(),
+        to="recipient@example.com",
+        subject="Hello",
+        body="**Bold** and a [link](https://lab5.ca)",
+        workflow_id=workflow.id,
+    )
+
+    msg, parts = _get_sent_mime(service)
+    assert msg.get_content_type() == "multipart/alternative"
+    assert len(parts) == 2
+    plain_part = parts[0]
+    html_part = parts[1]
+    assert plain_part.get_content_type() == "text/plain"
+    assert html_part.get_content_type() == "text/html"
+    html_raw = html_part.get_payload(decode=True)
+    assert isinstance(html_raw, bytes)
+    html_body = html_raw.decode()
+    assert "<strong>" in html_body
+    assert "lab5.ca" in html_body
+    plain_raw = plain_part.get_payload(decode=True)
+    assert isinstance(plain_raw, bytes)
+    plain_body = plain_raw.decode()
+    assert "**" not in plain_body
+    assert "Bold" in plain_body
+
+
+def test_send_email_stores_plain_text_in_db(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """body_text in DB contains stripped plain text, not Markdown."""
+    account = make_test_account(database_connection, email="db@example.com")
+    client, _service = _make_send_client(account.email)
+
+    email = send_email(
+        database_connection,
+        account=account,
+        gmail_client=client,
+        settings=make_test_settings(),
+        to="recipient@example.com",
+        subject="Hello",
+        body="**Bold** text",
+    )
+
+    assert "**" not in email.body_text
+    assert "Bold" in email.body_text

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -116,9 +116,16 @@ def _make_gmail_message(
     body: str = "Body of the email",
     received_at: datetime | None = None,
     label_ids: list[str] | None = None,
+    rfc_message_id: str | None = None,
 ) -> dict[str, Any]:
     received_at = received_at or datetime.now(UTC)
     body_b64 = base64.urlsafe_b64encode(body.encode()).decode()
+    headers = [
+        {"name": "From", "value": from_header},
+        {"name": "Subject", "value": subject},
+    ]
+    if rfc_message_id is not None:
+        headers.append({"name": "Message-ID", "value": rfc_message_id})
     return {
         "id": message_id,
         "threadId": thread_id,
@@ -126,10 +133,7 @@ def _make_gmail_message(
         "labelIds": label_ids or ["INBOX"],
         "payload": {
             "mimeType": "text/plain",
-            "headers": [
-                {"name": "From", "value": from_header},
-                {"name": "Subject", "value": subject},
-            ],
+            "headers": headers,
             "body": {"data": body_b64},
         },
     }
@@ -782,3 +786,134 @@ def test_send_email_passes_multiple_to_recipients(
     raw = base64.urlsafe_b64decode(send_body["raw"])
     msg = message_from_bytes(raw)
     assert msg["to"] == "a@example.com,b@example.com"
+
+
+# -- Message-ID / In-Reply-To threading ----------------------------------------
+
+
+def test_sync_stores_message_id_from_inbound_email(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Sync extracts the RFC 2822 Message-ID header and stores it."""
+    account = make_test_account(database_connection, email="sync-mid@example.com")
+    client, service = _make_mock_client(account.email)
+    rfc_mid = "<CABx123@mail.gmail.com>"
+    _set_list_messages(service, [{"id": "m-mid", "threadId": "t-mid"}])
+    _set_get_messages(
+        service,
+        [_make_gmail_message("m-mid", "t-mid", rfc_message_id=rfc_mid)],
+    )
+
+    sync_account(database_connection, account, client, make_test_settings())
+
+    email = get_email_by_gmail_message_id(database_connection, "m-mid")
+    assert email is not None
+    assert email.rfc2822_message_id == rfc_mid
+
+
+def test_sync_stores_none_when_message_id_absent(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """When a message has no Message-ID header, message_id stays None."""
+    account = make_test_account(database_connection, email="sync-nomid@example.com")
+    client, service = _make_mock_client(account.email)
+    _set_list_messages(service, [{"id": "m-nomid", "threadId": "t-nomid"}])
+    _set_get_messages(
+        service,
+        [_make_gmail_message("m-nomid", "t-nomid")],
+    )
+
+    sync_account(database_connection, account, client, make_test_settings())
+
+    email = get_email_by_gmail_message_id(database_connection, "m-nomid")
+    assert email is not None
+    assert email.rfc2822_message_id is None
+
+
+def test_send_email_sets_in_reply_to_and_references_headers(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """When in_reply_to is provided, the MIME message includes threading headers."""
+    from email import message_from_bytes
+
+    account = make_test_account(database_connection, email="reply-hdr@example.com")
+    client, service = _make_send_client(account.email)
+    original_mid = "<orig-123@mail.gmail.com>"
+
+    send_email(
+        database_connection,
+        account=account,
+        gmail_client=client,
+        settings=make_test_settings(),
+        to="recipient@example.com",
+        subject="Re: Hello",
+        body="Reply body",
+        thread_id="existing-thread",
+        in_reply_to=original_mid,
+    )
+
+    send_body = service.users.return_value.messages.return_value.send.call_args.kwargs[
+        "body"
+    ]
+    raw = base64.urlsafe_b64decode(send_body["raw"])
+    msg = message_from_bytes(raw)
+    assert msg["In-Reply-To"] == original_mid
+    assert msg["References"] == original_mid
+
+
+def test_send_email_omits_threading_headers_without_in_reply_to(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Without in_reply_to, no In-Reply-To or References headers are set."""
+    from email import message_from_bytes
+
+    account = make_test_account(database_connection, email="no-irt@example.com")
+    client, service = _make_send_client(account.email)
+
+    send_email(
+        database_connection,
+        account=account,
+        gmail_client=client,
+        settings=make_test_settings(),
+        to="recipient@example.com",
+        subject="Hello",
+        body="New message",
+    )
+
+    send_body = service.users.return_value.messages.return_value.send.call_args.kwargs[
+        "body"
+    ]
+    raw = base64.urlsafe_b64decode(send_body["raw"])
+    msg = message_from_bytes(raw)
+    assert msg["In-Reply-To"] is None
+    assert msg["References"] is None
+
+
+def test_send_email_always_uses_utf8_base64_encoding(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """All outbound emails use UTF-8 with base64 encoding for consistent
+    rendering across mail clients, regardless of body content."""
+    from email import message_from_bytes
+
+    account = make_test_account(database_connection, email="enc@example.com")
+    client, service = _make_send_client(account.email)
+
+    # Pure ASCII body -- should still use utf-8/base64, not us-ascii/7bit.
+    send_email(
+        database_connection,
+        account=account,
+        gmail_client=client,
+        settings=make_test_settings(),
+        to="recipient@example.com",
+        subject="Hello",
+        body="Plain ASCII body with no special characters.",
+    )
+
+    send_body = service.users.return_value.messages.return_value.send.call_args.kwargs[
+        "body"
+    ]
+    raw = base64.urlsafe_b64decode(send_body["raw"])
+    msg = message_from_bytes(raw)
+    assert msg.get_content_charset() == "utf-8"
+    assert msg["Content-Transfer-Encoding"] == "base64"

--- a/tests/test_workflow_theme.py
+++ b/tests/test_workflow_theme.py
@@ -1,0 +1,63 @@
+"""Tests for workflow theme support."""
+
+from typing import Any
+
+import psycopg
+
+from conftest import make_test_account
+from mailpilot.database import create_workflow, get_workflow, update_workflow
+
+
+def test_create_workflow_default_theme(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    account = make_test_account(database_connection)
+    workflow = create_workflow(
+        database_connection,
+        name="Test",
+        workflow_type="outbound",
+        account_id=account.id,
+    )
+    assert workflow.theme == "blue"
+
+
+def test_create_workflow_custom_theme(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    account = make_test_account(database_connection)
+    workflow = create_workflow(
+        database_connection,
+        name="Themed",
+        workflow_type="outbound",
+        account_id=account.id,
+        theme="green",
+    )
+    assert workflow.theme == "green"
+
+
+def test_update_workflow_theme(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    account = make_test_account(database_connection)
+    workflow = create_workflow(
+        database_connection, name="W", workflow_type="outbound", account_id=account.id
+    )
+    updated = update_workflow(database_connection, workflow.id, theme="orange")
+    assert updated is not None
+    assert updated.theme == "orange"
+
+
+def test_get_workflow_includes_theme(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    account = make_test_account(database_connection)
+    created = create_workflow(
+        database_connection,
+        name="Get",
+        workflow_type="inbound",
+        account_id=account.id,
+        theme="purple",
+    )
+    fetched = get_workflow(database_connection, created.id)
+    assert fetched is not None
+    assert fetched.theme == "purple"

--- a/uv.lock
+++ b/uv.lock
@@ -560,6 +560,7 @@ dependencies = [
     { name = "google-auth" },
     { name = "google-cloud-pubsub" },
     { name = "logfire" },
+    { name = "mistune" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic-ai-slim", extra = ["anthropic"] },
     { name = "pydantic-settings" },
@@ -581,6 +582,7 @@ requires-dist = [
     { name = "google-auth", specifier = ">=2.40.0,<3.0.0" },
     { name = "google-cloud-pubsub", specifier = ">=2.29.0,<3.0.0" },
     { name = "logfire", specifier = ">=4.0.0,<5.0.0" },
+    { name = "mistune", specifier = ">=3.1.0,<4.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0,<4.0.0" },
     { name = "pydantic-ai-slim", extras = ["anthropic"], specifier = ">=1.10.0,<2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.7.0,<3.0.0" },
@@ -614,6 +616,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mistune"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/55/d01f0c4b45ade6536c51170b9043db8b2ec6ddf4a35c7ea3f5f559ac935b/mistune-3.2.0.tar.gz", hash = "sha256:708487c8a8cdd99c9d90eb3ed4c3ed961246ff78ac82f03418f5183ab70e398a", size = 95467, upload-time = "2025-12-23T11:36:34.994Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/f7/4a5e785ec9fbd65146a27b6b70b6cdc161a66f2024e4b04ac06a67f5578b/mistune-3.2.0-py3-none-any.whl", hash = "sha256:febdc629a3c78616b94393c6580551e0e34cc289987ec6c35ed3f4be42d0eee1", size = 53598, upload-time = "2025-12-23T11:36:33.211Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR delivers four bundled features for the inbound workflow loop and email delivery pipeline:

1. **`workflow run` inbound support** — removes the outbound-only guard so inbound workflows can be exercised directly via CLI. Looks up the most recent unprocessed email via `get_unprocessed_inbound_email()` and attaches it to the task; falls back to a generic trigger if no email is found.
2. **HTML email rendering** — agent-generated Markdown bodies are converted to themed HTML via a custom `mistune` renderer with inline styles. Six color palettes (`blue`, `green`, `orange`, `purple`, `red`, `slate`) are stored as a `theme` column on the workflow table and selected per-workflow.
3. **RFC 2822 Message-ID threading** — inbound emails store the `Message-ID` header in a new `rfc2822_message_id` column; `reply_email` propagates `In-Reply-To` / `References` headers so replies group correctly in all mail clients.
4. **Agent observability** — `agent.invoke` and `agent.classify_email` spans now emit `model` and `total_tokens` attributes for cost estimation in Logfire.

Also restructures the smoke-test skill to create both workflows in Phase 0 (fixing the `predates_workflows` timing issue from PR #70) and replaces the `timeout 30 mailpilot run` loop in Phase 3 with a direct `workflow run` call.

Resolves #66