### PR TITLE
fix(routing): prevent agent-to-agent reply loop on shared Gmail threads

### DIFF
--- a/docs/adr-04-email-routing.md
+++ b/docs/adr-04-email-routing.md
@@ -22,6 +22,15 @@ When an inbound email arrives for an account, route it through a three-step pipe
   email arrives
        |
        v
+  bounce? ------------> yes ----------> mark original outbound bounced
+       |                                disable contact, is_routed = true
+       | no
+       v
+  sender is managed   --> yes --------> is_routed = true, workflow_id = NULL
+  account?  (self-sender guard)        (skip pipeline -- internal echo)
+       |
+       | no
+       v
   1. thread match -----> found? -----> route to workflow
        |                                     |
        | no match                            v
@@ -70,6 +79,16 @@ The `email` table has `is_routed BOOLEAN NOT NULL DEFAULT FALSE`. Semantics:
 - An email with `is_routed = TRUE` and `workflow_id = NULL` is a deliberate "unrouted" decision, not a missing classification
 - An email with `is_routed = FALSE` has not yet been processed by the routing pipeline
 
+### Self-Sender Guard
+
+When the inbound email's `From` address matches a row in `account` (case-insensitive), short-circuit the pipeline: mark the email `is_routed = TRUE`, leave `workflow_id = NULL`, and skip thread match, classification, and `workflow_contact` creation.
+
+Why: when two MailPilot-managed accounts share a Gmail thread (e.g. an outbound campaign account and an inbound auto-reply account on the same domain), each side's reply round-trips into the other's mailbox as a fresh inbound email. Without this guard, thread match links the echo to the local workflow, `create_tasks_for_routed_emails` enqueues another agent task, the agent fires, and the cycle repeats unbounded -- the bug reported in #83 (12 `agent.invoke` spans in ~3 minutes during smoke test).
+
+The guard runs after bounce detection but before thread match, so genuine bounces are still processed normally.
+
+Trade-off: a real human at one of our managed addresses replying through Gmail UI is also ignored. Acceptable -- they can operate the CRM directly.
+
 ### Bounce Detection
 
 When a bounce notification is detected during sync:
@@ -95,6 +114,7 @@ Bounce detection relies on Gmail bounce notification emails and labels. The exac
 - `is_routed` flag prevents non-deterministic re-classification on re-sync
 - Paused workflow exclusion from classification is consistent with "no new work" semantics
 - Bounce detection feeds into global contact status for cross-workflow protection
