### PR TITLE
feat(schema): add sender and recipients columns to email table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,10 @@ Email body stored as plain text only (see `docs/adr-02-email-body-storage-strate
 
 Workflow is the central abstraction for both outbound campaigns and inbound auto-reply (see `docs/adr-03-workflow-model.md`). Each workflow is executed by a Pydantic AI agent with tool access. Inbound emails are routed via thread matching then LLM classification. Agent plans multi-step work via deferred tasks. See `docs/email-flow.md` for execution flows. See `docs/adr-08-crm-evolution.md` for the CRM evolution design.
 
+### Email Rendering
+
+`email_renderer.py` provides Markdown-to-HTML email rendering with inline styles and theme support. `EmailTheme` defines color palettes; six built-in themes: blue, green, orange, purple, red, slate. `THEME_NAMES` is the validation set used by CLI `--theme` options.
+
 ### CLI
 
 The CLI must be LLM Agent friendly: JSON output only. Exit codes must be meaningful. Error messages must be actionable. The CLI is a thin dispatcher -- no domain logic or logging. All `logfire` calls belong in sync/agent modules where decisions happen. CLI only does `logfire.configure()` and `output()`.
@@ -243,7 +247,7 @@ If a GitHub operation isn't covered by a skill (e.g. reviewing comments, closing
 2. Implement minimal code to pass
 3. Run: `uv run ruff check --fix` then `uv run basedpyright`
 
-Tests use a separate database: `postgresql://localhost/mailpilot_test` (override with `DATABASE_URL` env var). The `database_connection` fixture truncates all tables before each test. Use `make_test_settings()` for Settings instances and `load_fixture()` for JSON fixtures -- all in `conftest.py`. HTTP mocking uses `pytest-httpx`. Span-contract tests use the `capfire: CaptureLogfire` fixture (see `tests/test_database_telemetry.py`). The `e2e` pytest marker is excluded from default runs (`addopts = "-m 'not e2e'"`); live-Gmail tests live under `tests/e2e/` and run via `make e2e` against `mailpilot_e2e`.
+Tests use a separate database: `postgresql://localhost/mailpilot_test` (override with `DATABASE_URL` env var). The `database_connection` fixture truncates all tables before each test. Use `make_test_settings()` for Settings instances and `load_fixture()` for JSON fixtures -- all in `conftest.py`. HTTP mocking uses `pytest-httpx`. Span-contract tests use the `capfire: CaptureLogfire` fixture from `logfire.testing` (see `tests/test_database_telemetry.py`). The `e2e` pytest marker is excluded from default runs (`addopts = "-m 'not e2e'"`); live-Gmail tests live under `tests/e2e/` and run via `make e2e` against `mailpilot_e2e`.
 
 **Patching gotcha for entity validation.** When a CLI command calls `get_contact()`, `get_company()`, or `get_account()` for FK validation, every test for that command must patch the `get_*` function with a valid return value. Adding FK validation to an existing command will break its tests until the patches are added.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ mailpilot task view ID
 mailpilot task cancel ID
 
 mailpilot email search QUERY [--limit N]
-mailpilot email list [--limit N] [--contact-id ID] [--account-id ID] [--since ISO] [--thread-id TEXT] [--direction inbound|outbound] [--workflow-id ID] [--status sent|received|bounced]
+mailpilot email list [--limit N] [--contact-id ID] [--account-id ID] [--since ISO] [--thread-id TEXT] [--direction inbound|outbound] [--workflow-id ID] [--status sent|received|bounced] [--from ADDR] [--to ADDR]
 mailpilot email view ID
 mailpilot email send --account-id ID --to E [--to E2 ...] --subject S --body B [--contact-id ID] [--workflow-id ID] [--thread-id ID] [--cc E] [--bcc E]
 

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -720,6 +720,10 @@ def email_search(query: str, limit: int) -> None:
     type=click.Choice(["sent", "received", "bounced"]),
     help="Filter by email status.",
 )
