### PR TITLE
fix(routing): RFC2822 message-id fallback and complete span coverage

### DIFF
--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -1212,6 +1212,8 @@ def create_email(
     sent_at: datetime | None = None,
     labels: list[str] | None = None,
     rfc2822_message_id: str | None = None,
+    in_reply_to: str | None = None,
+    references_header: str | None = None,
     sender: str = "",
     recipients: dict[str, list[str]] | None = None,
 ) -> Email | None:
@@ -1239,6 +1241,11 @@ def create_email(
         sent_at: When the outbound message was handed to Gmail (UTC datetime).
         labels: Gmail label IDs attached to the message.
         rfc2822_message_id: RFC 2822 Message-ID header value.
+        in_reply_to: RFC 2822 In-Reply-To header value (parent message id).
+        references_header: RFC 2822 References header value (full
+            whitespace-separated chain of ancestor message ids). Stored as
+            ``references_header`` because ``references`` is a reserved SQL
+            keyword.
         sender: Sender email address (lowercase).
         recipients: Recipient addresses grouped by type
             (``{"to": [...], "cc": [...], "bcc": [...]}``)
@@ -1253,12 +1260,14 @@ def create_email(
             body_text, gmail_message_id, gmail_thread_id,
             contact_id, workflow_id, status, is_routed,
             received_at, sent_at, labels, rfc2822_message_id,
+            in_reply_to, references_header,
             sender, recipients)
         VALUES (%(id)s, %(account_id)s, %(direction)s,
             %(subject)s, %(body_text)s, %(gmail_message_id)s,
             %(gmail_thread_id)s, %(contact_id)s, %(workflow_id)s,
             %(status)s, %(is_routed)s, %(received_at)s, %(sent_at)s,
             %(labels)s, %(rfc2822_message_id)s,
+            %(in_reply_to)s, %(references_header)s,
             %(sender)s, %(recipients)s)
         ON CONFLICT (gmail_message_id) DO NOTHING
         RETURNING *
@@ -1279,6 +1288,8 @@ def create_email(
             "sent_at": sent_at,
             "labels": Json(labels or []),
             "rfc2822_message_id": rfc2822_message_id,
+            "in_reply_to": in_reply_to,
+            "references_header": references_header,
             "sender": sender,
             "recipients": Json(recipients or {}),
         },
@@ -1463,6 +1474,49 @@ def get_emails_by_gmail_thread_id(
         {"gmail_thread_id": gmail_thread_id},
     ).fetchall()
     return [Email.model_validate(row) for row in rows]
+
+
+def find_email_by_rfc2822_message_id(
+    connection: psycopg.Connection[dict[str, Any]],
+    account_id: str,
+    message_ids: list[str],
+) -> Email | None:
+    """Find the most recent email matching any of the given RFC 2822 message ids.
+
+    Used by the routing pipeline as a fallback when ``gmail_thread_id`` no
+    longer joins inbound replies to their outbound parents (Gmail re-threads
+    on the recipient side, producing a different ``threadId`` for the same
+    conversation). Restricted to a single ``account_id`` so cross-account
+    collisions on a shared Message-ID cannot leak workflow assignments.
+
+    Args:
+        connection: Open database connection.
+        account_id: Account scope -- only rows belonging to this account
+            are considered.
+        message_ids: Candidate RFC 2822 Message-ID values, typically the
+            inbound email's ``In-Reply-To`` plus every entry in its
+            ``References`` chain.
+
+    Returns:
+        The most-recently created matching email, or ``None`` when no row
+        in this account stores any of ``message_ids`` in its
+        ``rfc2822_message_id`` column.
+    """
+    if not message_ids:
+        return None
+    row = connection.execute(
+        """\
+        SELECT * FROM email
+        WHERE account_id = %(account_id)s
+          AND rfc2822_message_id = ANY(%(message_ids)s)
+        ORDER BY created_at DESC
+        LIMIT 1
+        """,
+        {"account_id": account_id, "message_ids": message_ids},
+    ).fetchone()
+    if row is None:
+        return None
+    return Email.model_validate(row)
 
 
 def get_last_cold_outbound(

--- a/src/mailpilot/models.py
+++ b/src/mailpilot/models.py
@@ -119,6 +119,8 @@ class Email(BaseModel):
     gmail_message_id: str | None = None
     gmail_thread_id: str | None = None
     rfc2822_message_id: str | None = None
+    in_reply_to: str | None = None
+    references_header: str | None = None
     account_id: str
     contact_id: str | None = None
     workflow_id: str | None = None

--- a/src/mailpilot/routing.py
+++ b/src/mailpilot/routing.py
@@ -1,10 +1,14 @@
 """Email routing pipeline (ADR-04).
 
-Three-step pipeline that assigns inbound emails to the correct workflow:
+Pipeline that assigns inbound emails to the correct workflow:
 
 1. **Thread match** -- prior email in same Gmail thread has a workflow_id
-2. **LLM classification** -- single-turn call against active inbound workflows
-3. **Unrouted** -- store with is_routed=True, workflow_id=NULL
+2. **RFC 2822 message-id match** -- inbound In-Reply-To / References headers
+   cite a stored email's ``rfc2822_message_id`` (covers Gmail recipient-side
+   re-threading, where the same conversation has different ``threadId`` on
+   each side)
+3. **LLM classification** -- single-turn call against active inbound workflows
+4. **Unrouted** -- store with is_routed=True, workflow_id=NULL
 
 Also handles bounce detection (mailer-daemon/postmaster senders and
 bounce-related Gmail labels) and creates ``enrollment`` entries
@@ -22,6 +26,7 @@ from mailpilot.agent.classify import classify_email
 from mailpilot.database import (
     create_enrollment,
     disable_contact,
+    find_email_by_rfc2822_message_id,
     get_emails_by_gmail_thread_id,
     list_workflows,
     update_email,
@@ -70,19 +75,27 @@ def route_email(
                 return _handle_bounce(connection, email)
 
             workflow_id = _try_thread_match(connection, email)
+            route_method: str
             if workflow_id is not None:
-                span.set_attribute("result", "thread_match")
-                span.set_attribute("route_method", "thread_match")
-                span.set_attribute("workflow_id", workflow_id)
+                route_method = "thread_match"
             else:
-                workflow_id = _try_classify(connection, email, sender_email, settings)
+                workflow_id = _try_rfc_message_id_match(connection, email)
                 if workflow_id is not None:
-                    span.set_attribute("result", "classified")
-                    span.set_attribute("route_method", "classified")
-                    span.set_attribute("workflow_id", workflow_id)
+                    route_method = "rfc_message_id_match"
                 else:
-                    span.set_attribute("result", "unrouted")
-                    span.set_attribute("route_method", "unrouted")
+                    workflow_id = _try_classify(
+                        connection, email, sender_email, settings
+                    )
+                    route_method = (
+                        "classified" if workflow_id is not None else "unrouted"
+                    )
+            span.set_attribute(
+                "result",
+                route_method if workflow_id is not None else "unrouted",
+            )
+            span.set_attribute("route_method", route_method)
+            if workflow_id is not None:
+                span.set_attribute("workflow_id", workflow_id)
 
             updated = update_email(
                 connection, email.id, workflow_id=workflow_id, is_routed=True
@@ -195,6 +208,60 @@ def _try_thread_match(
         return None
     matches.sort(key=lambda e: e.created_at, reverse=True)
     return matches[0].workflow_id
+
+
+def _try_rfc_message_id_match(
+    connection: psycopg.Connection[dict[str, Any]],
+    email: Email,
+) -> str | None:
+    """Step 1b: match via RFC 2822 In-Reply-To / References headers.
+
+    Gmail re-threads on the recipient side: a reply that lands on the
+    outbound mailbox can have a fresh ``threadId`` even though it cites
+    our original send via ``In-Reply-To`` and ``References``. When the
+    Gmail-thread lookup returns no match, walk the cited message-ids and
+    look them up against ``email.rfc2822_message_id`` within the same
+    account.
+
+    Returns the matching email's ``workflow_id`` or ``None``. Scope is
+    intentionally restricted to the inbound email's own ``account_id`` so
+    cross-account collisions on a shared Message-ID cannot leak workflow
+    assignments.
+    """
+    referenced_ids = _collect_referenced_message_ids(email)
+    if not referenced_ids:
+        return None
+    parent = find_email_by_rfc2822_message_id(
+        connection, email.account_id, referenced_ids
+    )
+    if parent is None or parent.workflow_id is None:
+        return None
+    return parent.workflow_id
+
+
+def _collect_referenced_message_ids(email: Email) -> list[str]:
+    """Return message-ids cited by an inbound email's threading headers.
+
+    Combines the parent ``In-Reply-To`` value with every entry in the
+    whitespace-separated ``References`` chain. Duplicates are dropped
+    while preserving the order that the original headers used (parent
+    first, then ancestors). Returns an empty list when neither header
+    is populated.
+    """
+    candidates: list[str] = []
+    if email.in_reply_to:
+        candidates.extend(email.in_reply_to.split())
+    if email.references_header:
+        candidates.extend(email.references_header.split())
+    seen: set[str] = set()
+    unique: list[str] = []
+    for raw in candidates:
+        token = raw.strip()
+        if not token or token in seen:
+            continue
+        seen.add(token)
+        unique.append(token)
+    return unique
 
 
 def _try_classify(

--- a/src/mailpilot/schema.sql
+++ b/src/mailpilot/schema.sql
@@ -88,6 +88,8 @@ CREATE TABLE IF NOT EXISTS email (
     gmail_message_id  TEXT UNIQUE,
     gmail_thread_id   TEXT,
     rfc2822_message_id TEXT,
+    in_reply_to       TEXT,
+    references_header TEXT,
     account_id        TEXT NOT NULL REFERENCES account(id),
     contact_id        TEXT REFERENCES contact(id),
     workflow_id       TEXT REFERENCES workflow(id),
@@ -109,6 +111,7 @@ CREATE INDEX IF NOT EXISTS idx_email_account_id ON email(account_id);
 CREATE INDEX IF NOT EXISTS idx_email_contact_id ON email(contact_id);
 CREATE INDEX IF NOT EXISTS idx_email_workflow_id ON email(workflow_id);
 CREATE INDEX IF NOT EXISTS idx_email_gmail_thread_id ON email(gmail_thread_id);
+CREATE INDEX IF NOT EXISTS idx_email_rfc2822_message_id ON email(rfc2822_message_id);
 
 CREATE TABLE IF NOT EXISTS task (
     id            TEXT PRIMARY KEY,

--- a/src/mailpilot/sync.py
+++ b/src/mailpilot/sync.py
@@ -700,10 +700,38 @@ def _store_inbound_message(  # noqa: PLR0913
             connection, email, sender_email=sender_email, settings=settings
         )
     elif within_window:
+        # Within recency window but no LLM classification will run. Record
+        # the skip with a reason so observability stays complete -- every
+        # inbound delivery produces either a routing.route_email span or a
+        # routing.route_email_skipped span (D5).
+        skip_reason = (
+            "predates_workflows" if predates_workflows else "no_active_workflows"
+        )
+        _emit_route_skipped_span(email, skip_reason)
         updated = update_email(connection, email.id, is_routed=True)
         if updated is not None:
             email = updated
+    else:
+        # Outside the 7-day recency window -- create_email already set
+        # is_routed=True, so emit the skip span and return.
+        _emit_route_skipped_span(email, "outside_recency_window")
     return email
+
+
+def _emit_route_skipped_span(email: Email, reason: str) -> None:
+    """Emit a ``routing.route_email_skipped`` span for an inbound email.
+
+    Mirrors the attribute shape of ``routing.route_email`` so dashboards
+    that filter on ``email_id`` / ``account_id`` keep working when an
+    inbound delivery skips the routing pipeline (D5).
+    """
+    with logfire.span(
+        "routing.route_email_skipped",
+        email_id=email.id,
+        account_id=email.account_id,
+        reason=reason,
+    ):
+        pass
 
 
 def _received_at_from_message(message: dict[str, Any]) -> datetime | None:

--- a/src/mailpilot/sync.py
+++ b/src/mailpilot/sync.py
@@ -676,6 +676,8 @@ def _store_inbound_message(  # noqa: PLR0913
         received_at=received_at,
         labels=list(message.get("labelIds", [])),
         rfc2822_message_id=headers.get("message-id"),
+        in_reply_to=headers.get("in-reply-to"),
+        references_header=headers.get("references"),
         sender=sender_email.lower(),
         recipients=inbound_recipients,
     )

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -697,3 +697,256 @@ def test_route_email_span_has_route_method_unrouted(
     spans = _routing_spans(capfire)
     assert len(spans) == 1
     assert spans[0]["attributes"]["route_method"] == "unrouted"
+
+
+# -- RFC 2822 In-Reply-To fallback (Defect 2) ---------------------------------
+
+
+def test_route_email_falls_back_to_rfc_message_id_match(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """When the Gmail thread differs (Gmail re-threads on recipient side) the
+    inbound's In-Reply-To must still resolve to the prior outbound's workflow.
+    """
+    account = make_test_account(database_connection, email="rfc1@example.com")
+    workflow = make_test_workflow(
+        database_connection, account_id=account.id, workflow_type="inbound"
+    )
+    _activate_workflow(database_connection, workflow.id)
+
+    # Prior outbound has the original Gmail thread id and a known Message-ID.
+    prior = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="initial",
+        gmail_thread_id="thread-outbound",
+        rfc2822_message_id="<original@mailpilot.test>",
+        workflow_id=workflow.id,
+        is_routed=True,
+    )
+    assert prior is not None
+
+    # Reply lands with a NEW gmail_thread_id (Gmail re-threaded on the
+    # recipient side) but cites the original via In-Reply-To.
+    reply = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Re: initial",
+        gmail_thread_id="thread-reply-different",
+        in_reply_to="<original@mailpilot.test>",
+    )
+    assert reply is not None
+
+    routed = route_email(
+        database_connection, reply, "alice@example.com", make_test_settings()
+    )
+
+    assert routed.workflow_id == workflow.id
+    assert routed.is_routed is True
+
+
+def test_route_email_falls_back_via_references_header(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """References header (multi-id chain) is also walked for the fallback."""
+    account = make_test_account(database_connection, email="rfc2@example.com")
+    workflow = make_test_workflow(
+        database_connection, account_id=account.id, workflow_type="inbound"
+    )
+    _activate_workflow(database_connection, workflow.id)
+
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="initial",
+        gmail_thread_id="thread-out",
+        rfc2822_message_id="<root@mailpilot.test>",
+        workflow_id=workflow.id,
+        is_routed=True,
+    )
+
+    # Inbound only carries References, no In-Reply-To.
+    reply = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Re: initial",
+        gmail_thread_id="thread-reply-x",
+        references_header="<unrelated@mailpilot.test> <root@mailpilot.test>",
+    )
+    assert reply is not None
+
+    routed = route_email(
+        database_connection, reply, "alice@example.com", make_test_settings()
+    )
+
+    assert routed.workflow_id == workflow.id
+
+
+def test_route_email_rfc_match_scoped_to_account(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """An RFC match in a different account must NOT leak the workflow."""
+    account_a = make_test_account(database_connection, email="acc-a@example.com")
+    account_b = make_test_account(database_connection, email="acc-b@example.com")
+    workflow_a = make_test_workflow(
+        database_connection, account_id=account_a.id, workflow_type="inbound"
+    )
+    _activate_workflow(database_connection, workflow_a.id)
+
+    # Outbound row exists on account A under workflow A.
+    create_email(
+        database_connection,
+        account_id=account_a.id,
+        direction="outbound",
+        subject="initial",
+        gmail_thread_id="thread-cross",
+        rfc2822_message_id="<shared@mailpilot.test>",
+        workflow_id=workflow_a.id,
+        is_routed=True,
+    )
+
+    # Inbound on account B cites the same Message-ID but must NOT pick up
+    # account A's workflow.
+    reply = create_email(
+        database_connection,
+        account_id=account_b.id,
+        direction="inbound",
+        subject="Re: initial",
+        gmail_thread_id="thread-cross-b",
+        in_reply_to="<shared@mailpilot.test>",
+    )
+    assert reply is not None
+
+    routed = route_email(
+        database_connection, reply, "alice@example.com", make_test_settings()
+    )
+
+    assert routed.workflow_id is None
+    assert routed.is_routed is True
+
+
+def test_route_email_span_has_route_method_rfc_message_id_match(
+    capfire: CaptureLogfire,
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """routing.route_email span must set route_method='rfc_message_id_match'."""
+    account = make_test_account(database_connection, email="rfcspan@example.com")
+    workflow = make_test_workflow(
+        database_connection, account_id=account.id, workflow_type="inbound"
+    )
+    _activate_workflow(database_connection, workflow.id)
+
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="initial",
+        gmail_thread_id="thread-x",
+        rfc2822_message_id="<orig-span@mailpilot.test>",
+        workflow_id=workflow.id,
+        is_routed=True,
+    )
+    reply = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Re: initial",
+        gmail_thread_id="thread-y",
+        in_reply_to="<orig-span@mailpilot.test>",
+    )
+    assert reply is not None
+
+    route_email(database_connection, reply, "alice@example.com", make_test_settings())
+
+    spans = _routing_spans(capfire)
+    assert len(spans) == 1
+    assert spans[0]["attributes"]["route_method"] == "rfc_message_id_match"
+    assert spans[0]["attributes"]["workflow_id"] == workflow.id
+
+
+def test_route_email_thread_match_takes_precedence_over_rfc(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """When both signals are present, thread match wins (cheaper, no
+    cross-side ambiguity)."""
+    account = make_test_account(database_connection, email="prec@example.com")
+    workflow_thread = make_test_workflow(
+        database_connection,
+        account_id=account.id,
+        name="Thread WF",
+        workflow_type="inbound",
+    )
+    workflow_rfc = make_test_workflow(
+        database_connection,
+        account_id=account.id,
+        name="RFC WF",
+        workflow_type="inbound",
+    )
+    _activate_workflow(database_connection, workflow_thread.id)
+    _activate_workflow(database_connection, workflow_rfc.id)
+
+    # Same Gmail thread -> thread WF.
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="thread parent",
+        gmail_thread_id="thread-shared",
+        rfc2822_message_id="<thread-parent@mailpilot.test>",
+        workflow_id=workflow_thread.id,
+        is_routed=True,
+    )
+    # Different Gmail thread, but its Message-ID is what reply cites -> RFC WF.
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="rfc parent",
+        gmail_thread_id="thread-other",
+        rfc2822_message_id="<rfc-parent@mailpilot.test>",
+        workflow_id=workflow_rfc.id,
+        is_routed=True,
+    )
+
+    reply = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Re: ambiguous",
+        gmail_thread_id="thread-shared",
+        in_reply_to="<rfc-parent@mailpilot.test>",
+    )
+    assert reply is not None
+
+    routed = route_email(
+        database_connection, reply, "alice@example.com", make_test_settings()
+    )
+
+    assert routed.workflow_id == workflow_thread.id
+
+
+def test_route_email_rfc_match_no_referenced_ids_falls_through(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """No In-Reply-To and no References -> RFC step yields nothing, classify runs."""
+    account = make_test_account(database_connection, email="rfcnone@example.com")
+    new_email = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="bare",
+        gmail_thread_id="t-bare",
+    )
+    assert new_email is not None
+
+    routed = route_email(
+        database_connection, new_email, "alice@example.com", make_test_settings()
+    )
+
+    # No active workflows -> unrouted, but importantly no exception raised.
+    assert routed.is_routed is True
+    assert routed.workflow_id is None

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1321,3 +1321,44 @@ def test_sync_stores_sender_and_recipients(
         "to": ["inbox@lab5.ca"],
         "cc": ["dev@lab5.ca"],
     }
+
+
+def test_sync_stores_in_reply_to_and_references_headers(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Inbound sync persists In-Reply-To / References for routing fallback."""
+    account = make_test_account(database_connection, email="hdr@example.com")
+    message = _make_gmail_message(
+        message_id="msg_hdr_1",
+        thread_id="thread_hdr_1",
+        from_header="Alice <alice@example.com>",
+        subject="Re: hello",
+        extra_headers=[
+            {"name": "In-Reply-To", "value": "<orig@mailpilot.test>"},
+            {
+                "name": "References",
+                "value": "<root@mailpilot.test> <orig@mailpilot.test>",
+            },
+        ],
+    )
+
+    from mailpilot.sync import (
+        _store_inbound_message,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    contact = make_test_contact(
+        database_connection, email="alice@example.com", domain="example.com"
+    )
+    email = _store_inbound_message(
+        database_connection,
+        account,
+        message,
+        contacts_by_email={"alice@example.com": contact},
+        settings=make_test_settings(),
+        has_active_workflows=False,
+    )
+    assert email is not None
+    assert email.in_reply_to == "<orig@mailpilot.test>"
+    assert email.references_header == "<root@mailpilot.test> <orig@mailpilot.test>"
+
+

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import psycopg
 import pytest
 from googleapiclient.errors import HttpError
+from logfire.testing import CaptureLogfire
 
 from conftest import (
     make_test_account,
@@ -1362,3 +1363,129 @@ def test_sync_stores_in_reply_to_and_references_headers(
     assert email.references_header == "<root@mailpilot.test> <orig@mailpilot.test>"
 
 
+# -- D5: routing observability -------------------------------------------------
+
+
+def _spans_named(capfire: CaptureLogfire, name: str) -> list[dict[str, Any]]:
+    return [s for s in capfire.exporter.exported_spans_as_dict() if s["name"] == name]
+
+
+def test_sync_emits_route_skipped_span_when_no_active_workflows(
+    capfire: CaptureLogfire,
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """No active workflows -> emit routing.route_email_skipped span (D5)."""
+    from mailpilot.sync import (
+        _store_inbound_message,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    account = make_test_account(database_connection, email="d5none@example.com")
+    contact = make_test_contact(
+        database_connection, email="alice@example.com", domain="example.com"
+    )
+    message = _make_gmail_message(
+        message_id="msg_d5_none",
+        thread_id="thread_d5_none",
+        from_header="Alice <alice@example.com>",
+    )
+
+    email = _store_inbound_message(
+        database_connection,
+        account,
+        message,
+        contacts_by_email={"alice@example.com": contact},
+        settings=make_test_settings(),
+        has_active_workflows=False,
+    )
+    assert email is not None
+    assert email.is_routed is True
+
+    skipped = _spans_named(capfire, "routing.route_email_skipped")
+    routed = _spans_named(capfire, "routing.route_email")
+    assert len(routed) == 0
+    assert len(skipped) == 1
+    attrs = skipped[0]["attributes"]
+    assert attrs["email_id"] == email.id
+    assert attrs["account_id"] == account.id
+    assert attrs["reason"] == "no_active_workflows"
+
+
+def test_sync_emits_route_skipped_span_outside_recency_window(
+    capfire: CaptureLogfire,
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Old inbound (outside recency window) -> emit routing.route_email_skipped."""
+    from mailpilot.sync import (
+        _store_inbound_message,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    account = make_test_account(database_connection, email="d5old@example.com")
+    contact = make_test_contact(
+        database_connection, email="alice@example.com", domain="example.com"
+    )
+    old_time = datetime.now(UTC) - timedelta(days=30)
+    message = _make_gmail_message(
+        message_id="msg_d5_old",
+        thread_id="thread_d5_old",
+        from_header="Alice <alice@example.com>",
+        received_at=old_time,
+    )
+
+    email = _store_inbound_message(
+        database_connection,
+        account,
+        message,
+        contacts_by_email={"alice@example.com": contact},
+        settings=make_test_settings(),
+        has_active_workflows=True,
+    )
+    assert email is not None
+    assert email.is_routed is True
+
+    skipped = _spans_named(capfire, "routing.route_email_skipped")
+    routed = _spans_named(capfire, "routing.route_email")
+    assert len(routed) == 0
+    assert len(skipped) == 1
+    assert skipped[0]["attributes"]["reason"] == "outside_recency_window"
+
+
+def test_sync_emits_route_skipped_span_when_predates_workflows(
+    capfire: CaptureLogfire,
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Email older than the earliest active workflow -> route_email_skipped."""
+    from mailpilot.sync import (
+        _store_inbound_message,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    account = make_test_account(database_connection, email="d5pre@example.com")
+    contact = make_test_contact(
+        database_connection, email="alice@example.com", domain="example.com"
+    )
+    now = datetime.now(UTC)
+    earliest_workflow_at = now - timedelta(hours=1)
+    received = now - timedelta(days=2)  # within window but before workflow
+    message = _make_gmail_message(
+        message_id="msg_d5_pre",
+        thread_id="thread_d5_pre",
+        from_header="Alice <alice@example.com>",
+        received_at=received,
+    )
+
+    email = _store_inbound_message(
+        database_connection,
+        account,
+        message,
+        contacts_by_email={"alice@example.com": contact},
+        settings=make_test_settings(),
+        has_active_workflows=True,
+        earliest_workflow_at=earliest_workflow_at,
+    )
+    assert email is not None
+    assert email.is_routed is True
+
+    skipped = _spans_named(capfire, "routing.route_email_skipped")
+    routed = _spans_named(capfire, "routing.route_email")
+    assert len(routed) == 0
+    assert len(skipped) == 1
+    assert skipped[0]["attributes"]["reason"] == "predates_workflows"


### PR DESCRIPTION
## Summary

Bundles two routing-layer fixes surfaced by today's smoke test:

- **Defect 2** -- `_try_thread_match` only matched by `gmail_thread_id`. When Gmail re-threads a reply on the recipient side, the outbound and inbound copies have different thread IDs and routing fell through to LLM classification (or unrouted). New step `_try_rfc_message_id_match` falls back on RFC2822 `In-Reply-To` and `References` headers against `email.rfc2822_message_id` within the same account.
- **Defect 5** -- 2 of 4 inbound deliveries today produced no \`routing.route_email\` span, so it was invisible from Logfire whether routing actually ran. Every bypass path now emits a \`routing.route_email_skipped\` span with a \`reason\` attribute.

## Schema changes

- `email` table: new \`in_reply_to TEXT\`, \`references_header TEXT\` (\`references\` is a SQL reserved word), index \`idx_email_rfc2822_message_id\`.
- `make clean` flow unchanged. Fresh DB picks the columns up; existing operators need one \`make clean\` to migrate (no in-place ALTER).

## Changes

- `src/mailpilot/schema.sql` -- columns + index.
- `src/mailpilot/models.py` -- \`Email\` model fields.
- `src/mailpilot/database.py` -- new \`find_email_by_rfc2822_message_id\`; \`create_email\` accepts the new fields.
- `src/mailpilot/routing.py` -- \`_try_rfc_message_id_match\` step + \`_collect_referenced_message_ids\` helper; new span attribute value \`route_method=rfc_message_id_match\`. \`thread_match\` still takes precedence.
- `src/mailpilot/sync.py` -- persists \`In-Reply-To\` and \`References\` headers at sync time; emits \`routing.route_email_skipped\` for every bypass with \`reason\` in \`{outside_recency_window, no_active_workflows, predates_workflows}\`.

## Tests

10 added, all 542 passing; ruff + basedpyright clean.

- D2 (routing fallback): \`test_route_email_falls_back_to_rfc_message_id_match\`, \`*_via_references_header\`, \`*_scoped_to_account\`, \`*_span_has_route_method_rfc_message_id_match\`, \`*_thread_match_takes_precedence_over_rfc\`, \`*_no_referenced_ids_falls_through\`.
- D2 (persistence): \`test_sync_stores_in_reply_to_and_references_headers\`.
- D5: \`test_sync_emits_route_skipped_span_when_no_active_workflows\`, \`*_outside_recency_window\`, \`*_when_predates_workflows\`.

## Test plan

- [ ] CI passes (\`make check\`)
- [ ] Re-run smoke test -- expect Scenario A's operator reply to route via \`rfc_message_id_match\` once #88 also lands
- [ ] Inspect Logfire after a smoke run: every email's routing decision should be visible as either \`routing.route_email\` or \`routing.route_email_skipped\`