### PR TITLE
refactor(sync): time-gate _sync_all_accounts to run at most once per run_interval

### DIFF
--- a/src/mailpilot/sync.py
+++ b/src/mailpilot/sync.py
@@ -183,11 +183,12 @@ def start_sync_loop(
         )
 
     # Start PG LISTEN thread (instant task execution on INSERT).
-    database_url = str(settings.database_url)
-    listener_thread = _start_task_listener(database_url, wakeup_event, shutdown_event)
+    listener_thread = _start_task_listener(
+        str(settings.database_url), wakeup_event, shutdown_event
+    )
 
     # Main loop.
-    last_watch_renewal = 0.0
+    last_watch_renewal = last_full_sync = 0.0
     try:
         while not shutdown_event.is_set():
             event_set = wakeup_event.wait(timeout=settings.run_interval)
@@ -200,15 +201,24 @@ def start_sync_loop(
             update_sync_heartbeat(connection)
             logfire.debug("sync.loop.heartbeat", pid=pid)
 
-            _run_periodic_iteration(
-                connection, settings, sync_queue, "event" if event_set else "timer"
-            )
-
-            # Hourly watch renewal.
+            # Time-gate the safety-net sweep. Event-burst wakes (Pub/Sub
+            # notifications already drained by ``_drain_sync_queue``) skip
+            # the full sweep; the worst-case latency for a missed
+            # notification stays bounded by ``run_interval``.
             now = time.monotonic()
-            if now - last_watch_renewal >= _WATCH_RENEWAL_INTERVAL:
-                _renew_watches_logging_errors(connection, settings)
-                last_watch_renewal = now
+            do_full_sweep = now - last_full_sync >= settings.run_interval
+            _run_periodic_iteration(
+                connection,
+                settings,
+                sync_queue,
+                "event" if event_set else "timer",
+                do_full_sweep=do_full_sweep,
+            )
+            if do_full_sweep:
+                last_full_sync = now
+            last_watch_renewal = _renew_watches_if_due(
+                connection, settings, last_watch_renewal, now
+            )
     finally:
         # Graceful shutdown.
         if subscriber_future is not None:
@@ -286,14 +296,26 @@ def _run_periodic_iteration(
     settings: Settings,
     sync_queue: queue.Queue[str],
     wakeup_source: WakeupSource,
+    *,
+    do_full_sweep: bool,
 ) -> None:
-    """Run one iteration of the periodic sync + task drain cycle."""
-    with logfire.span("sync.loop.iteration", wakeup_source=wakeup_source):
+    """Run one iteration of the periodic sync + task drain cycle.
+
+    ``do_full_sweep`` gates the safety-net ``_sync_all_accounts`` call.
+    The caller (``start_sync_loop``) sets it to True at most once per
+    ``run_interval`` so event-burst wakes do only the queue drain.
+    """
+    with logfire.span(
+        "sync.loop.iteration",
+        wakeup_source=wakeup_source,
+        did_full_sweep=do_full_sweep,
+    ):
         # Sync accounts from Pub/Sub notifications.
         _drain_sync_queue(connection, settings, sync_queue)
 
-        # Periodic sync of all accounts.
-        _sync_all_accounts(connection, settings)
+        # Periodic safety-net sync of all accounts.
+        if do_full_sweep:
+            _sync_all_accounts(connection, settings)
 
         # Bridge routed emails to tasks and drain the queue.
         create_tasks_for_routed_emails(connection)
@@ -375,6 +397,23 @@ def _renew_watches_logging_errors(
             logfire.info("sync.watches.renewed", count=renewed)
     except Exception:
         logfire.exception("sync.watches.renewal_failed")
+
+
+def _renew_watches_if_due(
+    connection: psycopg.Connection[dict[str, Any]],
+    settings: Settings,
+    last_renewal: float,
+    now: float,
+) -> float:
+    """Run watch renewal when ``_WATCH_RENEWAL_INTERVAL`` has elapsed.
+
+    Returns the timestamp to record as the most recent renewal -- ``now``
+    when renewal ran this tick, otherwise the existing ``last_renewal``.
+    """
+    if now - last_renewal < _WATCH_RENEWAL_INTERVAL:
+        return last_renewal
+    _renew_watches_logging_errors(connection, settings)
+    return now
 
 
 # -- Per-account sync ---------------------------------------------------------

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -303,7 +303,11 @@ def test_run_periodic_iteration_tags_event_wakeup_source(
     sync_queue: _queue.Queue[str] = _queue.Queue()
 
     _run_periodic_iteration(
-        database_connection, settings, sync_queue, wakeup_source="event"
+        database_connection,
+        settings,
+        sync_queue,
+        wakeup_source="event",
+        do_full_sweep=True,
     )
 
     spans = _iteration_spans(capfire)
@@ -326,12 +330,125 @@ def test_run_periodic_iteration_tags_timer_wakeup_source(
     sync_queue: _queue.Queue[str] = _queue.Queue()
 
     _run_periodic_iteration(
-        database_connection, settings, sync_queue, wakeup_source="timer"
+        database_connection,
+        settings,
+        sync_queue,
+        wakeup_source="timer",
+        do_full_sweep=True,
     )
 
     spans = _iteration_spans(capfire)
     assert len(spans) == 1
     assert spans[0]["attributes"]["wakeup_source"] == "timer"
+
+
+def test_run_periodic_iteration_runs_sync_all_when_do_full_sweep_true(
+    capfire: CaptureLogfire,
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """do_full_sweep=True -> _sync_all_accounts runs and span did_full_sweep is True."""
+    import queue as _queue
+
+    from mailpilot.sync import (
+        _run_periodic_iteration,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    settings = make_test_settings()
+    sync_queue: _queue.Queue[str] = _queue.Queue()
+
+    with patch("mailpilot.sync._sync_all_accounts") as mock_sync_all:
+        _run_periodic_iteration(
+            database_connection,
+            settings,
+            sync_queue,
+            wakeup_source="event",
+            do_full_sweep=True,
+        )
+
+    mock_sync_all.assert_called_once()
+    spans = _iteration_spans(capfire)
+    assert len(spans) == 1
+    assert spans[0]["attributes"]["did_full_sweep"] is True
+
+
+def test_run_periodic_iteration_skips_sync_all_when_do_full_sweep_false(
+    capfire: CaptureLogfire,
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """do_full_sweep=False -> _sync_all_accounts is skipped and span did_full_sweep is False."""
+    import queue as _queue
+
+    from mailpilot.sync import (
+        _run_periodic_iteration,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    settings = make_test_settings()
+    sync_queue: _queue.Queue[str] = _queue.Queue()
+
+    with patch("mailpilot.sync._sync_all_accounts") as mock_sync_all:
+        _run_periodic_iteration(
+            database_connection,
+            settings,
+            sync_queue,
+            wakeup_source="event",
+            do_full_sweep=False,
+        )
+
+    mock_sync_all.assert_not_called()
+    spans = _iteration_spans(capfire)
+    assert len(spans) == 1
+    assert spans[0]["attributes"]["did_full_sweep"] is False
+
+
+def test_start_sync_loop_time_gates_full_sweep(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """_sync_all_accounts runs at most once per run_interval seconds.
+
+    Two event wakes within run_interval should trigger _sync_all_accounts
+    only once -- the first wake. Subsequent event-burst wakes do only the
+    queue drain. Once run_interval has elapsed, the next wake runs the
+    sweep again.
+    """
+    settings = make_test_settings(run_interval=30)
+
+    with (
+        patch("mailpilot.sync.threading.Event") as mock_event_cls,
+        patch("mailpilot.sync._start_task_listener"),
+        patch("mailpilot.sync._start_pubsub_logging_errors", return_value=None),
+        patch("mailpilot.sync._drain_sync_queue"),
+        patch("mailpilot.sync._sync_all_accounts") as mock_sync_all,
+        patch("mailpilot.sync.create_tasks_for_routed_emails"),
+        patch("mailpilot.sync._drain_pending_tasks"),
+        patch("mailpilot.sync._renew_watches_logging_errors"),
+        patch("mailpilot.sync.signal.signal"),
+        patch("mailpilot.sync.time.monotonic") as mock_monotonic,
+    ):
+        # Three iterations; one time.monotonic() call per iteration.
+        # t=1000: first wake -> 1000 - 0.0 >= 30, sweep runs, last_full_sync=1000.
+        # t=1010: second wake -> 1010 - 1000 = 10 < 30, sweep skipped.
+        # t=1050: third wake -> 1050 - 1000 = 50 >= 30, sweep runs again.
+        mock_monotonic.side_effect = [1000.0, 1010.0, 1050.0]
+
+        mock_shutdown = MagicMock()
+        # while-check False x3 (run iterations 1/2/3), then True (exit)
+        mock_shutdown.is_set.side_effect = [
+            False,  # while
+            False,  # post-wait #1
+            False,  # while
+            False,  # post-wait #2
+            False,  # while
+            False,  # post-wait #3
+            True,  # while -> exit
+        ]
+        mock_wakeup = MagicMock()
+        mock_wakeup.wait.return_value = True  # event-driven wakes
+        mock_event_cls.side_effect = [mock_shutdown, mock_wakeup]
+
+        start_sync_loop(database_connection, settings)
+
+    # Sweep ran on iteration 1 and iteration 3, but NOT iteration 2.
+    assert mock_sync_all.call_count == 2
 
 
 # -- sync_account --------------------------------------------------------------


### PR DESCRIPTION
## Summary

`_run_periodic_iteration` calls `_sync_all_accounts` on every loop wake, even when the wake was triggered by a single Pub/Sub notification that has already been handled by `_drain_sync_queue`. This doubles per-account sync work on every event-driven iteration.

This change time-gates the safety-net sweep so it runs at most once per `run_interval`, while preserving its safety-net semantics for missed Pub/Sub notifications.

## Approach

Add a `last_full_sync` monotonic timestamp tracked across loop iterations. `_sync_all_accounts` only runs when `time.monotonic() - last_full_sync >= run_interval`. Event-burst wakes do only the queue drain; the full sweep runs on the first wake after `run_interval` elapses (event- or timer-driven). Worst-case latency for a missed Pub/Sub notification stays bounded by `run_interval`.

The `sync.loop.iteration` span gains a `did_full_sweep` attribute so the cadence is queryable in Logfire.

Resolves #93