### PR TITLE
test(cli): regression coverage for JSON envelope with control characters

### DIFF
--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -61,8 +61,14 @@ def configure_logging(debug: bool = False) -> None:
 
 
 def output(data: dict[str, Any]) -> None:
-    """Print structured JSON response to stdout."""
-    click.echo(json.dumps({**data, "ok": True}, indent=2))
+    r"""Print structured JSON response to stdout.
+
+    Always RFC 8259 compliant: control characters (\n, \r, \t, etc.) inside
+    string values are escaped, so downstream `json.loads` / `jq` callers never
+    trip on raw control bytes. `ensure_ascii=False` keeps non-ASCII glyphs
+    (em-dashes, accented characters) readable instead of `\uXXXX`-encoded.
+    """
+    click.echo(json.dumps({**data, "ok": True}, indent=2, ensure_ascii=False))
 
 
 def output_error(message: str, code: str) -> NoReturn:
@@ -74,7 +80,7 @@ def output_error(message: str, code: str) -> NoReturn:
     ctx = current.get_span_context() if current else None
     if ctx is not None and ctx.is_valid:
         payload["trace_id"] = format(ctx.trace_id, "032x")
-    click.echo(json.dumps(payload, indent=2), err=True)
+    click.echo(json.dumps(payload, indent=2, ensure_ascii=False), err=True)
     raise SystemExit(1)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1262,6 +1262,76 @@ def test_email_view_not_found(runner: CliRunner, mock_connection: MagicMock) -> 
     assert data["error"] == "not_found"
 
 
+def test_email_list_body_text_with_newlines_is_valid_json(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    """body_text containing newlines must serialize as valid JSON (RFC 8259).
+
+    Regression: defect 3 -- raw \n bytes inside string literals broke
+    `python -c json.load` and `jq` for downstream agents.
+    """
+    body = "line one\nline two\nline three"
+    email = _make_email(body_text=body)
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_emails", return_value=[email]),
+    ):
+        result = runner.invoke(main, ["email", "list"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["emails"][0]["body_text"] == body
+
+
+def test_email_view_body_text_with_newlines_is_valid_json(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    """`email view` must escape control characters in body_text (RFC 8259)."""
+    body = "line one\nline two\nline three"
+    email = _make_email(body_text=body)
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_email", return_value=email),
+    ):
+        result = runner.invoke(main, ["email", "view", email.id])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["body_text"] == body
+
+
+def test_output_escapes_all_control_characters() -> None:
+    """The `output()` helper must escape every control character so the result
+    parses cleanly with `json.loads`. Control chars include \\n, \\r, \\t, \\v
+    and arbitrary low bytes such as \\x00 and \\x1c."""
+    from mailpilot.cli import output
+
+    runner_local = CliRunner()
+    payload = {"body_text": "a\x00b\x01c\nd\re\tf\x0bg\x1ch"}
+    with runner_local.isolation() as (out, _err, _mix):
+        output(payload)
+    raw = out.getvalue().decode("utf-8")
+    parsed = json.loads(raw)
+    assert parsed["body_text"] == payload["body_text"]
+
+
+def test_output_preserves_non_ascii_as_utf8() -> None:
+    """`ensure_ascii=False` keeps glyphs like em-dashes readable in the JSON
+    body instead of `\\u2014`. Output must still parse cleanly."""
+    from mailpilot.cli import output
+
+    runner_local = CliRunner()
+    payload = {"body_text": "hello \u2014 world"}
+    with runner_local.isolation() as (out, _err, _mix):
+        output(payload)
+    raw = out.getvalue().decode("utf-8")
+    assert "\u2014" in raw  # em-dash glyph, not the escaped form
+    parsed = json.loads(raw)
+    assert parsed["body_text"] == payload["body_text"]
+
+
 def test_email_list_contact_not_found(
     runner: CliRunner, mock_connection: MagicMock
 ) -> None:


### PR DESCRIPTION
## Summary

Reported as **Defect 3** during today's smoke test: \`mailpilot email list\` and \`email view\` appeared to emit invalid JSON when \`body_text\` contained newlines. On investigation the current code (\`json.dumps(..., indent=2)\`) already escapes control characters correctly per RFC 8259 -- the original report likely misread \`\\n\` escape sequences as raw newlines in transcript display.

This PR locks in the contract with regression tests and adds \`ensure_ascii=False\` so non-ASCII glyphs (em-dashes, accents) round-trip natively as UTF-8 instead of \`\\u2014\` escapes. Control characters remain escaped in both modes.

## Changes

- \`src/mailpilot/cli.py\` -- \`output()\` and \`output_error()\` now pass \`ensure_ascii=False, indent=2\`.
- \`tests/test_cli.py\` -- four new regression tests.

## Tests

4 added, all 536 passing; ruff + basedpyright clean.

- \`test_email_list_body_text_with_newlines_is_valid_json\`
- \`test_email_view_body_text_with_newlines_is_valid_json\`
- \`test_output_escapes_all_control_characters\`
- \`test_output_preserves_non_ascii_as_utf8\`

## Test plan

- [ ] CI passes
- [ ] Pipe \`mailpilot email list --direction outbound | python3 -m json.tool\` -- exits 0