+- Self-sender guard prevents agent-to-agent reply loops between managed accounts on shared Gmail threads (#83)
 - Auto-contact creation ensures every email has a `contact_id` for history queries and cooldown checks
 - Recency gate prevents stale emails from triggering agent actions during full sync
 

--- a/src/mailpilot/routing.py
+++ b/src/mailpilot/routing.py
@@ -7,8 +7,9 @@ Three-step pipeline that assigns inbound emails to the correct workflow:
 3. **Unrouted** -- store with is_routed=True, workflow_id=NULL
 
 Also handles bounce detection (mailer-daemon/postmaster senders and
-bounce-related Gmail labels) and creates ``workflow_contact`` entries
-on successful routing.
+bounce-related Gmail labels), the self-sender guard that breaks
+agent-to-agent reply loops between managed accounts (#83), and creates
+``workflow_contact`` entries on successful routing.
 """
 
 from __future__ import annotations
@@ -22,6 +23,7 @@ from mailpilot.agent.classify import classify_email
 from mailpilot.database import (
     create_workflow_contact,
     disable_contact,
+    get_account_by_email,
     get_emails_by_gmail_thread_id,
     list_workflows,
     update_email,
@@ -68,6 +70,12 @@ def route_email(
             if _is_bounce(sender_email, email.labels):
                 span.set_attribute("result", "bounce")
                 return _handle_bounce(connection, email)
+
+            if _is_self_sender(connection, sender_email):
+                span.set_attribute("result", "self_sender")
+                span.set_attribute("route_method", "self_sender")
+                updated = update_email(connection, email.id, is_routed=True)
+                return updated if updated is not None else email
 
             workflow_id = _try_thread_match(connection, email)
             if workflow_id is not None:
@@ -166,6 +174,29 @@ def _handle_bounce(
 
         updated = update_email(connection, email.id, is_routed=True)
         return updated if updated is not None else email
+
+
+# -- Self-sender guard ---------------------------------------------------------
+
+
+def _is_self_sender(
+    connection: psycopg.Connection[dict[str, Any]],
+    sender_email: str,
+) -> bool:
+    """Check if the sender is one of our managed MailPilot accounts.
+
+    When two managed accounts share a Gmail thread (e.g. an outbound campaign
+    account replying to an inbound auto-reply account on the same domain),
+    each side's reply round-trips into the other's mailbox as a fresh inbound
+    email. Without this guard, ``_try_thread_match`` would link the echo to
+    the local workflow and ``create_tasks_for_routed_emails`` would enqueue
+    another agent task -- the runaway loop reported in #83.
+
+    Match is case-insensitive (Gmail may normalise display-cased addresses).
+    """
+    if not sender_email:
+        return False
+    return get_account_by_email(connection, sender_email) is not None
 
 
 # -- Three-step routing pipeline -----------------------------------------------

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -527,6 +527,183 @@ def test_route_email_bounce_no_outbound_in_thread_still_marks_routed(
     assert routed.is_routed is True
 
 
+# -- Self-sender guard ---------------------------------------------------------
+
+
+def test_route_email_self_sender_skips_thread_match(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """Inbound email from a managed account.email is not thread-matched (#83).
+
+    Reproduces the runaway agent-to-agent reply loop: two MailPilot accounts
+    end up on the same Gmail thread, the inbound side replies, and that reply
+    arrives on the outbound account as a fresh inbound email. Without this
+    guard, _try_thread_match would route it to the outbound workflow and
+    enqueue another agent task.
+    """
+    outbound_account = make_test_account(database_connection, email="outbound@lab5.ca")
+    inbound_account = make_test_account(
+        database_connection, email="inbound@lab5.ca", display_name="Inbound"
+    )
+    workflow = make_test_workflow(
+        database_connection,
+        account_id=outbound_account.id,
+        workflow_type="outbound",
+    )
+    _activate_workflow(database_connection, workflow.id)
+
+    # Original outbound send: workflow owns the thread on outbound_account.
+    create_email(
+        database_connection,
+        account_id=outbound_account.id,
+        direction="outbound",
+        subject="hello",
+        gmail_thread_id="t-loop",
+        workflow_id=workflow.id,
+        is_routed=True,
+    )
+
+    # Reply from the inbound MailPilot account arrives on outbound's mailbox.
+    echo = create_email(
+        database_connection,
+        account_id=outbound_account.id,
+        direction="inbound",
+        subject="Re: hello",
+        gmail_thread_id="t-loop",
+    )
+    assert echo is not None
+
+    routed = route_email(
+        database_connection, echo, inbound_account.email, make_test_settings()
+    )
+
+    assert routed.workflow_id is None
+    assert routed.is_routed is True
+
+
+def test_route_email_self_sender_creates_no_workflow_contact(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """Self-sender short-circuit must not create a workflow_contact row."""
+    outbound_account = make_test_account(database_connection, email="outbound2@lab5.ca")
+    inbound_account = make_test_account(
+        database_connection, email="inbound2@lab5.ca", display_name="Inbound"
+    )
+    contact = make_test_contact(
+        database_connection, email=inbound_account.email, domain="lab5.ca"
+    )
+    workflow = make_test_workflow(
+        database_connection,
+        account_id=outbound_account.id,
+        workflow_type="outbound",
+    )
+    _activate_workflow(database_connection, workflow.id)
+
+    create_email(
+        database_connection,
+        account_id=outbound_account.id,
+        direction="outbound",
+        subject="hello",
+        gmail_thread_id="t-loop2",
+        workflow_id=workflow.id,
+        is_routed=True,
+    )
+
+    echo = create_email(
+        database_connection,
+        account_id=outbound_account.id,
+        direction="inbound",
+        subject="Re: hello",
+        gmail_thread_id="t-loop2",
+        contact_id=contact.id,
+    )
+    assert echo is not None
+
+    route_email(database_connection, echo, inbound_account.email, make_test_settings())
+
+    wc = get_workflow_contact(database_connection, workflow.id, contact.id)
+    assert wc is None
+
+
+def test_route_email_self_sender_case_insensitive(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """Sender match is case-insensitive (Gmail may upper-case the From header)."""
+    outbound_account = make_test_account(database_connection, email="ob3@lab5.ca")
+    make_test_account(database_connection, email="ib3@lab5.ca", display_name="Inbound")
+    workflow = make_test_workflow(
+        database_connection,
+        account_id=outbound_account.id,
+        workflow_type="outbound",
+    )
+    _activate_workflow(database_connection, workflow.id)
+
+    create_email(
+        database_connection,
+        account_id=outbound_account.id,
+        direction="outbound",
+        subject="hi",
+        gmail_thread_id="t-case",
+        workflow_id=workflow.id,
+        is_routed=True,
+    )
+
+    echo = create_email(
+        database_connection,
+        account_id=outbound_account.id,
+        direction="inbound",
+        subject="Re: hi",
+        gmail_thread_id="t-case",
+    )
+    assert echo is not None
+
+    routed = route_email(database_connection, echo, "IB3@LAB5.CA", make_test_settings())
+
+    assert routed.workflow_id is None
+    assert routed.is_routed is True
+
+
+def test_route_email_span_has_route_method_self_sender(
+    capfire: CaptureLogfire,
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """routing.route_email span must set route_method='self_sender'."""
+    outbound_account = make_test_account(database_connection, email="span-ob@lab5.ca")
+    make_test_account(
+        database_connection, email="span-ib@lab5.ca", display_name="Inbound"
+    )
+    workflow = make_test_workflow(
+        database_connection,
+        account_id=outbound_account.id,
+        workflow_type="outbound",
+    )
+    _activate_workflow(database_connection, workflow.id)
+
+    create_email(
+        database_connection,
+        account_id=outbound_account.id,
+        direction="outbound",
+        subject="prior",
+        gmail_thread_id="t-self-span",
+        workflow_id=workflow.id,
+        is_routed=True,
+    )
+    echo = create_email(
+        database_connection,
+        account_id=outbound_account.id,
+        direction="inbound",
+        subject="echo",
+        gmail_thread_id="t-self-span",
+    )
+    assert echo is not None
+
+    route_email(database_connection, echo, "span-ib@lab5.ca", make_test_settings())
+
+    spans = _routing_spans(capfire)
+    assert len(spans) == 1
+    assert spans[0]["attributes"]["route_method"] == "self_sender"
+
+
 # -- workflow_contact creation --------------------------------------------------
 
 


### PR DESCRIPTION
Resolves #83

## Summary

P1 bug fix. When two MailPilot-managed accounts share a Gmail thread (e.g. an outbound campaign account replying to an inbound auto-reply account on the same domain), the system enters an unbounded agent-to-agent reply loop. Each side's sync ingests the other side's reply, `routing.route_email` thread-matches it to a workflow on the local account, `create_tasks_for_routed_emails` enqueues a task, the agent fires, replies, and the cycle repeats.

A recent smoke test produced 12 `agent.invoke` spans in ~3 minutes before manual termination -- with real-money implications (LLM tokens, sender reputation, recipient annoyance).

## Approach

Plan to implement **mitigation #1** from the issue (self-thread guard) as the surgical fix:

- In `routing._try_thread_match` (or before calling it), refuse to thread-match when the inbound email's `From` address belongs to one of our own `account.email` rows -- treat it as an internal echo, not a real customer reply.
- Add a regression test in `tests/test_routing.py` simulating an inbound email whose sender is one of our accounts on a thread already linked to a workflow; assert no new task is created.
- Document the guard in `docs/adr-04-*.md` (routing pipeline) so the loop cannot be re-introduced silently.

Mitigation #2 (status gate on task creation) is tracked separately as #79 and is out of scope for this PR.

## Test plan

- [ ] Unit regression test: inbound email from a managed `account.email` on a workflow-linked thread does NOT produce a routed task.
- [ ] `make check` passes (lint + basedpyright + unit tests).
- [ ] `/smoke-test` end-to-end run: exactly 1 `agent.invoke` per workflow per contact, both `workflow_contact` rows reach `completed`, no further `routing.route_email` thread-match spans, no further tasks created.