### PR TITLE
refactor(cli): unify list/view interface -- reduced fields for list, full record for view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,16 @@ The CLI must be LLM Agent friendly: JSON output only. Exit codes must be meaning
 
 **Verbs: GitHub CLI (`gh`) as default guidance, not a rule.** Common verbs: `list` (summary), `view ID` (full record), `get` (fetch from external API), `set` (update config). The primary concern is LLM-agent ease-of-operation and fewer mistakes -- when a domain-specific verb (e.g., `reply`) reduces parameters or ambiguity for the operator, prefer it over forcing a `gh`-style alternative. All IDs are UUIDv7.
 
+**List vs view contract.** A `<entity> list` row exists to answer one question -- "is this the row I want to drill into?" -- so it MUST contain only fields that:
+
+1. **Identify** -- `id` plus the natural identifier (email, name, subject, domain).
+2. **Filter** -- every field exposed as a `--flag` on the same `list` command (status, type, direction, FK refs).
+3. **Order** -- the timestamp the list is sorted by.
+
+It MUST NOT contain long-text fields (`body_text`, `instructions`, `objective`, `profile_summary`, `qualification_notes`, ...), JSON blobs (`detail`, `context`, `result`, `recipients`), variable-cardinality lists (`labels`, `domain_aliases`, `products_services`, `locations`), or internal Gmail bookkeeping (`gmail_history_id`, `watch_expiration`, `references_header`, `in_reply_to`, `rfc2822_message_id`).
+
+Mechanics: each entity has a `<Entity>Summary` Pydantic model in `models.py` (a strict subset of the full model). `list_<entity>` in `database.py` SELECTs only summary columns and returns `list[<Entity>Summary]`. `<entity> view ID` (and `get_<entity>()`) returns the full record. Exceptions: `Tag` already matches the summary contract (no `TagSummary`); `Note` summary keeps `body_preview` (first 80 chars + `...` if truncated) since the body is the entire content; `EnrollmentSummary` is denormalised with `contact_email` / `contact_name` because the join is already established in `list_enrollments_detailed`. Internal hot paths that need full records (sync loops over accounts, agent prompt assembly that needs `body_text`, classifier that needs `objective`) hydrate via `get_<entity>()` per id rather than introducing a `list_*_full` variant.
+
 **Input validation in CLI commands.** All commands validate before touching the database:
 
 1. Required text fields reject empty/whitespace-only values: `output_error("X cannot be empty", "validation_error")` -- checked before `initialize_database()`.
@@ -63,7 +73,7 @@ mailpilot --debug COMMAND
 mailpilot --completion bash|zsh|fish
 
 mailpilot account create --email E [--display-name N]
-mailpilot account list
+mailpilot account list [--limit N] [--since ISO]
 mailpilot account view ID
 mailpilot account update ID [--display-name N]
 mailpilot account sync [--account-id ID]
@@ -71,7 +81,7 @@ mailpilot account sync [--account-id ID]
 mailpilot company create --domain D [--name N] [opts]
 mailpilot company update ID [--name N]
 mailpilot company search QUERY [--limit N]
-mailpilot company list [--limit N]
+mailpilot company list [--limit N] [--since ISO]
 mailpilot company view ID
 mailpilot company export FILE
 mailpilot company import FILE
@@ -79,7 +89,7 @@ mailpilot company import FILE
 mailpilot contact create --email E [--first-name F] [--last-name L] [opts]
 mailpilot contact update ID [--email E] [--first-name F] [--last-name L] [opts]
 mailpilot contact search QUERY [--limit N]
-mailpilot contact list [--limit N] [--domain D] [--company-id ID] [--status active|bounced|unsubscribed]
+mailpilot contact list [--limit N] [--domain D] [--company-id ID] [--status active|bounced|unsubscribed] [--since ISO]
 mailpilot contact view ID
 mailpilot contact export FILE
 mailpilot contact import FILE
@@ -87,7 +97,7 @@ mailpilot contact import FILE
 mailpilot workflow create --name N --type inbound|outbound --account-id ID [--objective O] [--instructions TEXT | --instructions-file F] [--draft]
 mailpilot workflow update ID [--name N] [--objective O] [--instructions TEXT | --instructions-file F]
 mailpilot workflow search QUERY [--limit N]
-mailpilot workflow list [--account-id ID] [--status draft|active|paused] [--type inbound|outbound]
+mailpilot workflow list [--account-id ID] [--status draft|active|paused] [--type inbound|outbound] [--limit N] [--since ISO]
 mailpilot workflow view ID
 mailpilot workflow start ID
 mailpilot workflow stop ID
@@ -95,11 +105,11 @@ mailpilot workflow stop ID
 mailpilot enrollment add --workflow-id ID --contact-id ID
 mailpilot enrollment remove --workflow-id ID --contact-id ID
 mailpilot enrollment view --workflow-id ID --contact-id ID
-mailpilot enrollment list [--workflow-id ID] [--contact-id ID] [--status pending|active|completed|failed] [--limit N]
+mailpilot enrollment list [--workflow-id ID] [--contact-id ID] [--status pending|active|completed|failed] [--limit N] [--since ISO]
 mailpilot enrollment update --workflow-id ID --contact-id ID --status S [--reason R]
 mailpilot enrollment run --workflow-id ID --contact-id ID
 
-mailpilot task list [--workflow-id ID] [--contact-id ID] [--status pending|completed|failed|cancelled] [--limit N]
+mailpilot task list [--workflow-id ID] [--contact-id ID] [--status pending|completed|failed|cancelled] [--limit N] [--since ISO]
 mailpilot task view ID
 mailpilot task cancel ID
 
@@ -117,8 +127,8 @@ mailpilot tag add --contact-id ID NAME
 mailpilot tag add --company-id ID NAME
 mailpilot tag remove --contact-id ID NAME
 mailpilot tag remove --company-id ID NAME
-mailpilot tag list --contact-id ID
-mailpilot tag list --company-id ID
+mailpilot tag list --contact-id ID [--limit N] [--since ISO]
+mailpilot tag list --company-id ID [--limit N] [--since ISO]
 mailpilot tag search NAME [--type contact|company] [--limit N]
 
 mailpilot note add --contact-id ID --body TEXT

--- a/src/mailpilot/agent/invoke.py
+++ b/src/mailpilot/agent/invoke.py
@@ -452,13 +452,22 @@ def invoke_workflow_agent(  # noqa: PLR0913
                     f"account not found for workflow: {workflow.account_id}"
                 )
 
-            # Load email history scoped to this workflow + contact.
-            email_history = database.list_emails(
+            # Load email history scoped to this workflow + contact. The
+            # agent prompt needs ``body_text`` (not in EmailSummary), so
+            # hydrate each summary via ``get_email``.
+            email_summaries = database.list_emails(
                 connection,
                 contact_id=contact.id,
                 account_id=account.id,
                 workflow_id=workflow.id,
             )
+            email_history = [
+                full
+                for full in (
+                    database.get_email(connection, s.id) for s in email_summaries
+                )
+                if full is not None
+            ]
 
             # Build agent and deps.
             agent = _build_agent(workflow)

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -254,13 +254,15 @@ def account_create(email: str, display_name: str) -> None:
 
 
 @account.command("list")
-def account_list() -> None:
-    """List all Gmail accounts."""
+@click.option("--limit", default=100, help="Maximum results.")
+@click.option("--since", default=None, help="ISO datetime lower bound on created_at.")
+def account_list(limit: int, since: str | None) -> None:
+    """List Gmail accounts as summaries."""
     from mailpilot.database import initialize_database, list_accounts
 
     connection = initialize_database(_database_url())
     try:
-        accounts = list_accounts(connection)
+        accounts = list_accounts(connection, limit=limit, since=since)
         output({"accounts": [a.model_dump(mode="json") for a in accounts]})
     finally:
         connection.close()
@@ -326,7 +328,12 @@ def account_sync(account_id: str | None) -> None:
                 output_error(f"account not found: {account_id}", "not_found")
             accounts = [single]
         else:
-            accounts = list_accounts(connection)
+            summaries = list_accounts(connection, limit=1000)
+            accounts = [
+                full
+                for full in (get_account(connection, s.id) for s in summaries)
+                if full is not None
+            ]
 
         results: list[dict[str, object]] = []
         total_stored = 0
@@ -430,13 +437,14 @@ def company_search(query: str, limit: int) -> None:
 
 @company.command("list")
 @click.option("--limit", default=100, help="Maximum results.")
-def company_list(limit: int) -> None:
-    """List all companies."""
+@click.option("--since", default=None, help="ISO datetime lower bound on created_at.")
+def company_list(limit: int, since: str | None) -> None:
+    """List companies as summaries."""
     from mailpilot.database import initialize_database, list_companies
 
     connection = initialize_database(_database_url())
     try:
-        companies = list_companies(connection, limit=limit)
+        companies = list_companies(connection, limit=limit, since=since)
         output({"companies": [c.model_dump(mode="json") for c in companies]})
     finally:
         connection.close()
@@ -464,12 +472,13 @@ def company_export(file: str) -> None:
     """Export all companies to a JSON file."""
     import pathlib
 
-    from mailpilot.database import initialize_database, list_companies
+    from mailpilot.database import get_company, initialize_database, list_companies
 
     connection = initialize_database(_database_url())
     try:
-        companies = list_companies(connection)
-        data = [c.model_dump(mode="json") for c in companies]
+        summaries = list_companies(connection, limit=100_000)
+        full = [get_company(connection, s.id) for s in summaries]
+        data = [c.model_dump(mode="json") for c in full if c is not None]
         pathlib.Path(file).write_text(json.dumps(data, indent=2))
         output({"exported": len(data), "file": file})
     finally:
@@ -601,10 +610,15 @@ def contact_search(query: str, limit: int) -> None:
     type=click.Choice(["active", "bounced", "unsubscribed"]),
     help="Filter by contact status.",
 )
