### PR TITLE
fix(pubsub): decode gmail watch notifications and surface decode-error diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 **/__pycache__/
 *.egg-info/
 .claude/ralph-loop.local.md
+.claude/worktrees/
 .env
 .firecrawl/
 .superpowers/

--- a/src/mailpilot/pubsub.py
+++ b/src/mailpilot/pubsub.py
@@ -6,7 +6,6 @@ that enqueues account emails for sync, and periodic watch renewal.
 
 from __future__ import annotations
 
-import base64
 import json
 import queue
 import threading
@@ -195,10 +194,20 @@ def make_notification_callback(
     def callback(message: Any) -> None:
         with logfire.span("pubsub.notification"):
             try:
-                data = json.loads(base64.urlsafe_b64decode(message.data))
+                # Message.data is already-decoded raw bytes from the pubsub
+                # client; re-decoding raises binascii.Error on real Gmail
+                # watch payloads (see #82).
+                data = json.loads(message.data)
                 email_address = data["emailAddress"]
-            except json.JSONDecodeError, KeyError, Exception:
-                logfire.warn("pubsub.notification.decode_error")
+            except json.JSONDecodeError, KeyError, UnicodeDecodeError:
+                logfire.exception(
+                    "pubsub.notification.decode_error",
+                    pubsub_message_id=message.message_id,
+                    payload_size_bytes=len(message.data),
+                    payload_excerpt=message.data[:200].decode(
+                        "utf-8", errors="replace"
+                    ),
+                )
                 message.ack()
                 return
             logfire.debug(

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import base64
 import json
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import psycopg
+from logfire.testing import CaptureLogfire
 
 from conftest import make_test_account, make_test_settings
 from mailpilot.database import get_account, update_account
@@ -159,6 +159,12 @@ def test_start_subscriber_returns_future() -> None:
 
 
 def test_notification_callback_decodes_and_enqueues() -> None:
+    """Gmail Pub/Sub Message.data is already-decoded raw JSON bytes.
+
+    The google-cloud-pubsub client library performs the transport-layer
+    base64 decode before invoking the callback. Re-decoding inside the
+    callback raises binascii.Error on every real notification -- see #82.
+    """
     import queue
 
     from mailpilot.pubsub import make_notification_callback
@@ -167,9 +173,9 @@ def test_notification_callback_decodes_and_enqueues() -> None:
     callback = make_notification_callback(sync_queue)
 
     message = MagicMock()
-    message.data = base64.urlsafe_b64encode(
-        json.dumps({"emailAddress": "user@example.com", "historyId": "12345"}).encode()
-    )
+    message.data = json.dumps(
+        {"emailAddress": "user@example.com", "historyId": "12345"}
+    ).encode()
 
     callback(message)
 
@@ -194,9 +200,7 @@ def test_notification_callback_sets_wakeup_event() -> None:
     callback = make_notification_callback(sync_queue, wakeup_event)
 
     message = MagicMock()
-    message.data = base64.urlsafe_b64encode(
-        json.dumps({"emailAddress": "user@example.com"}).encode()
-    )
+    message.data = json.dumps({"emailAddress": "user@example.com"}).encode()
 
     callback(message)
 
@@ -214,7 +218,7 @@ def test_notification_callback_acks_on_decode_error() -> None:
     callback = make_notification_callback(sync_queue)
 
     message = MagicMock()
-    message.data = b"not-valid-base64-json!!!"
+    message.data = b"not-valid-json{"
 
     callback(message)
 
@@ -231,12 +235,81 @@ def test_notification_callback_acks_on_missing_email_field() -> None:
     callback = make_notification_callback(sync_queue)
 
     message = MagicMock()
-    message.data = base64.urlsafe_b64encode(json.dumps({"historyId": "12345"}).encode())
+    message.data = json.dumps({"historyId": "12345"}).encode()
 
     callback(message)
 
     assert sync_queue.empty()
     message.ack.assert_called_once()
+
+
+def test_notification_callback_decode_error_attaches_diagnostics(
+    capfire: CaptureLogfire,
+) -> None:
+    """Decode-error span must carry enough context to diagnose without re-running.
+
+    Without these attributes, decode regressions (like #82) are invisible:
+    the operator sees a count of `pubsub.notification.decode_error` spans
+    but cannot tell what payload caused them or what exception was raised.
+    """
+    import queue
+
+    from mailpilot.pubsub import make_notification_callback
+
+    sync_queue: queue.Queue[str] = queue.Queue()
+    callback = make_notification_callback(sync_queue)
+
+    message = MagicMock()
+    message.data = b"not-valid-json{"
+    message.message_id = "msg-abc-123"
+
+    callback(message)
+
+    error_spans = [
+        span
+        for span in capfire.exporter.exported_spans_as_dict()
+        if span["name"] == "pubsub.notification.decode_error"
+    ]
+    assert len(error_spans) == 1
+    attrs = error_spans[0]["attributes"]
+    assert attrs["pubsub_message_id"] == "msg-abc-123"
+    assert attrs["payload_size_bytes"] == len(b"not-valid-json{")
+    assert "not-valid-json" in attrs["payload_excerpt"]
+
+
+def test_notification_callback_decode_error_records_exception(
+    capfire: CaptureLogfire,
+) -> None:
+    """logfire.exception must capture the underlying exception type and message.
+
+    Switching from logfire.warn to logfire.exception is what attaches
+    exception.type / exception.message via OTEL exception events. Without
+    them, debugging a decode regression requires reproducing the bug.
+    """
+    import queue
+
+    from mailpilot.pubsub import make_notification_callback
+
+    sync_queue: queue.Queue[str] = queue.Queue()
+    callback = make_notification_callback(sync_queue)
+
+    message = MagicMock()
+    message.data = b"not-valid-json{"
+    message.message_id = "msg-abc-123"
+
+    callback(message)
+
+    error_spans = [
+        span
+        for span in capfire.exporter.exported_spans_as_dict()
+        if span["name"] == "pubsub.notification.decode_error"
+    ]
+    assert len(error_spans) == 1
+    events = error_spans[0].get("events") or []
+    exception_events = [e for e in events if e.get("name") == "exception"]
+    assert len(exception_events) == 1
+    event_attrs = exception_events[0]["attributes"]
+    assert "JSONDecodeError" in event_attrs["exception.type"]
 
 
 # -- renew_watches -------------------------------------------------------------


### PR DESCRIPTION
## Summary

Every Gmail Pub/Sub notification arriving at `mailpilot run` was failing to decode and being silently dropped. Real-time wake-up via Pub/Sub was fully broken; the sync loop had degraded to its 30s timer fallback. This PR fixes the decode bug and adds the diagnostic attributes needed to catch a regression of this class.

Logfire (mailpilot project, last 24h) confirmed the exact symptom before this work began: 20 `pubsub.notification` spans, 20 `pubsub.notification.decode_error` spans (100% failure), all decode-error spans missing `exception_type` / `exception_message` / payload context. Sync was running purely off the 30s timer (10 `sync.loop.iteration` spans, 20 `gmail.get_history` calls = 2 accounts x 10 polls).

### Root cause

`src/mailpilot/pubsub.py` (`make_notification_callback.<locals>.callback`) called `base64.urlsafe_b64decode(message.data)`, but `Message.data` from `google-cloud-pubsub` is already-decoded raw bytes -- the client library does the transport-layer base64 decode before the callback runs. Gmail's watch payload starts with `{`, which is not a valid base64 character, so every real notification raised `binascii.Error`. The except clause swallowed `Exception` and the warn log captured none of it, so the failure was invisible.

### Fix

1. Decode `message.data` directly as JSON; drop the redundant `base64.urlsafe_b64decode()` call.
2. Narrow the except clause to `(json.JSONDecodeError, KeyError, UnicodeDecodeError)` and use `logfire.exception(...)` with diagnostic attributes (`pubsub.message_id`, `payload.size_bytes`, `payload.excerpt`) so future regressions are debuggable from a single span.
3. Add unit tests that feed a realistic Gmail watch payload through the callback and assert the email address is enqueued, `wakeup_event` is set, and decode-error spans carry full diagnostic context.

Resolves #82

## Acceptance criteria

- [x] Zero `pubsub.notification.decode_error` spans across a fresh smoke run
- [x] Inbound emails appear in `email list` within ~5s of arrival (real-time path), not at the next 30s poll boundary
- [x] Decode-error spans, when they do occur, carry attributes sufficient to diagnose without re-running
- [x] `tests/test_pubsub.py` exercises the callback with a realistic Gmail watch payload