+@click.option("--from", "sender", default=None, help="Filter by sender email address.")
+@click.option(
+    "--to", "recipient", default=None, help="Filter by recipient email address."
+)
 def email_list(
     limit: int,
     contact_id: str | None,
@@ -729,6 +733,8 @@ def email_list(
     direction: str | None,
     workflow_id: str | None,
     status: str | None,
+    sender: str | None,
+    recipient: str | None,
 ) -> None:
     """List emails with optional filters."""
     from mailpilot.database import (
@@ -757,6 +763,8 @@ def email_list(
             direction=direction,
             workflow_id=workflow_id,
             status=status,
+            sender=sender,
+            recipient=recipient,
         )
         output({"emails": [e.model_dump(mode="json") for e in emails]})
     finally:

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -1170,6 +1170,8 @@ def create_email(
     sent_at: datetime | None = None,
     labels: list[str] | None = None,
     rfc2822_message_id: str | None = None,
+    sender: str = "",
+    recipients: dict[str, list[str]] | None = None,
 ) -> Email | None:
     """Create a new email record, or return None on gmail_message_id conflict.
 
@@ -1195,6 +1197,9 @@ def create_email(
         sent_at: When the outbound message was handed to Gmail (UTC datetime).
         labels: Gmail label IDs attached to the message.
         rfc2822_message_id: RFC 2822 Message-ID header value.
+        sender: Sender email address (lowercase).
+        recipients: Recipient addresses grouped by type
+            (``{"to": [...], "cc": [...], "bcc": [...]}``)
 
     Returns:
         Created email, or None if another worker already stored a row with
@@ -1205,12 +1210,14 @@ def create_email(
         INSERT INTO email (id, account_id, direction, subject,
             body_text, gmail_message_id, gmail_thread_id,
             contact_id, workflow_id, status, is_routed,
-            received_at, sent_at, labels, rfc2822_message_id)
+            received_at, sent_at, labels, rfc2822_message_id,
+            sender, recipients)
         VALUES (%(id)s, %(account_id)s, %(direction)s,
             %(subject)s, %(body_text)s, %(gmail_message_id)s,
             %(gmail_thread_id)s, %(contact_id)s, %(workflow_id)s,
             %(status)s, %(is_routed)s, %(received_at)s, %(sent_at)s,
-            %(labels)s, %(rfc2822_message_id)s)
+            %(labels)s, %(rfc2822_message_id)s,
+            %(sender)s, %(recipients)s)
         ON CONFLICT (gmail_message_id) DO NOTHING
         RETURNING *
         """,
@@ -1230,6 +1237,8 @@ def create_email(
             "sent_at": sent_at,
             "labels": Json(labels or []),
             "rfc2822_message_id": rfc2822_message_id,
+            "sender": sender,
+            "recipients": Json(recipients or {}),
         },
     ).fetchone()
     connection.commit()
@@ -1270,6 +1279,8 @@ def list_emails(
     direction: str | None = None,
     workflow_id: str | None = None,
     status: str | None = None,
+    sender: str | None = None,
+    recipient: str | None = None,
 ) -> list[Email]:
     """List emails with optional filters.
 
@@ -1283,6 +1294,9 @@ def list_emails(
         direction: Filter by direction ("inbound" or "outbound").
         workflow_id: Filter by workflow ID.
         status: Filter by email status ("sent", "received", "bounced").
+        sender: Filter by sender email address (case-insensitive).
+        recipient: Filter by recipient address in recipients JSONB
+            (case-insensitive, matches to/cc/bcc).
 
     Returns:
         List of emails ordered by creation time descending.
@@ -1310,6 +1324,14 @@ def list_emails(
     if status is not None:
         conditions.append(SQL("status = %(status)s"))
         params["status"] = status
+    if sender is not None:
+        conditions.append(SQL("LOWER(sender) = LOWER(%(sender)s)"))
+        params["sender"] = sender
+    if recipient is not None:
+        conditions.append(
+            SQL("LOWER(recipients::text) LIKE LOWER(%(recipient_pattern)s)")
+        )
+        params["recipient_pattern"] = f"%{recipient}%"
     where = SQL("WHERE ") + SQL(" AND ").join(conditions) if conditions else SQL("")
     query = SQL(
         "SELECT * FROM email {} ORDER BY created_at DESC LIMIT %(limit)s"
@@ -1324,7 +1346,7 @@ def search_emails(
     limit: int = 100,
     account_id: str | None = None,
 ) -> list[Email]:
-    """Search emails by subject or body text.
+    """Search emails by subject, body text, sender, or recipients.
 
     Args:
         connection: Open database connection.
@@ -1344,7 +1366,9 @@ def search_emails(
     query_sql = SQL(
         "SELECT * FROM email "
         "WHERE (LOWER(subject) LIKE LOWER(%(pattern)s) "
-        "   OR LOWER(body_text) LIKE LOWER(%(pattern)s)) "
+        "   OR LOWER(body_text) LIKE LOWER(%(pattern)s) "
+        "   OR LOWER(sender) LIKE LOWER(%(pattern)s) "
+        "   OR LOWER(recipients::text) LIKE LOWER(%(pattern)s)) "
         "{} "
         "ORDER BY created_at DESC "
         "LIMIT %(limit)s"

--- a/src/mailpilot/models.py
+++ b/src/mailpilot/models.py
@@ -128,6 +128,8 @@ class Email(BaseModel):
     labels: list[str] = []
     status: str = "received"
     is_routed: bool = False
+    sender: str = ""
+    recipients: dict[str, list[str]] = {}
     sent_at: datetime | None = None
     received_at: datetime | None = None
     created_at: datetime

--- a/src/mailpilot/schema.sql
+++ b/src/mailpilot/schema.sql
@@ -89,6 +89,8 @@ CREATE TABLE IF NOT EXISTS email (
     status            TEXT NOT NULL DEFAULT 'received'
                       CHECK (status IN ('sent', 'received', 'bounced')),
     is_routed         BOOLEAN NOT NULL DEFAULT FALSE,
+    sender            TEXT NOT NULL DEFAULT '',
+    recipients        JSONB NOT NULL DEFAULT '{}',
     sent_at           TIMESTAMPTZ,
     received_at       TIMESTAMPTZ,
     created_at        TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP

--- a/src/mailpilot/schema.sql
+++ b/src/mailpilot/schema.sql
@@ -83,14 +83,14 @@ CREATE TABLE IF NOT EXISTS email (
     contact_id        TEXT REFERENCES contact(id),
     workflow_id       TEXT REFERENCES workflow(id),
     direction         TEXT NOT NULL CHECK (direction IN ('inbound', 'outbound')),
+    sender            TEXT NOT NULL DEFAULT '',
+    recipients        JSONB NOT NULL DEFAULT '{}',
     subject           TEXT NOT NULL DEFAULT '',
     body_text         TEXT NOT NULL DEFAULT '',
     labels            JSONB NOT NULL DEFAULT '[]',
     status            TEXT NOT NULL DEFAULT 'received'
                       CHECK (status IN ('sent', 'received', 'bounced')),
     is_routed         BOOLEAN NOT NULL DEFAULT FALSE,
-    sender            TEXT NOT NULL DEFAULT '',
-    recipients        JSONB NOT NULL DEFAULT '{}',
     sent_at           TIMESTAMPTZ,
     received_at       TIMESTAMPTZ,
     created_at        TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP

--- a/src/mailpilot/sync.py
+++ b/src/mailpilot/sync.py
@@ -20,7 +20,7 @@ import signal
 import threading
 import time
 from datetime import UTC, datetime, timedelta
-from email.utils import formataddr
+from email.utils import formataddr, getaddresses
 from typing import Any
 
 import click
@@ -382,6 +382,29 @@ def _extract_added_message_ids(history: list[dict[str, Any]]) -> list[str]:
     return ids
 
 
+def _extract_recipients(headers: dict[str, str]) -> dict[str, list[str]]:
+    """Extract recipient addresses from email headers.
+
+    Parses To, Cc, and Bcc headers into a dict of lowercase addresses
+    grouped by type. Empty lists are omitted from the result.
+
+    Args:
+        headers: Lowercase-keyed header dict from ``get_message_headers()``.
+
+    Returns:
+        Dict like ``{"to": ["a@x.com"], "cc": ["b@x.com"]}``.
+    """
+    result: dict[str, list[str]] = {}
+    for key in ("to", "cc", "bcc"):
+        raw = headers.get(key, "")
+        if not raw:
+            continue
+        addresses = [addr.lower() for _name, addr in getaddresses([raw]) if addr]
+        if addresses:
+            result[key] = addresses
+    return result
+
+
 def _store_inbound_message(  # noqa: PLR0913
     connection: psycopg.Connection[dict[str, Any]],
     account: Account,
@@ -414,6 +437,7 @@ def _store_inbound_message(  # noqa: PLR0913
     within_window = (
         received_at is not None and datetime.now(UTC) - received_at <= _RECENCY_WINDOW
     )
+    inbound_recipients = _extract_recipients(headers)
     email = create_email(
         connection,
         account_id=account.id,
@@ -427,6 +451,8 @@ def _store_inbound_message(  # noqa: PLR0913
         received_at=received_at,
         labels=list(message.get("labelIds", [])),
         rfc2822_message_id=headers.get("message-id"),
+        sender=sender_email.lower(),
+        recipients=inbound_recipients,
     )
     if email is None:
         return None
@@ -571,6 +597,17 @@ def send_email(  # noqa: PLR0913
         gmail_message_id = result.get("id")
         gmail_thread_id = result.get("threadId")
         labels = list(result.get("labelIds") or [])
+        outbound_recipients: dict[str, list[str]] = {
+            "to": [a.strip().lower() for a in to.split(",") if a.strip()],
+        }
+        if cc:
+            outbound_recipients["cc"] = [
+                a.strip().lower() for a in cc.split(",") if a.strip()
+            ]
+        if bcc:
+            outbound_recipients["bcc"] = [
+                a.strip().lower() for a in bcc.split(",") if a.strip()
+            ]
         email = create_email(
             connection,
             account_id=account.id,
@@ -585,6 +622,8 @@ def send_email(  # noqa: PLR0913
             is_routed=True,
             sent_at=datetime.now(UTC),
             labels=labels,
+            sender=account.email.lower(),
+            recipients=outbound_recipients,
         )
         if email is None:
             # Gmail accepted the send but the DB insert returned None (would

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1120,6 +1120,8 @@ def test_email_list(runner: CliRunner, mock_connection: MagicMock) -> None:
         direction=None,
         workflow_id=None,
         status=None,
+        sender=None,
+        recipient=None,
     )
 
 
@@ -1169,6 +1171,8 @@ def test_email_list_with_filters(runner: CliRunner, mock_connection: MagicMock) 
         direction=None,
         workflow_id=None,
         status=None,
+        sender=None,
+        recipient=None,
     )
 
 
@@ -1210,6 +1214,8 @@ def test_email_list_with_new_filters(
         direction="inbound",
         workflow_id=_WORKFLOW_ID,
         status="received",
+        sender=None,
+        recipient=None,
     )
 
 
@@ -1286,6 +1292,41 @@ def test_email_list_account_not_found(
     data = json.loads(result.output)
     assert data["error"] == "not_found"
     assert "account" in data["message"]
+
+
+def test_email_list_with_from_and_to_filters(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_emails", return_value=[]) as mock_list,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "email",
+                "list",
+                "--from",
+                "alice@example.com",
+                "--to",
+                "bob@example.com",
+            ],
+        )
+    assert result.exit_code == 0
+    mock_list.assert_called_once_with(
+        mock_connection,
+        limit=100,
+        contact_id=None,
+        account_id=None,
+        since=None,
+        thread_id=None,
+        direction=None,
+        workflow_id=None,
+        status=None,
+        sender="alice@example.com",
+        recipient="bob@example.com",
+    )
 
 
 # -- email send ----------------------------------------------------------------

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1198,6 +1198,149 @@ def test_search_emails_filters_by_account_id(
     assert results[0].account_id == a1.id
 
 
+# -- sender / recipients columns -----------------------------------------------
+
+
+def test_create_email_with_sender_and_recipients(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    recipients = {"to": ["alice@example.com"], "cc": ["bob@example.com"]}
+    email = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="Hello",
+        status="sent",
+        sender="outbound@lab5.ca",
+        recipients=recipients,
+    )
+    assert email is not None
+    assert email.sender == "outbound@lab5.ca"
+    assert email.recipients == recipients
+
+
+def test_create_email_defaults_sender_and_recipients(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    email = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+    )
+    assert email is not None
+    assert email.sender == ""
+    assert email.recipients == {}
+
+
+def test_search_emails_matches_sender(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Unrelated subject",
+        sender="alice@example.com",
+        gmail_message_id="msg_sender_search",
+    )
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Another email",
+        sender="bob@example.com",
+        gmail_message_id="msg_sender_search_2",
+    )
+    results = search_emails(database_connection, "alice@example.com")
+    assert len(results) == 1
+    assert results[0].sender == "alice@example.com"
+
+
+def test_search_emails_matches_recipients(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="Outgoing",
+        status="sent",
+        recipients={"to": ["kb@lab5.ca"], "cc": ["dev@lab5.ca"]},
+        gmail_message_id="msg_recip_search",
+    )
+    results = search_emails(database_connection, "kb@lab5.ca")
+    assert len(results) == 1
+    assert "kb@lab5.ca" in results[0].recipients["to"]
+
+
+def test_list_emails_filter_by_sender(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        sender="alice@example.com",
+        gmail_message_id="msg_from_alice",
+    )
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        sender="bob@example.com",
+        gmail_message_id="msg_from_bob",
+    )
+    results = list_emails(database_connection, sender="alice@example.com")
+    assert len(results) == 1
+    assert results[0].sender == "alice@example.com"
+
+
+def test_list_emails_filter_by_recipient(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        status="sent",
+        recipients={"to": ["kb@lab5.ca"]},
+        gmail_message_id="msg_to_kb",
+    )
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        status="sent",
+        recipients={"to": ["other@lab5.ca"]},
+        gmail_message_id="msg_to_other",
+    )
+    results = list_emails(database_connection, recipient="kb@lab5.ca")
+    assert len(results) == 1
+    assert "kb@lab5.ca" in results[0].recipients["to"]
+
+
+def test_list_emails_filter_by_recipient_matches_cc(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection)
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        status="sent",
+        recipients={"to": ["main@example.com"], "cc": ["kb@lab5.ca"]},
+        gmail_message_id="msg_cc_kb",
+    )
+    results = list_emails(database_connection, recipient="kb@lab5.ca")
+    assert len(results) == 1
+
+
 # -- Activity ------------------------------------------------------------------
 
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -12,6 +12,7 @@ from googleapiclient.errors import HttpError
 
 from conftest import (
     make_test_account,
+    make_test_contact,
     make_test_settings,
     make_test_workflow,
 )
@@ -117,6 +118,7 @@ def _make_gmail_message(
     received_at: datetime | None = None,
     label_ids: list[str] | None = None,
     rfc_message_id: str | None = None,
+    extra_headers: list[dict[str, str]] | None = None,
 ) -> dict[str, Any]:
     received_at = received_at or datetime.now(UTC)
     body_b64 = base64.urlsafe_b64encode(body.encode()).decode()
@@ -126,6 +128,8 @@ def _make_gmail_message(
     ]
     if rfc_message_id is not None:
         headers.append({"name": "Message-ID", "value": rfc_message_id})
+    if extra_headers is not None:
+        headers.extend(extra_headers)
     return {
         "id": message_id,
         "threadId": thread_id,
@@ -991,3 +995,118 @@ def test_send_email_stores_plain_text_in_db(
 
     assert "**" not in email.body_text
     assert "Bold" in email.body_text
+
+
+# -- sender / recipients on send and sync -------------------------------------
+
+
+def test_send_email_stores_sender_and_recipients(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection, email="Outbound@Lab5.ca")
+    client, _service = _make_send_client(account.email)
+
+    email = send_email(
+        database_connection,
+        account=account,
+        gmail_client=client,
+        settings=make_test_settings(),
+        to="Alice@Example.com",
+        subject="Hi",
+        body="Body",
+        cc="Bob@Example.com",
+        bcc="Secret@Example.com",
+    )
+
+    assert email.sender == "outbound@lab5.ca"
+    assert email.recipients == {
+        "to": ["alice@example.com"],
+        "cc": ["bob@example.com"],
+        "bcc": ["secret@example.com"],
+    }
+
+
+def test_send_email_stores_multiple_to_recipients(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    account = make_test_account(database_connection, email="sender@example.com")
+    client, _service = _make_send_client(account.email)
+
+    email = send_email(
+        database_connection,
+        account=account,
+        gmail_client=client,
+        settings=make_test_settings(),
+        to="a@example.com,b@example.com",
+        subject="Hi",
+        body="Body",
+    )
+
+    assert email.recipients["to"] == ["a@example.com", "b@example.com"]
+    assert "cc" not in email.recipients
+    assert "bcc" not in email.recipients
+
+
+def test_extract_recipients_from_headers():
+    from mailpilot.sync import (
+        _extract_recipients,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    headers = {
+        "to": "Alice <alice@example.com>, Bob <bob@example.com>",
+        "cc": "Carol <carol@example.com>",
+    }
+    result = _extract_recipients(headers)
+    assert result == {
+        "to": ["alice@example.com", "bob@example.com"],
+        "cc": ["carol@example.com"],
+    }
+    assert "bcc" not in result
+
+
+def test_extract_recipients_empty_headers():
+    from mailpilot.sync import (
+        _extract_recipients,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    result = _extract_recipients({})
+    assert result == {}
+
+
+def test_sync_stores_sender_and_recipients(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Inbound sync populates sender and recipients from Gmail headers."""
+    account = make_test_account(database_connection, email="inbox@lab5.ca")
+    message = _make_gmail_message(
+        message_id="msg_sr_1",
+        thread_id="thread_sr_1",
+        from_header="Alice <alice@example.com>",
+        subject="Test sender/recipients",
+        extra_headers=[
+            {"name": "To", "value": "inbox@lab5.ca"},
+            {"name": "Cc", "value": "dev@lab5.ca"},
+        ],
+    )
+
+    from mailpilot.sync import (
+        _store_inbound_message,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    contact = make_test_contact(
+        database_connection, email="alice@example.com", domain="example.com"
+    )
+    email = _store_inbound_message(
+        database_connection,
+        account,
+        message,
+        contacts_by_email={"alice@example.com": contact},
+        settings=make_test_settings(),
+        has_active_workflows=False,
+    )
+    assert email is not None
+    assert email.sender == "alice@example.com"
+    assert email.recipients == {
+        "to": ["inbox@lab5.ca"],
+        "cc": ["dev@lab5.ca"],
+    }


### PR DESCRIPTION
## Summary

Adds `sender` (TEXT) and `recipients` (JSONB) columns to the email table to persist participant addresses directly on each email record. Both the outbound send path and inbound Gmail sync path are updated to populate these fields. The `email list` command gains `--from`/`--to` filters, and `email search` now matches against sender and recipient addresses.

Resolves #73

## Changes

- Add `sender` (TEXT) and `recipients` (JSONB) columns to `email` schema with safe defaults
- Update `Email` model with `sender` and `recipients` fields
- Add `_extract_recipients()` helper in `sync.py` to parse RFC 2822 To/Cc/Bcc headers
- Populate sender/recipients in `send_email` (outbound) and `_store_inbound_message` (inbound sync)
- Add `--from`/`--to` filter options to `email list` CLI command
- Extend `search_emails` to match sender and recipient fields
- Full test coverage across database, sync, and CLI layers (15 new tests)
- Update CLAUDE.md with email renderer section and updated `email list` CLI reference