+@click.option("--since", default=None, help="ISO datetime lower bound on created_at.")
 def contact_list(
-    limit: int, domain: str | None, company_id: str | None, status: str | None
+    limit: int,
+    domain: str | None,
+    company_id: str | None,
+    status: str | None,
+    since: str | None,
 ) -> None:
-    """List contacts."""
+    """List contacts as summaries."""
     from mailpilot.database import get_company, initialize_database, list_contacts
 
     connection = initialize_database(_database_url())
@@ -612,7 +626,12 @@ def contact_list(
         if company_id is not None and get_company(connection, company_id) is None:
             output_error(f"company not found: {company_id}", "not_found")
         contacts = list_contacts(
-            connection, limit=limit, domain=domain, company_id=company_id, status=status
+            connection,
+            limit=limit,
+            domain=domain,
+            company_id=company_id,
+            status=status,
+            since=since,
         )
         output({"contacts": [c.model_dump(mode="json") for c in contacts]})
     finally:
@@ -641,12 +660,13 @@ def contact_export(file: str) -> None:
     """Export all contacts to a JSON file."""
     import pathlib
 
-    from mailpilot.database import initialize_database, list_contacts
+    from mailpilot.database import get_contact, initialize_database, list_contacts
 
     connection = initialize_database(_database_url())
     try:
-        contacts = list_contacts(connection)
-        data = [c.model_dump(mode="json") for c in contacts]
+        summaries = list_contacts(connection, limit=100_000)
+        full = [get_contact(connection, s.id) for s in summaries]
+        data = [c.model_dump(mode="json") for c in full if c is not None]
         pathlib.Path(file).write_text(json.dumps(data, indent=2))
         output({"exported": len(data), "file": file})
     finally:
@@ -1176,7 +1196,14 @@ def tag_remove(contact_id: str | None, company_id: str | None, name: str) -> Non
 @tag.command("list")
 @click.option("--contact-id", default=None, help="Contact ID.")
 @click.option("--company-id", default=None, help="Company ID.")
-def tag_list(contact_id: str | None, company_id: str | None) -> None:
+@click.option("--limit", default=100, help="Maximum results.")
+@click.option("--since", default=None, help="ISO datetime lower bound on created_at.")
+def tag_list(
+    contact_id: str | None,
+    company_id: str | None,
+    limit: int,
+    since: str | None,
+) -> None:
     """List tags on a contact or company."""
     from mailpilot.database import (
         get_company,
@@ -1193,7 +1220,13 @@ def tag_list(contact_id: str | None, company_id: str | None) -> None:
                 output_error(f"contact {entity_id} not found", "not_found")
         elif get_company(connection, entity_id) is None:
             output_error(f"company {entity_id} not found", "not_found")
-        tags = list_tags(connection, entity_type=entity_type, entity_id=entity_id)
+        tags = list_tags(
+            connection,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            limit=limit,
+            since=since,
+        )
         output({"tags": [t.model_dump(mode="json") for t in tags]})
     finally:
         connection.close()
@@ -1549,10 +1582,16 @@ def workflow_search(query: str, limit: int) -> None:
     type=click.Choice(["inbound", "outbound"]),
     help="Filter by workflow type.",
 )
+@click.option("--limit", default=100, help="Maximum results.")
+@click.option("--since", default=None, help="ISO datetime lower bound on created_at.")
 def workflow_list(
-    account_id: str | None, status: str | None, workflow_type: str | None
+    account_id: str | None,
+    status: str | None,
+    workflow_type: str | None,
+    limit: int,
+    since: str | None,
 ) -> None:
-    """List workflows."""
+    """List workflows as summaries."""
     from mailpilot.database import get_account, initialize_database, list_workflows
 
     connection = initialize_database(_database_url())
@@ -1564,6 +1603,8 @@ def workflow_list(
             account_id=account_id,
             status=status,
             workflow_type=workflow_type,
+            limit=limit,
+            since=since,
         )
         output({"workflows": [w.model_dump(mode="json") for w in workflows]})
     finally:
@@ -1792,13 +1833,15 @@ def enrollment_view(workflow_id: str, contact_id: str) -> None:
     help="Filter by enrollment status.",
 )
 @click.option("--limit", default=100, help="Maximum results.")
+@click.option("--since", default=None, help="ISO datetime lower bound on updated_at.")
 def enrollment_list(
     workflow_id: str | None,
     contact_id: str | None,
     status: str | None,
     limit: int,
+    since: str | None,
 ) -> None:
-    """List enrollments. Filter by workflow, contact, or both."""
+    """List enrollments as summaries. Filter by workflow, contact, or both."""
     from mailpilot.database import (
         get_contact,
         get_workflow,
@@ -1818,6 +1861,7 @@ def enrollment_list(
             contact_id=contact_id,
             status=status,
             limit=limit,
+            since=since,
         )
         output({"enrollments": [r.model_dump(mode="json") for r in rows]})
     finally:
@@ -1871,13 +1915,15 @@ def task() -> None:
     help="Filter by task status.",
 )
 @click.option("--limit", default=100, help="Maximum results.")
+@click.option("--since", default=None, help="ISO datetime lower bound on scheduled_at.")
 def task_list(
     workflow_id: str | None,
     contact_id: str | None,
     status: str | None,
     limit: int,
+    since: str | None,
 ) -> None:
-    """List tasks with optional filters."""
+    """List tasks as summaries with optional filters."""
     from mailpilot.database import (
         get_contact,
         get_workflow,
@@ -1897,6 +1943,7 @@ def task_list(
             contact_id=contact_id,
             status=status,
             limit=limit,
+            since=since,
         )
         output({"tasks": [t.model_dump(mode="json") for t in tasks]})
     finally:

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -1410,7 +1410,10 @@ def list_emails(
             (case-insensitive, matches to/cc/bcc).
 
     Returns:
-        List of email summaries ordered by creation time descending.
+        List of email summaries ordered by ``COALESCE(sent_at, received_at)``
+        descending -- the same expression used by the ``since`` filter, so
+        operators can page newest-first using a timestamp visible in
+        ``EmailSummary``.
     """
     conditions: list[SQL] = []
     params: dict[str, object] = {"limit": limit}
@@ -1447,7 +1450,8 @@ def list_emails(
     query = SQL(
         "SELECT id, account_id, contact_id, workflow_id, direction, "
         "subject, sender, status, sent_at, received_at "
-        "FROM email {} ORDER BY created_at DESC LIMIT %(limit)s"
+        "FROM email {} "
+        "ORDER BY COALESCE(sent_at, received_at) DESC LIMIT %(limit)s"
     ).format(where)
     rows = connection.execute(query, params).fetchall()
     return [EmailSummary.model_validate(row) for row in rows]

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -24,17 +24,25 @@ from psycopg.types.json import Json
 
 from mailpilot.models import (
     Account,
+    AccountSummary,
     Activity,
+    ActivitySummary,
     Company,
+    CompanySummary,
     Contact,
+    ContactSummary,
     Email,
+    EmailSummary,
     Enrollment,
-    EnrollmentDetail,
+    EnrollmentSummary,
     Note,
+    NoteSummary,
     SyncStatus,
     Tag,
     Task,
+    TaskSummary,
     Workflow,
+    WorkflowSummary,
 )
 
 SCHEMA_PATH = Path(__file__).parent / "schema.sql"
@@ -201,17 +209,34 @@ def get_account(
 
 def list_accounts(
     connection: psycopg.Connection[dict[str, Any]],
-) -> list[Account]:
-    """List all accounts.
+    limit: int = 100,
+    since: str | None = None,
+) -> list[AccountSummary]:
+    """List accounts as summaries (identify/filter/order fields only).
+
+    Internal callers needing the full record (e.g. ``gmail_history_id``,
+    ``watch_expiration``) must hydrate via ``get_account()`` per id.
 
     Args:
         connection: Open database connection.
+        limit: Maximum results.
+        since: ISO datetime lower bound on ``created_at``.
 
     Returns:
-        List of accounts ordered by creation time.
+        List of account summaries ordered by creation time.
     """
-    rows = connection.execute("SELECT * FROM account ORDER BY created_at").fetchall()
-    return [Account.model_validate(row) for row in rows]
+    conditions: list[Composed | SQL] = []
+    params: dict[str, object] = {"limit": limit}
+    if since is not None:
+        conditions.append(SQL("created_at >= %(since)s"))
+        params["since"] = since
+    where = SQL("WHERE ") + SQL(" AND ").join(conditions) if conditions else SQL("")
+    query = SQL(
+        "SELECT id, email, display_name, last_synced_at, created_at "
+        "FROM account {where} ORDER BY created_at LIMIT %(limit)s"
+    ).format(where=where)
+    rows = connection.execute(query, params).fetchall()
+    return [AccountSummary.model_validate(row) for row in rows]
 
 
 def get_account_by_email(
@@ -319,21 +344,30 @@ def get_company(
 def list_companies(
     connection: psycopg.Connection[dict[str, Any]],
     limit: int = 100,
-) -> list[Company]:
-    """List companies.
+    since: str | None = None,
+) -> list[CompanySummary]:
+    """List companies as summaries.
 
     Args:
         connection: Open database connection.
-        limit: Maximum number of companies to return.
+        limit: Maximum results.
+        since: ISO datetime lower bound on ``created_at``.
 
     Returns:
-        List of companies ordered by name.
+        List of company summaries ordered by name.
     """
-    rows = connection.execute(
-        "SELECT * FROM company ORDER BY LOWER(name) LIMIT %(limit)s",
-        {"limit": limit},
-    ).fetchall()
-    return [Company.model_validate(row) for row in rows]
+    conditions: list[Composed | SQL] = []
+    params: dict[str, object] = {"limit": limit}
+    if since is not None:
+        conditions.append(SQL("created_at >= %(since)s"))
+        params["since"] = since
+    where = SQL("WHERE ") + SQL(" AND ").join(conditions) if conditions else SQL("")
+    query = SQL(
+        "SELECT id, name, domain, industry, employee_count, created_at "
+        "FROM company {where} ORDER BY LOWER(name) LIMIT %(limit)s"
+    ).format(where=where)
+    rows = connection.execute(query, params).fetchall()
+    return [CompanySummary.model_validate(row) for row in rows]
 
 
 def search_companies(
@@ -629,18 +663,20 @@ def list_contacts(
     domain: str | None = None,
     company_id: str | None = None,
     status: str | None = None,
-) -> list[Contact]:
-    """List contacts with optional filters.
+    since: str | None = None,
+) -> list[ContactSummary]:
+    """List contacts as summaries with optional filters.
 
     Args:
         connection: Open database connection.
-        limit: Maximum number of contacts to return.
+        limit: Maximum results.
         domain: Filter by domain.
         company_id: Filter by company ID.
         status: Filter by contact status ("active", "bounced", "unsubscribed").
+        since: ISO datetime lower bound on ``created_at``.
 
     Returns:
-        List of contacts ordered by email.
+        List of contact summaries ordered by email.
     """
     conditions: list[SQL] = []
     params: dict[str, object] = {"limit": limit}
@@ -653,10 +689,16 @@ def list_contacts(
     if status is not None:
         conditions.append(SQL("status = %(status)s"))
         params["status"] = status
+    if since is not None:
+        conditions.append(SQL("created_at >= %(since)s"))
+        params["since"] = since
     where = SQL("WHERE ") + SQL(" AND ").join(conditions) if conditions else SQL("")
-    query = SQL("SELECT * FROM contact {} ORDER BY email LIMIT %(limit)s").format(where)
+    query = SQL(
+        "SELECT id, email, first_name, last_name, company_id, status, created_at "
+        "FROM contact {} ORDER BY email LIMIT %(limit)s"
+    ).format(where)
     rows = connection.execute(query, params).fetchall()
-    return [Contact.model_validate(row) for row in rows]
+    return [ContactSummary.model_validate(row) for row in rows]
 
 
 def search_contacts(
@@ -822,20 +864,24 @@ def list_workflows(
     account_id: str | None = None,
     status: str | None = None,
     workflow_type: str | None = None,
-) -> list[Workflow]:
-    """List workflows with optional account, status, and type filters.
+    limit: int = 100,
+    since: str | None = None,
+) -> list[WorkflowSummary]:
+    """List workflows as summaries with optional account, status, and type filters.
 
     Args:
         connection: Open database connection.
         account_id: Filter by account ID.
         status: Filter by workflow status (e.g., "active").
         workflow_type: Filter by workflow type ("inbound" or "outbound").
+        limit: Maximum results.
+        since: ISO datetime lower bound on ``created_at``.
 
     Returns:
-        List of workflows ordered by creation time.
+        List of workflow summaries ordered by creation time.
     """
     conditions: list[SQL] = []
-    params: dict[str, object] = {}
+    params: dict[str, object] = {"limit": limit}
     if account_id is not None:
         conditions.append(SQL("account_id = %(account_id)s"))
         params["account_id"] = account_id
@@ -845,10 +891,16 @@ def list_workflows(
     if workflow_type is not None:
         conditions.append(SQL("type = %(workflow_type)s"))
         params["workflow_type"] = workflow_type
+    if since is not None:
+        conditions.append(SQL("created_at >= %(since)s"))
+        params["since"] = since
     where = SQL("WHERE ") + SQL(" AND ").join(conditions) if conditions else SQL("")
-    query = SQL("SELECT * FROM workflow {} ORDER BY created_at").format(where)
+    query = SQL(
+        "SELECT id, name, type, account_id, status, created_at "
+        "FROM workflow {} ORDER BY created_at LIMIT %(limit)s"
+    ).format(where)
     rows = connection.execute(query, params).fetchall()
-    return [Workflow.model_validate(row) for row in rows]
+    return [WorkflowSummary.model_validate(row) for row in rows]
 
 
 def search_workflows(
@@ -1147,8 +1199,9 @@ def list_enrollments_detailed(
     contact_id: str | None = None,
     status: str | None = None,
     limit: int = 100,
-) -> list[EnrollmentDetail]:
-    """List enrollments with denormalised contact info for display.
+    since: str | None = None,
+) -> list[EnrollmentSummary]:
+    """List enrollments with denormalised contact info as summaries.
 
     JOINs the contact table to include email and name. Separate from
     ``list_enrollments`` to avoid breaking agent tools which expect
@@ -1160,10 +1213,11 @@ def list_enrollments_detailed(
         workflow_id: Optional workflow FK filter.
         contact_id: Optional contact FK filter.
         status: Filter by enrollment status.
-        limit: Maximum results (default 100).
+        limit: Maximum results.
+        since: ISO datetime lower bound on ``e.updated_at``.
 
     Returns:
-        List of enrollment details.
+        List of enrollment summaries.
     """
     params: dict[str, object] = {"limit": limit}
     where_parts: list[Composed | SQL] = []
@@ -1176,21 +1230,25 @@ def list_enrollments_detailed(
     if status is not None:
         where_parts.append(SQL("e.status = %(status)s"))
         params["status"] = status
+    if since is not None:
+        where_parts.append(SQL("e.updated_at >= %(since)s"))
+        params["since"] = since
     where_clause = (
         SQL("WHERE ") + SQL(" AND ").join(where_parts) if where_parts else SQL("")
     )
     query = SQL(
-        "SELECT e.*, c.email AS contact_email, "
+        "SELECT e.workflow_id, e.contact_id, e.status, e.updated_at, "
+        "c.email AS contact_email, "
         "TRIM(COALESCE(c.first_name, '') || ' ' || COALESCE(c.last_name, '')) "
         "AS contact_name "
         "FROM enrollment e "
         "JOIN contact c ON c.id = e.contact_id "
         "{} "
-        "ORDER BY e.created_at "
+        "ORDER BY e.updated_at "
         "LIMIT %(limit)s"
     ).format(where_clause)
     rows = connection.execute(query, params).fetchall()
-    return [EnrollmentDetail.model_validate(row) for row in rows]
+    return [EnrollmentSummary.model_validate(row) for row in rows]
 
 
 # -- Email ---------------------------------------------------------------------
@@ -1334,12 +1392,12 @@ def list_emails(
     status: str | None = None,
     sender: str | None = None,
     recipient: str | None = None,
-) -> list[Email]:
-    """List emails with optional filters.
+) -> list[EmailSummary]:
+    """List emails as summaries with optional filters.
 
     Args:
         connection: Open database connection.
-        limit: Maximum number of emails to return.
+        limit: Maximum results.
         contact_id: Filter by contact ID.
         account_id: Filter by account ID.
         since: ISO datetime lower bound for COALESCE(sent_at, received_at).
@@ -1352,7 +1410,7 @@ def list_emails(
             (case-insensitive, matches to/cc/bcc).
 
     Returns:
-        List of emails ordered by creation time descending.
+        List of email summaries ordered by creation time descending.
     """
     conditions: list[SQL] = []
     params: dict[str, object] = {"limit": limit}
@@ -1387,10 +1445,12 @@ def list_emails(
         params["recipient_pattern"] = f"%{recipient}%"
     where = SQL("WHERE ") + SQL(" AND ").join(conditions) if conditions else SQL("")
     query = SQL(
-        "SELECT * FROM email {} ORDER BY created_at DESC LIMIT %(limit)s"
+        "SELECT id, account_id, contact_id, workflow_id, direction, "
+        "subject, sender, status, sent_at, received_at "
+        "FROM email {} ORDER BY created_at DESC LIMIT %(limit)s"
     ).format(where)
     rows = connection.execute(query, params).fetchall()
-    return [Email.model_validate(row) for row in rows]
+    return [EmailSummary.model_validate(row) for row in rows]
 
 
 def search_emails(
@@ -1815,18 +1875,20 @@ def list_tasks(
     contact_id: str | None = None,
     status: str | None = None,
     limit: int = 100,
-) -> list[Task]:
-    """List tasks with optional filters.
+    since: str | None = None,
+) -> list[TaskSummary]:
+    """List tasks as summaries with optional filters.
 
     Args:
         connection: Open database connection.
         workflow_id: Filter by workflow ID.
         contact_id: Filter by contact ID.
         status: Filter by task status.
-        limit: Maximum number of tasks to return.
+        limit: Maximum results.
+        since: ISO datetime lower bound on ``scheduled_at``.
 
     Returns:
-        List of tasks ordered by scheduled_at descending.
+        List of task summaries ordered by scheduled_at descending.
     """
     conditions: list[SQL] = []
     params: dict[str, object] = {"limit": limit}
@@ -1839,12 +1901,17 @@ def list_tasks(
     if status is not None:
         conditions.append(SQL("status = %(status)s"))
         params["status"] = status
+    if since is not None:
+        conditions.append(SQL("scheduled_at >= %(since)s"))
+        params["since"] = since
     where = SQL("WHERE ") + SQL(" AND ").join(conditions) if conditions else SQL("")
     query = SQL(
-        "SELECT * FROM task {} ORDER BY scheduled_at DESC LIMIT %(limit)s"
+        "SELECT id, workflow_id, contact_id, email_id, description, "
+        "scheduled_at, status "
+        "FROM task {} ORDER BY scheduled_at DESC LIMIT %(limit)s"
     ).format(where)
     rows = connection.execute(query, params).fetchall()
-    return [Task.model_validate(row) for row in rows]
+    return [TaskSummary.model_validate(row) for row in rows]
 
 
 def get_unprocessed_inbound_email(
@@ -1980,8 +2047,8 @@ def list_activities(
     activity_type: str | None = None,
     limit: int = 100,
     since: str | None = None,
-) -> list[Activity]:
-    """List activities with required contact or company filter.
+) -> list[ActivitySummary]:
+    """List activities as summaries with required contact or company filter.
 
     At least one of ``contact_id`` or ``company_id`` must be provided.
 
@@ -1994,7 +2061,7 @@ def list_activities(
         since: ISO datetime lower bound for created_at.
 
     Returns:
-        Activities ordered by created_at descending.
+        Activity summaries ordered by created_at descending.
 
     Raises:
         ValueError: If neither contact_id nor company_id is provided.
@@ -2017,10 +2084,11 @@ def list_activities(
         params["since"] = since
     where = SQL("WHERE ") + SQL(" AND ").join(conditions) if conditions else SQL("")
     query = SQL(
-        "SELECT * FROM activity {} ORDER BY created_at DESC LIMIT %(limit)s"
+        "SELECT id, contact_id, company_id, type, summary, created_at "
+        "FROM activity {} ORDER BY created_at DESC LIMIT %(limit)s"
     ).format(where)
     rows = connection.execute(query, params).fetchall()
-    return [Activity.model_validate(row) for row in rows]
+    return [ActivitySummary.model_validate(row) for row in rows]
 
 
 # -- Tag -----------------------------------------------------------------------
@@ -2107,25 +2175,39 @@ def list_tags(
     connection: psycopg.Connection[dict[str, Any]],
     entity_type: str,
     entity_id: str,
+    limit: int = 100,
+    since: str | None = None,
 ) -> list[Tag]:
     """List all tags on a contact or company.
+
+    Tag has no Summary projection -- the full row already matches the
+    summary contract (id, entity_type, entity_id, name, created_at).
 
     Args:
         connection: Open database connection.
         entity_type: "contact" or "company".
         entity_id: ID of the tagged entity.
+        limit: Maximum results.
+        since: ISO datetime lower bound on ``created_at``.
 
     Returns:
         Tags ordered by name.
     """
-    rows = connection.execute(
-        """\
-        SELECT * FROM tag
-        WHERE entity_type = %(entity_type)s AND entity_id = %(entity_id)s
-        ORDER BY name
-        """,
-        {"entity_type": entity_type, "entity_id": entity_id},
-    ).fetchall()
+    conditions: list[Composed | SQL] = [
+        SQL("entity_type = %(entity_type)s"),
+        SQL("entity_id = %(entity_id)s"),
+    ]
+    params: dict[str, object] = {
+        "entity_type": entity_type,
+        "entity_id": entity_id,
+        "limit": limit,
+    }
+    if since is not None:
+        conditions.append(SQL("created_at >= %(since)s"))
+        params["since"] = since
+    where = SQL("WHERE ") + SQL(" AND ").join(conditions)
+    query = SQL("SELECT * FROM tag {} ORDER BY name LIMIT %(limit)s").format(where)
+    rows = connection.execute(query, params).fetchall()
     return [Tag.model_validate(row) for row in rows]
 
 
@@ -2232,18 +2314,21 @@ def list_notes(
     entity_id: str,
     limit: int = 100,
     since: str | None = None,
-) -> list[Note]:
-    """List notes on a contact or company.
+) -> list[NoteSummary]:
+    """List notes on a contact or company as summaries with body previews.
+
+    The full body is replaced by ``body_preview`` -- the first 80 characters
+    with a trailing ellipsis when the body is longer.
 
     Args:
         connection: Open database connection.
         entity_type: "contact" or "company".
         entity_id: ID of the annotated entity.
-        limit: Maximum number of notes to return.
+        limit: Maximum results.
         since: ISO datetime lower bound for created_at.
 
     Returns:
-        Notes ordered by created_at descending.
+        Note summaries ordered by created_at descending.
     """
     conditions: list[SQL] = [
         SQL("entity_type = %(entity_type)s"),
@@ -2259,10 +2344,14 @@ def list_notes(
         params["since"] = since
     where = SQL("WHERE ") + SQL(" AND ").join(conditions)
     query = SQL(
-        "SELECT * FROM note {} ORDER BY created_at DESC LIMIT %(limit)s"
+        "SELECT id, entity_type, entity_id, "
+        "CASE WHEN LENGTH(body) > 80 THEN LEFT(body, 80) || '...' "
+        "ELSE body END AS body_preview, "
+        "created_at "
+        "FROM note {} ORDER BY created_at DESC LIMIT %(limit)s"
     ).format(where)
     rows = connection.execute(query, params).fetchall()
-    return [Note.model_validate(row) for row in rows]
+    return [NoteSummary.model_validate(row) for row in rows]
 
 
 def get_note(

--- a/src/mailpilot/models.py
+++ b/src/mailpilot/models.py
@@ -21,6 +21,16 @@ class Account(BaseModel):
     updated_at: datetime
 
 
+class AccountSummary(BaseModel):
+    """List-view projection of `Account`."""
+
+    id: str
+    email: str
+    display_name: str
+    last_synced_at: datetime | None
+    created_at: datetime
+
+
 class Company(BaseModel):
     """Target company for outbound campaigns."""
 
@@ -40,6 +50,17 @@ class Company(BaseModel):
     qualification_notes: str | None = None
     created_at: datetime
     updated_at: datetime
+
+
+class CompanySummary(BaseModel):
+    """List-view projection of `Company`."""
+
+    id: str
+    name: str
+    domain: str
+    industry: str | None
+    employee_count: int | None
+    created_at: datetime
 
 
 class Contact(BaseModel):
@@ -63,6 +84,18 @@ class Contact(BaseModel):
     updated_at: datetime
 
 
+class ContactSummary(BaseModel):
+    """List-view projection of `Contact`."""
+
+    id: str
+    email: str
+    first_name: str | None
+    last_name: str | None
+    company_id: str | None
+    status: str
+    created_at: datetime
+
+
 WorkflowType = Literal["inbound", "outbound"]
 WorkflowStatus = Literal["draft", "active", "paused"]
 
@@ -82,6 +115,17 @@ class Workflow(BaseModel):
     updated_at: datetime
 
 
+class WorkflowSummary(BaseModel):
+    """List-view projection of `Workflow`."""
+
+    id: str
+    name: str
+    type: WorkflowType
+    account_id: str
+    status: WorkflowStatus
+    created_at: datetime
+
+
 EnrollmentStatus = Literal["pending", "active", "completed", "failed"]
 
 
@@ -96,16 +140,14 @@ class Enrollment(BaseModel):
     updated_at: datetime
 
 
-class EnrollmentDetail(BaseModel):
-    """Enrollment with denormalised contact info for list display."""
+class EnrollmentSummary(BaseModel):
+    """List-view projection of `Enrollment` joined with contact identity."""
 
     workflow_id: str
     contact_id: str
     contact_email: str
     contact_name: str
     status: EnrollmentStatus
-    reason: str
-    created_at: datetime
     updated_at: datetime
 
 
@@ -137,6 +179,21 @@ class Email(BaseModel):
     created_at: datetime
 
 
+class EmailSummary(BaseModel):
+    """List-view projection of `Email`."""
+
+    id: str
+    account_id: str
+    contact_id: str | None
+    workflow_id: str | None
+    direction: EmailDirection
+    subject: str
+    sender: str
+    status: str
+    sent_at: datetime | None
+    received_at: datetime | None
+
+
 TaskStatus = Literal["pending", "completed", "failed", "cancelled"]
 
 
@@ -154,6 +211,18 @@ class Task(BaseModel):
     result: dict[str, object] = {}
     completed_at: datetime | None = None
     created_at: datetime
+
+
+class TaskSummary(BaseModel):
+    """List-view projection of `Task`."""
+
+    id: str
+    workflow_id: str
+    contact_id: str
+    email_id: str | None
+    description: str
+    scheduled_at: datetime
+    status: TaskStatus
 
 
 ActivityType = Literal[
@@ -181,6 +250,17 @@ class Activity(BaseModel):
     created_at: datetime
 
 
+class ActivitySummary(BaseModel):
+    """List-view projection of `Activity`."""
+
+    id: str
+    contact_id: str
+    company_id: str | None
+    type: ActivityType
+    summary: str
+    created_at: datetime
+
+
 EntityType = Literal["contact", "company"]
 
 
@@ -201,6 +281,16 @@ class Note(BaseModel):
     entity_type: EntityType
     entity_id: str
     body: str
+    created_at: datetime
+
+
+class NoteSummary(BaseModel):
+    """List-view projection of `Note` with truncated body preview."""
+
+    id: str
+    entity_type: EntityType
+    entity_id: str
+    body_preview: str
     created_at: datetime
 
 

--- a/src/mailpilot/pubsub.py
+++ b/src/mailpilot/pubsub.py
@@ -238,20 +238,23 @@ def renew_watches(
     Returns:
         Number of watches renewed.
     """
-    from mailpilot.database import list_accounts, update_account
+    from mailpilot.database import get_account, list_accounts, update_account
     from mailpilot.gmail import GmailClient
 
     project_id = _resolve_project_id(settings)
     topic = _topic_path(project_id, settings)
     threshold = datetime.now(UTC) + _WATCH_RENEWAL_THRESHOLD
 
-    accounts = list_accounts(connection)
+    summaries = list_accounts(connection, limit=1000)
     renewed = 0
 
     # Per-account spans rather than a single wrapper. A hung Gmail
     # watch call would otherwise block the wrapper span from flushing
     # and hide which account is the offender.
-    for account in accounts:
+    for summary in summaries:
+        account = get_account(connection, summary.id)
+        if account is None:
+            continue
         if (
             account.watch_expiration is not None
             and account.watch_expiration > threshold

--- a/src/mailpilot/routing.py
+++ b/src/mailpilot/routing.py
@@ -28,6 +28,7 @@ from mailpilot.database import (
     disable_contact,
     find_email_by_rfc2822_message_id,
     get_emails_by_gmail_thread_id,
+    get_workflow,
     list_workflows,
     update_email,
 )
@@ -271,8 +272,17 @@ def _try_classify(
     settings: Settings,
 ) -> str | None:
     """Step 2: LLM classification against active inbound workflows."""
-    workflows = list_workflows(connection, account_id=email.account_id, status="active")
-    inbound_workflows = [w for w in workflows if w.type == "inbound"]
+    summaries = list_workflows(connection, account_id=email.account_id, status="active")
+    inbound_summaries = [s for s in summaries if s.type == "inbound"]
+    if not inbound_summaries:
+        return None
+    # classify_email reads workflow.objective, which is not in WorkflowSummary;
+    # hydrate via get_workflow so the LLM prompt has the full record.
+    inbound_workflows = [
+        full
+        for full in (get_workflow(connection, s.id) for s in inbound_summaries)
+        if full is not None
+    ]
     if not inbound_workflows:
         return None
     return classify_email(

--- a/src/mailpilot/run.py
+++ b/src/mailpilot/run.py
@@ -17,6 +17,7 @@ from mailpilot.agent import invoke_workflow_agent
 from mailpilot.database import (
     complete_task,
     create_tasks_for_routed_emails,
+    get_account,
     get_contact,
     get_email,
     get_workflow,
@@ -151,8 +152,11 @@ def _sync_all_accounts(
     settings: Settings,
 ) -> None:
     """Sync all Gmail accounts. Errors per account are logged, not raised."""
-    accounts = list_accounts(connection)
-    for account in accounts:
+    summaries = list_accounts(connection, limit=1000)
+    for summary in summaries:
+        account = get_account(connection, summary.id)
+        if account is None:
+            continue
         try:
             client = GmailClient(account.email)
             sync_account(connection, account, client, settings)

--- a/src/mailpilot/sync.py
+++ b/src/mailpilot/sync.py
@@ -40,6 +40,7 @@ from mailpilot.database import (
     create_or_get_contact_by_email,
     create_tasks_for_routed_emails,
     delete_sync_status,
+    get_account,
     get_account_by_email,
     get_contacts_by_emails,
     get_email_by_gmail_message_id,
@@ -357,8 +358,11 @@ def _sync_all_accounts(
     settings: Settings,
 ) -> None:
     """Sync all Gmail accounts. Errors per account are logged, not raised."""
-    accounts = list_accounts(connection)
-    for account in accounts:
+    summaries = list_accounts(connection, limit=1000)
+    for summary in summaries:
+        account = get_account(connection, summary.id)
+        if account is None:
+            continue
         try:
             client = GmailClient(account.email)
             sync_account(connection, account, client, settings)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,10 +17,12 @@ from mailpilot.models import (
     Account,
     Activity,
     Company,
+    CompanySummary,
     Contact,
+    ContactSummary,
     Email,
     Enrollment,
-    EnrollmentDetail,
+    EnrollmentSummary,
     Note,
     Tag,
     Task,
@@ -174,6 +176,25 @@ def test_account_list_empty(runner: CliRunner, mock_connection: MagicMock) -> No
     assert data["accounts"] == []
 
 
+def test_account_list_limit_and_since(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_accounts", return_value=[]) as mock_list,
+    ):
+        result = runner.invoke(
+            main,
+            ["account", "list", "--limit", "5", "--since", "2024-01-01T00:00:00"],
+        )
+
+    assert result.exit_code == 0
+    mock_list.assert_called_once_with(
+        mock_connection, limit=5, since="2024-01-01T00:00:00"
+    )
+
+
 # -- account view --------------------------------------------------------------
 
 
@@ -284,6 +305,7 @@ def test_account_sync_all_accounts(
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
         patch("mailpilot.database.list_accounts", return_value=[acc_a, acc_b]),
+        patch("mailpilot.database.get_account", side_effect=[acc_a, acc_b]),
         patch("mailpilot.gmail.GmailClient") as mock_client_cls,
         patch("mailpilot.sync.sync_account", side_effect=[3, 5]) as mock_sync,
     ):
@@ -349,6 +371,7 @@ def test_account_sync_error_isolated_per_account(
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
         patch("mailpilot.database.list_accounts", return_value=[acc_a, acc_b]),
+        patch("mailpilot.database.get_account", side_effect=[acc_a, acc_b]),
         patch("mailpilot.gmail.GmailClient"),
         patch("logfire.exception"),
         patch(
@@ -463,7 +486,23 @@ def test_company_list_with_limit(runner: CliRunner, mock_connection: MagicMock) 
         result = runner.invoke(main, ["company", "list", "--limit", "5"])
 
     assert result.exit_code == 0
-    mock_list.assert_called_once_with(mock_connection, limit=5)
+    mock_list.assert_called_once_with(mock_connection, limit=5, since=None)
+
+
+def test_company_list_with_since(runner: CliRunner, mock_connection: MagicMock) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_companies", return_value=[]) as mock_list,
+    ):
+        result = runner.invoke(
+            main, ["company", "list", "--since", "2024-01-01T00:00:00"]
+        )
+
+    assert result.exit_code == 0
+    mock_list.assert_called_once_with(
+        mock_connection, limit=100, since="2024-01-01T00:00:00"
+    )
 
 
 # -- company view --------------------------------------------------------------
@@ -611,12 +650,17 @@ def test_company_update_not_found(
 def test_company_export(
     runner: CliRunner, mock_connection: MagicMock, tmp_path: Any
 ) -> None:
-    companies = [_make_company(id="id-1"), _make_company(id="id-2")]
+    company_a = _make_company(id="id-1")
+    company_b = _make_company(id="id-2")
+    summaries = [
+        CompanySummary.model_validate(c.model_dump()) for c in (company_a, company_b)
+    ]
     export_file = str(tmp_path / "companies.json")
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
-        patch("mailpilot.database.list_companies", return_value=companies),
+        patch("mailpilot.database.list_companies", return_value=summaries),
+        patch("mailpilot.database.get_company", side_effect=[company_a, company_b]),
     ):
         result = runner.invoke(main, ["company", "export", export_file])
 
@@ -627,6 +671,7 @@ def test_company_export(
     exported = json.loads(pathlib.Path(export_file).read_text())
     assert len(exported) == 2
     assert exported[0]["id"] == "id-1"
+    assert "profile_summary" in exported[0]
 
 
 # -- company import ------------------------------------------------------------
@@ -916,7 +961,12 @@ def test_contact_list_with_filters(
 
     assert result.exit_code == 0
     mock_list.assert_called_once_with(
-        mock_connection, limit=5, domain="example.com", company_id="cid-1", status=None
+        mock_connection,
+        limit=5,
+        domain="example.com",
+        company_id="cid-1",
+        status=None,
+        since=None,
     )
 
 
@@ -932,7 +982,33 @@ def test_contact_list_with_status(
 
     assert result.exit_code == 0
     mock_list.assert_called_once_with(
-        mock_connection, limit=100, domain=None, company_id=None, status="bounced"
+        mock_connection,
+        limit=100,
+        domain=None,
+        company_id=None,
+        status="bounced",
+        since=None,
+    )
+
+
+def test_contact_list_with_since(runner: CliRunner, mock_connection: MagicMock) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.list_contacts", return_value=[]) as mock_list,
+    ):
+        result = runner.invoke(
+            main, ["contact", "list", "--since", "2024-01-01T00:00:00"]
+        )
+
+    assert result.exit_code == 0
+    mock_list.assert_called_once_with(
+        mock_connection,
+        limit=100,
+        domain=None,
+        company_id=None,
+        status=None,
+        since="2024-01-01T00:00:00",
     )
 
 
@@ -993,12 +1069,17 @@ def test_contact_view_not_found(runner: CliRunner, mock_connection: MagicMock) -
 def test_contact_export(
     runner: CliRunner, mock_connection: MagicMock, tmp_path: Any
 ) -> None:
-    contacts = [_make_contact(id="id-1"), _make_contact(id="id-2")]
+    contact_a = _make_contact(id="id-1")
+    contact_b = _make_contact(id="id-2")
+    summaries = [
+        ContactSummary.model_validate(c.model_dump()) for c in (contact_a, contact_b)
+    ]
     export_file = str(tmp_path / "contacts.json")
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
-        patch("mailpilot.database.list_contacts", return_value=contacts),
+        patch("mailpilot.database.list_contacts", return_value=summaries),
+        patch("mailpilot.database.get_contact", side_effect=[contact_a, contact_b]),
     ):
         result = runner.invoke(main, ["contact", "export", export_file])
 
@@ -1009,6 +1090,7 @@ def test_contact_export(
     exported = json.loads(pathlib.Path(export_file).read_text())
     assert len(exported) == 2
     assert exported[0]["id"] == "id-1"
+    assert "domain" in exported[0]
 
 
 # -- contact import ------------------------------------------------------------
@@ -2539,7 +2621,12 @@ def test_workflow_list(runner: CliRunner, mock_connection: MagicMock) -> None:
 
     assert result.exit_code == 0
     mock_list.assert_called_once_with(
-        mock_connection, account_id=None, status=None, workflow_type=None
+        mock_connection,
+        account_id=None,
+        status=None,
+        workflow_type=None,
+        limit=100,
+        since=None,
     )
     data = json.loads(result.output)
     assert len(data["workflows"]) == 2
@@ -2559,7 +2646,12 @@ def test_workflow_list_by_account(
 
     assert result.exit_code == 0
     mock_list.assert_called_once_with(
-        mock_connection, account_id=_ACCOUNT_ID, status=None, workflow_type=None
+        mock_connection,
+        account_id=_ACCOUNT_ID,
+        status=None,
+        workflow_type=None,
+        limit=100,
+        since=None,
     )
 
 
@@ -2596,7 +2688,12 @@ def test_workflow_list_with_filters(
 
     assert result.exit_code == 0
     mock_list.assert_called_once_with(
-        mock_connection, account_id=None, status="active", workflow_type="outbound"
+        mock_connection,
+        account_id=None,
+        status="active",
+        workflow_type="outbound",
+        limit=100,
+        since=None,
     )
 
 
@@ -3679,14 +3776,55 @@ def test_tag_list(runner: CliRunner, mock_connection: MagicMock) -> None:
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
         patch("mailpilot.database.get_contact", return_value=contact),
-        patch("mailpilot.database.list_tags", return_value=tags),
+        patch("mailpilot.database.list_tags", return_value=tags) as mock_list,
     ):
         result = runner.invoke(main, ["tag", "list", "--contact-id", "cid-1"])
 
     assert result.exit_code == 0
+    mock_list.assert_called_once_with(
+        mock_connection,
+        entity_type="contact",
+        entity_id="cid-1",
+        limit=100,
+        since=None,
+    )
     data = json.loads(result.output)
     assert data["ok"] is True
     assert len(data["tags"]) == 2
+
+
+def test_tag_list_limit_and_since(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    contact = _make_contact()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=contact),
+        patch("mailpilot.database.list_tags", return_value=[]) as mock_list,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "tag",
+                "list",
+                "--contact-id",
+                "cid-1",
+                "--limit",
+                "5",
+                "--since",
+                "2024-01-01T00:00:00",
+            ],
+        )
+
+    assert result.exit_code == 0
+    mock_list.assert_called_once_with(
+        mock_connection,
+        entity_type="contact",
+        entity_id="cid-1",
+        limit=5,
+        since="2024-01-01T00:00:00",
+    )
 
 
 def test_tag_list_no_entity(runner: CliRunner, mock_connection: MagicMock) -> None:
@@ -4117,18 +4255,16 @@ def _make_enrollment(**overrides: Any) -> Enrollment:
     return Enrollment(**{**defaults, **overrides})
 
 
-def _make_enrollment_detail(**overrides: Any) -> EnrollmentDetail:
+def _make_enrollment_summary(**overrides: Any) -> EnrollmentSummary:
     defaults: dict[str, Any] = {
         "workflow_id": _WORKFLOW_ID,
         "contact_id": _CONTACT_ID,
         "contact_email": "alice@example.com",
         "contact_name": "Alice Smith",
         "status": "pending",
-        "reason": "",
-        "created_at": _NOW,
         "updated_at": _NOW,
     }
-    return EnrollmentDetail(**{**defaults, **overrides})
+    return EnrollmentSummary(**{**defaults, **overrides})
 
 
 # -- enrollment add ------------------------------------------------------------
@@ -4366,13 +4502,13 @@ def test_enrollment_view_not_found(
 
 
 def test_enrollment_list(runner: CliRunner, mock_connection: MagicMock) -> None:
-    detail = _make_enrollment_detail()
+    summary = _make_enrollment_summary()
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
         patch("mailpilot.database.get_workflow", return_value=_make_workflow()),
         patch(
-            "mailpilot.database.list_enrollments_detailed", return_value=[detail]
+            "mailpilot.database.list_enrollments_detailed", return_value=[summary]
         ) as mock_list,
     ):
         result = runner.invoke(
@@ -4387,11 +4523,14 @@ def test_enrollment_list(runner: CliRunner, mock_connection: MagicMock) -> None:
         contact_id=None,
         status=None,
         limit=100,
+        since=None,
     )
     data = json.loads(result.output)
     assert data["ok"] is True
     assert len(data["enrollments"]) == 1
     assert data["enrollments"][0]["contact_email"] == "alice@example.com"
+    assert "reason" not in data["enrollments"][0]
+    assert "created_at" not in data["enrollments"][0]
 
 
 def test_enrollment_list_with_status(
@@ -4424,6 +4563,7 @@ def test_enrollment_list_with_status(
         contact_id=None,
         status="completed",
         limit=100,
+        since=None,
     )
 
 
@@ -4457,6 +4597,7 @@ def test_enrollment_list_with_limit(
         contact_id=None,
         status=None,
         limit=5,
+        since=None,
     )
 
 
@@ -4483,6 +4624,7 @@ def test_enrollment_list_filters_by_contact(
         contact_id=_CONTACT_ID,
         status=None,
         limit=100,
+        since=None,
     )
 
 
@@ -4641,7 +4783,12 @@ def test_task_list(runner: CliRunner, mock_connection: MagicMock) -> None:
 
     assert result.exit_code == 0, result.output
     mock_list.assert_called_once_with(
-        mock_connection, workflow_id=None, contact_id=None, status=None, limit=100
+        mock_connection,
+        workflow_id=None,
+        contact_id=None,
+        status=None,
+        limit=100,
+        since=None,
     )
     data = json.loads(result.output)
     assert len(data["tasks"]) == 1
@@ -4681,6 +4828,7 @@ def test_task_list_with_filters(runner: CliRunner, mock_connection: MagicMock) -
         contact_id=_CONTACT_ID,
         status="pending",
         limit=10,
+        since=None,
     )
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1024,6 +1024,41 @@ def test_list_emails_since(
     assert results[0].subject == "Recent"
 
 
+def test_list_emails_order_matches_since_filter(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """list_emails orders by COALESCE(sent_at, received_at) DESC.
+
+    The order column must agree with the `since` filter so an operator
+    can page newest-first using a timestamp visible in the summary.
+    """
+    from datetime import datetime, timedelta
+
+    account = make_test_account(database_connection)
+    # Insert the chronologically-newer row FIRST so that ordering by
+    # `created_at DESC` would put the older content on top -- only
+    # `COALESCE(sent_at, received_at) DESC` reorders correctly.
+    newer_outbound = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="Newer outbound",
+        sent_at=datetime.now(UTC),
+    )
+    older_inbound = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Older inbound",
+        gmail_message_id="msg_older_inbound",
+        received_at=datetime.now(UTC) - timedelta(days=2),
+    )
+    assert older_inbound is not None
+    assert newer_outbound is not None
+    results = list_emails(database_connection, account_id=account.id)
+    assert [r.subject for r in results] == ["Newer outbound", "Older inbound"]
+
+
 def test_list_emails_by_thread_id(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -237,7 +237,7 @@ def test_list_contacts_by_domain(
     make_test_contact(database_connection, email="b@bar.com", domain="bar.com")
     results = list_contacts(database_connection, domain="foo.com")
     assert len(results) == 1
-    assert results[0].domain == "foo.com"
+    assert results[0].email == "a@foo.com"
 
 
 def test_list_contacts_by_status(
@@ -1463,7 +1463,12 @@ def test_list_emails_filter_by_recipient(
     )
     results = list_emails(database_connection, recipient="kb@lab5.ca")
     assert len(results) == 1
-    assert "kb@lab5.ca" in results[0].recipients["to"]
+    # `recipients` is not in EmailSummary; verify by hydrating via get_email.
+    from mailpilot.database import get_email
+
+    full = get_email(database_connection, results[0].id)
+    assert full is not None
+    assert "kb@lab5.ca" in full.recipients["to"]
 
 
 def test_list_emails_filter_by_recipient_matches_cc(
@@ -1883,9 +1888,9 @@ def test_list_notes(
     )
     notes = list_notes(database_connection, entity_type="contact", entity_id=contact.id)
     assert len(notes) == 2
-    # Ordered by created_at DESC
-    assert notes[0].body == "second"
-    assert notes[1].body == "first"
+    # Ordered by created_at DESC. Summary exposes body_preview, not body.
+    assert notes[0].body_preview == "second"
+    assert notes[1].body_preview == "first"
 
 
 def test_list_notes_empty(
@@ -1934,7 +1939,7 @@ def test_list_notes_since(
         database_connection, entity_type="contact", entity_id=contact.id, since=since
     )
     assert len(results) == 1
-    assert results[0].body == "recent"
+    assert results[0].body_preview == "recent"
 
 
 def test_get_note(
@@ -2417,3 +2422,291 @@ def test_complete_task_stores_result(
     assert completed.result["reasoning"] == agent_result["reasoning"]
     assert completed.result["tool_calls"] == agent_result["tool_calls"]
     assert completed.completed_at is not None
+
+
+# -- List vs view contract -----------------------------------------------------
+#
+# Per ADR / CLAUDE.md "list (summary), view ID (full record)" rule:
+# every `list_*` returns the matching `<Entity>Summary` projection (a strict
+# subset of the full model), and every `get_*` returns the full domain model.
+# These tests pin the contract so accidental field additions to a Summary
+# (or accidental field reads after a `list_*`) are caught at test time.
+
+
+def test_account_list_summary_get_full(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    from mailpilot.models import AccountSummary
+
+    make_test_account(database_connection)
+    accounts = list_accounts(database_connection)
+    assert isinstance(accounts[0], AccountSummary)
+    assert not hasattr(accounts[0], "gmail_history_id")
+    full = get_account(database_connection, accounts[0].id)
+    assert full is not None
+    assert hasattr(full, "gmail_history_id")
+
+
+def test_company_list_summary_get_full(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    from mailpilot.models import CompanySummary
+
+    make_test_company(database_connection)
+    companies = list_companies(database_connection)
+    assert isinstance(companies[0], CompanySummary)
+    assert not hasattr(companies[0], "profile_summary")
+    full = get_company(database_connection, companies[0].id)
+    assert full is not None
+    assert hasattr(full, "profile_summary")
+
+
+def test_contact_list_summary_get_full(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    from mailpilot.models import ContactSummary
+
+    make_test_contact(database_connection)
+    contacts = list_contacts(database_connection)
+    assert isinstance(contacts[0], ContactSummary)
+    assert not hasattr(contacts[0], "position")
+    full = get_contact(database_connection, contacts[0].id)
+    assert full is not None
+    assert hasattr(full, "position")
+
+
+def test_workflow_list_summary_get_full(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    from mailpilot.models import WorkflowSummary
+
+    account = make_test_account(database_connection)
+    make_test_workflow(database_connection, account_id=account.id)
+    workflows = list_workflows(database_connection)
+    assert isinstance(workflows[0], WorkflowSummary)
+    assert not hasattr(workflows[0], "objective")
+    full = get_workflow(database_connection, workflows[0].id)
+    assert full is not None
+    assert hasattr(full, "objective")
+
+
+def test_enrollment_list_summary_drops_reason_and_created_at(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    from mailpilot.models import EnrollmentSummary
+
+    account = make_test_account(database_connection)
+    contact = make_test_contact(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    create_enrollment(database_connection, workflow.id, contact.id)
+    rows = list_enrollments_detailed(database_connection, workflow_id=workflow.id)
+    assert isinstance(rows[0], EnrollmentSummary)
+    assert not hasattr(rows[0], "reason")
+    assert not hasattr(rows[0], "created_at")
+
+
+def test_email_list_summary_get_full(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    from mailpilot.models import EmailSummary
+
+    account = make_test_account(database_connection)
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="hi",
+        body_text="body",
+        status="sent",
+        recipients={"to": ["x@y.com"]},
+    )
+    emails = list_emails(database_connection, account_id=account.id)
+    assert isinstance(emails[0], EmailSummary)
+    assert not hasattr(emails[0], "body_text")
+    assert not hasattr(emails[0], "recipients")
+    assert not hasattr(emails[0], "labels")
+    full = get_email(database_connection, emails[0].id)
+    assert full is not None
+    assert full.body_text == "body"
+    assert "x@y.com" in full.recipients["to"]
+
+
+def test_task_list_summary(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    from mailpilot.models import TaskSummary
+
+    account = make_test_account(database_connection)
+    contact = make_test_contact(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    create_task(
+        database_connection,
+        workflow_id=workflow.id,
+        contact_id=contact.id,
+        description="follow up",
+        scheduled_at="2024-01-01T00:00:00+00:00",
+    )
+    tasks = list_tasks(database_connection, workflow_id=workflow.id)
+    assert isinstance(tasks[0], TaskSummary)
+    assert not hasattr(tasks[0], "context")
+    assert not hasattr(tasks[0], "result")
+
+
+def test_activity_list_summary(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    from mailpilot.models import ActivitySummary
+
+    contact = make_test_contact(database_connection)
+    create_activity(
+        database_connection,
+        contact_id=contact.id,
+        activity_type="email_sent",
+        summary="sent X",
+        detail={"id": "abc"},
+    )
+    activities = list_activities(database_connection, contact_id=contact.id)
+    assert isinstance(activities[0], ActivitySummary)
+    assert not hasattr(activities[0], "detail")
+
+
+def test_note_list_summary_with_body_preview(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    from mailpilot.models import NoteSummary
+
+    contact = make_test_contact(database_connection)
+    make_test_note(
+        database_connection,
+        entity_type="contact",
+        entity_id=contact.id,
+        body="short",
+    )
+    make_test_note(
+        database_connection,
+        entity_type="contact",
+        entity_id=contact.id,
+        body="x" * 200,
+    )
+    notes = list_notes(database_connection, entity_type="contact", entity_id=contact.id)
+    assert isinstance(notes[0], NoteSummary)
+    assert not hasattr(notes[0], "body")
+    # Long body truncated to 80 chars + "..." (ordered DESC, long one is first).
+    assert notes[0].body_preview == ("x" * 80) + "..."
+    # Short body returned verbatim with no ellipsis.
+    assert notes[1].body_preview == "short"
+    full = get_note(database_connection, notes[0].id)
+    assert full is not None
+    assert full.body == "x" * 200
+
+
+def test_list_accounts_limit_and_since(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    make_test_account(database_connection, email="a@test.com")
+    make_test_account(database_connection, email="b@test.com")
+    assert len(list_accounts(database_connection, limit=1)) == 1
+    assert len(list_accounts(database_connection, since="9999-01-01T00:00:00")) == 0
+
+
+def test_list_workflows_limit_and_since(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    account = make_test_account(database_connection)
+    make_test_workflow(database_connection, account_id=account.id, name="A")
+    make_test_workflow(database_connection, account_id=account.id, name="B")
+    assert len(list_workflows(database_connection, limit=1)) == 1
+    assert len(list_workflows(database_connection, since="9999-01-01T00:00:00")) == 0
+
+
+def test_list_companies_since(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    make_test_company(database_connection)
+    assert len(list_companies(database_connection, since="9999-01-01T00:00:00")) == 0
+
+
+def test_list_contacts_since(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    make_test_contact(database_connection)
+    assert len(list_contacts(database_connection, since="9999-01-01T00:00:00")) == 0
+
+
+def test_list_tasks_since(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    contact = make_test_contact(database_connection)
+    workflow = make_test_workflow(
+        database_connection, account_id=make_test_account(database_connection).id
+    )
+    create_task(
+        database_connection,
+        workflow_id=workflow.id,
+        contact_id=contact.id,
+        description="x",
+        scheduled_at="2020-01-01T00:00:00+00:00",
+    )
+    assert (
+        len(
+            list_tasks(
+                database_connection,
+                workflow_id=workflow.id,
+                since="2030-01-01T00:00:00",
+            )
+        )
+        == 0
+    )
+
+
+def test_list_tags_limit_and_since(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    contact = make_test_contact(database_connection)
+    make_test_tag(
+        database_connection, entity_type="contact", entity_id=contact.id, name="a"
+    )
+    make_test_tag(
+        database_connection, entity_type="contact", entity_id=contact.id, name="b"
+    )
+    assert (
+        len(
+            list_tags(
+                database_connection,
+                entity_type="contact",
+                entity_id=contact.id,
+                limit=1,
+            )
+        )
+        == 1
+    )
+    assert (
+        len(
+            list_tags(
+                database_connection,
+                entity_type="contact",
+                entity_id=contact.id,
+                since="9999-01-01T00:00:00",
+            )
+        )
+        == 0
+    )
+
+
+def test_list_enrollments_detailed_since(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    account = make_test_account(database_connection)
+    contact = make_test_contact(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    create_enrollment(database_connection, workflow.id, contact.id)
+    assert (
+        len(
+            list_enrollments_detailed(
+                database_connection,
+                workflow_id=workflow.id,
+                since="9999-01-01T00:00:00",
+            )
+        )
+        == 0
+    )

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -314,6 +314,7 @@ def test_run_loop_sync_error_continues(
 
     with (
         patch("mailpilot.run.list_accounts", return_value=[account]),
+        patch("mailpilot.run.get_account", return_value=account),
         patch("mailpilot.run.GmailClient", side_effect=RuntimeError("auth failed")),
         patch(
             "mailpilot.run.create_tasks_for_routed_emails",


### PR DESCRIPTION
## Summary

Introduce per-entity `Summary` models so `<entity> list` returns a minimal projection while `<entity> view <id>` returns the full record. Standardize `--limit` / `--since` flags across `list` commands.

## Changes

- Add `AccountSummary`, `CompanySummary`, `ContactSummary`, `WorkflowSummary`, `EmailSummary`, `TaskSummary`, `ActivitySummary`, `NoteSummary` to `models.py` (no `TagSummary` -- `Tag` already matches the contract).
- Rename `EnrollmentDetail` -> `EnrollmentSummary`; drop `reason` and `created_at` from the projection.
- Narrow `SELECT` clauses in every `list_*` in `database.py` and update return types accordingly.
- `list_emails` now `ORDER BY COALESCE(sent_at, received_at) DESC` so the order column lives in `EmailSummary` and agrees with the `since` filter.
- `NoteSummary` includes `body_preview` (first 80 chars + ellipsis) since the body is the entire content.
- Internal hot paths that need full records (`_sync_all_accounts`, `renew_watches`, `_try_classify`, `invoke_workflow_agent`, `company_export`, `contact_export`) hydrate via `get_<entity>(id)` per the new convention rather than introducing a `list_*_full` variant.
- Add missing `--limit` / `--since` flags on CLI `list` commands; raise `company_export` / `contact_export` caps from default 100 to 100,000.
- Document the list/view contract and Summary mechanics in `CLAUDE.md`.
- Add `test_*_list_summary_get_full` contract tests pinning the projection rule for every entity.

## Follow-ups

- #98 -- extend the same contract to `search_*` (currently still SELECT *).

Resolves #78