### PR TITLE
feat(observability): add curated operator-log layer for mailpilot run

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -110,7 +110,7 @@ Save `OUTBOUND_WORKFLOW_ID`.
 
 Start `mailpilot run` in the background using `Bash` with `run_in_background: true`. Capture the bash_id so you can read its output later. This loop runs **once for the whole test** -- it stays up through Scenario B and is only stopped at the very end (Step B7).
 
-Always use `--debug` so the captured stdout shows per-iteration spans (`sync.loop.iteration`, `sync.account.run`, `gmail.get_history`, ...). Without it the loop is silent for minutes at a time, which makes diagnosing A4/B4 stalls require a Logfire round-trip.
+The loop emits curated `event=...` lifecycle lines on stdout regardless of `--debug` (`loop.tick`, `sync.account`, `route.match`, `agent.run`, `task.drain`, `error`). Use `--debug` only when you also need Logfire's full span output for deep diagnosis.
 
 ```
 uv run mailpilot --debug run
@@ -120,7 +120,7 @@ Wait ~3s, read the captured stdout, confirm:
 
 - `Sync loop started (pid <pid>)` printed.
 - `Pub/Sub subscriber started` printed (a `Warning: Pub/Sub setup failed` is acceptable -- periodic sync still works).
-- At least one `sync.loop.iteration` span has appeared (proves the loop is actually ticking, not just started).
+- At least one `event=loop.tick` line has appeared (proves the loop is actually ticking, not just started).
 
 **Gate A2:** background process alive; `sync_status` row present.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,6 +275,8 @@ Logging and tracing use [Pydantic Logfire](https://pydantic.dev/logfire) (OpenTe
 - Token: `mailpilot config set logfire_token <TOKEN>` or `LOGFIRE_TOKEN` env var
 - Cloud send: `send_to_logfire='if-token-present'` -- console-only when no token
 
+**Operator-log layer.** `src/mailpilot/operator_log.py` exposes `operator_event(name, **fields)` which writes a single-line `HH:MM:SS event=NAME k1=v1 ...` record to stdout, independent of Logfire's console exporter. It carries the curated lifecycle stream operators monitor under journald: `loop.start`, `loop.tick`, `loop.stop`, `pubsub.notify`, `sync.account`, `route.match`, `route.no_match`, `agent.run`, `task.drain`, `error`. Always on, regardless of `--debug`. When you add a new `logfire.exception` site reachable from `mailpilot run`, pair it with `operator_event("error", source=<event_name>, message=str(exc))` so the operator stream stays complete. Newlines in field values are collapsed to spaces -- preserves the one-line-per-event contract for `journalctl | grep`. See ADR-07 for the design.
+
 **Cloud project.** All records land in dedicated Logfire project **`mailpilot`** (scope of the project-scoped write token). The sibling `leadpilot` service uses its own project, so no `service_name` filter is needed when querying. Spans are split by `deployment_environment` (`development` | `production`), set from the `logfire_environment` setting. When querying via MCP, always pass `project='mailpilot'` and filter with `WHERE deployment_environment = 'production'` (or `'development'`).
 
 **Skills for Logfire work.** Prefer these skills over ad-hoc commands:

--- a/docs/adr-07-observability-with-logfire.md
+++ b/docs/adr-07-observability-with-logfire.md
@@ -127,6 +127,20 @@ except ApiError as exc:
 - Local development with live traces: use `/logfire:dev-session` to obtain write credentials. The session token lands in `~/.mailpilot/config.json` via `mailpilot config set logfire_token`.
 - Console output defaults to `warn`. Use `mailpilot --debug COMMAND` to see `debug` and `info` locally.
 
+### Operator log layer
+
+`src/mailpilot/operator_log.py` is a separate, single-function layer (`operator_event(name, **fields)`) that writes one structured line per lifecycle event to stdout. It is independent of Logfire's console exporter.
+
+**Why split:**
+
+- Under systemd, stdout becomes journald. journald rate-limits (default 10000/30s) and silently drops on overflow. Mirroring full Logfire span output to stdout risks dropped lines on busy mailboxes.
+- The operator-log layer answers "is it alive, what just happened, did anything error" -- a tight, high-signal feed. Logfire remains the deep-trace layer.
+- The `--debug` flag still controls Logfire's console exporter for local debugging. The operator log is always on.
+
+**Curated event set:** `loop.start`, `loop.tick`, `loop.stop`, `pubsub.notify`, `sync.account`, `route.match`, `route.no_match`, `agent.run`, `task.drain`, `error`. Each event line is single-line ASCII: `HH:MM:SS event=NAME k1=v1 k2=v2`.
+
+**When you add a new lifecycle event,** add it to `operator_event` call sites only -- do not add it to Logfire's console exporter. When you add a `logfire.exception` or `logfire.warn` reachable from `mailpilot run`, pair it with `operator_event("error", source=<event_name>, message=str(exc))` so the operator stream stays complete.
+
 ### Investigation workflow
 
 When debugging production behavior, use the `/logfire:debug` skill, which drives the Logfire MCP. Pass `project='mailpilot'` on every call. Standard filter prefix for production queries:

--- a/src/mailpilot/agent/invoke.py
+++ b/src/mailpilot/agent/invoke.py
@@ -30,6 +30,7 @@ from mailpilot.agent import tools as agent_tools
 from mailpilot.exceptions import AgentDidNotUseToolsError
 from mailpilot.gmail import GmailClient
 from mailpilot.models import Account, Contact, Email, Workflow
+from mailpilot.operator_log import operator_event
 from mailpilot.settings import Settings
 
 
@@ -552,6 +553,13 @@ def invoke_workflow_agent(  # noqa: PLR0913
 
             span.set_attribute("result", "completed")
             span.set_attribute("agent_reasoning", result.output)
+            operator_event(
+                "agent.run",
+                workflow_id=workflow.id,
+                contact_id=contact.id,
+                status="completed",
+                tool_calls=tool_call_count,
+            )
             return {
                 "workflow_id": workflow.id,
                 "contact_id": contact.id,

--- a/src/mailpilot/agent/invoke.py
+++ b/src/mailpilot/agent/invoke.py
@@ -552,6 +552,7 @@ def invoke_workflow_agent(  # noqa: PLR0913
                 )
 
             span.set_attribute("result", "completed")
+            span.set_attribute("status", "completed")
             span.set_attribute("agent_reasoning", result.output)
             operator_event(
                 "agent.run",
@@ -568,6 +569,14 @@ def invoke_workflow_agent(  # noqa: PLR0913
                 "tool_errors": tool_errors,
                 "reasoning": result.output,
             }
+
+        except Exception:
+            # Mirror the operator-log error event into the span so Logfire
+            # queries can identify failed runs without joining through
+            # task.status. The exception itself still propagates -- callers
+            # (e.g. run.py) emit the operator-log ``event=error`` line.
+            span.set_attribute("status", "failed")
+            raise
 
         finally:
             _release_advisory_lock(connection, workflow.id, contact.id)

--- a/src/mailpilot/gmail.py
+++ b/src/mailpilot/gmail.py
@@ -11,7 +11,6 @@ Scope: ``https://www.googleapis.com/auth/gmail.modify``
 from __future__ import annotations
 
 import base64
-import re
 import time
 from email.mime.base import MIMEBase
 from email.utils import parseaddr
@@ -21,17 +20,21 @@ from typing import Any
 
 import logfire
 
-# C0 control characters that strict JSON (RFC 8259) rejects when bare in a
-# string. Excludes \t (0x09) and \n (0x0A), which Python's json module escapes
-# correctly and which appear in legitimate email bodies. Other line-break
-# controls (\r, \v, \f, 0x1c-0x1e) are folded into \n by ``str.splitlines``
-# upstream and never reach this regex.
-_CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b-\x1f]")
+# Translation table that drops every C0 control byte except \t (0x09) and \n
+# (0x0A). Strict JSON parsers (RFC 8259) reject bare C0 controls in strings;
+# \t and \n are kept because Python's json module escapes them correctly and
+# they appear in legitimate email bodies. \r is intentionally dropped: inbound
+# Gmail bodies arrive with CRLF line endings, so removing \r leaves clean
+# \n-delimited lines for downstream splitlines/normalisation.
+_CONTROL_CHAR_TABLE = dict.fromkeys(
+    [i for i in range(0x20) if i not in (0x09, 0x0A)],
+    None,
+)
 
 
 def strip_control_chars(text: str) -> str:
     """Remove C0 control bytes that break strict JSON parsing of body_text."""
-    return _CONTROL_CHAR_RE.sub("", text)
+    return text.translate(_CONTROL_CHAR_TABLE)
 
 
 GmailService = Any

--- a/src/mailpilot/gmail.py
+++ b/src/mailpilot/gmail.py
@@ -11,6 +11,7 @@ Scope: ``https://www.googleapis.com/auth/gmail.modify``
 from __future__ import annotations
 
 import base64
+import re
 import time
 from email.mime.base import MIMEBase
 from email.utils import parseaddr
@@ -19,6 +20,19 @@ from importlib.metadata import version
 from typing import Any
 
 import logfire
+
+# C0 control characters that strict JSON (RFC 8259) rejects when bare in a
+# string. Excludes \t (0x09) and \n (0x0A), which Python's json module escapes
+# correctly and which appear in legitimate email bodies. Other line-break
+# controls (\r, \v, \f, 0x1c-0x1e) are folded into \n by ``str.splitlines``
+# upstream and never reach this regex.
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b-\x1f]")
+
+
+def strip_control_chars(text: str) -> str:
+    """Remove C0 control bytes that break strict JSON parsing of body_text."""
+    return _CONTROL_CHAR_RE.sub("", text)
+
 
 GmailService = Any
 """Type alias for the Gmail API service resource (untyped by Google)."""
@@ -591,6 +605,7 @@ def _normalize_text(text: str) -> str:
     """
     if not text:
         return ""
+    text = strip_control_chars(text)
     lines = [line.rstrip() for line in text.splitlines()]
     collapsed: list[str] = []
     blank_count = 0

--- a/src/mailpilot/operator_log.py
+++ b/src/mailpilot/operator_log.py
@@ -1,0 +1,35 @@
+"""Operator-facing console output for ``mailpilot run``.
+
+Independent of Logfire's console exporter. Always emits to stdout
+(captured by journald under systemd). Use Logfire for deep traces;
+use this for the lifecycle/error layer operators monitor.
+
+See ADR-07 "Operator log layer".
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from typing import Any
+
+
+def operator_event(name: str, **fields: Any) -> None:
+    """Write one structured line to stdout.
+
+    Format: ``HH:MM:SS event=NAME k1=v1 k2=v2`` -- single line, ASCII-only.
+    Values containing whitespace are double-quoted with internal quotes
+    escaped. Embedded newlines in values are collapsed to spaces so a
+    multi-line ``str(exc)`` cannot break the one-line-per-event contract
+    that journald grep relies on.
+    """
+    timestamp = time.strftime("%H:%M:%S")
+    parts = [f"event={name}"]
+    for key, value in fields.items():
+        text = str(value).replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
+        if any(character.isspace() for character in text):
+            text = '"' + text.replace('"', '\\"') + '"'
+        parts.append(f"{key}={text}")
+    line = f"{timestamp} " + " ".join(parts)
+    sys.stdout.write(line + "\n")
+    sys.stdout.flush()

--- a/src/mailpilot/routing.py
+++ b/src/mailpilot/routing.py
@@ -33,7 +33,14 @@ from mailpilot.database import (
     update_email,
 )
 from mailpilot.models import Email
+from mailpilot.operator_log import operator_event
 from mailpilot.settings import Settings
+
+_VIA_BY_ROUTE_METHOD: dict[str, str] = {
+    "thread_match": "thread",
+    "rfc_message_id_match": "message_id",
+    "classified": "llm",
+}
 
 _BOUNCE_SENDERS = frozenset({"mailer-daemon", "postmaster"})
 
@@ -103,13 +110,23 @@ def route_email(
             )
             result = updated if updated is not None else email
 
-            if workflow_id is not None and result.contact_id is not None:
-                _ensure_enrollment(connection, workflow_id, result.contact_id)
+            if workflow_id is not None:
+                operator_event(
+                    "route.match",
+                    email_id=result.id,
+                    workflow_id=workflow_id,
+                    via=_VIA_BY_ROUTE_METHOD[route_method],
+                )
+                if result.contact_id is not None:
+                    _ensure_enrollment(connection, workflow_id, result.contact_id)
+            else:
+                operator_event("route.no_match", email_id=result.id)
 
             return result
-        except Exception:
+        except Exception as exc:
             span.set_attribute("result", "failure")
             logfire.exception("routing.route_email failed", email_id=email.id)
+            operator_event("error", source="routing.route_email", message=str(exc))
             raise
 
 

--- a/src/mailpilot/run.py
+++ b/src/mailpilot/run.py
@@ -26,6 +26,7 @@ from mailpilot.database import (
 )
 from mailpilot.gmail import GmailClient
 from mailpilot.models import Task
+from mailpilot.operator_log import operator_event
 from mailpilot.settings import Settings
 from mailpilot.sync import sync_account
 
@@ -95,6 +96,7 @@ def execute_task(
                 "run.task.agent_failed",
                 task_id=task.id,
             )
+            operator_event("error", source="run.task.agent_failed", message=str(exc))
             connection.rollback()
             complete_task(
                 connection,

--- a/src/mailpilot/sync.py
+++ b/src/mailpilot/sync.py
@@ -62,6 +62,7 @@ from mailpilot.gmail import (
     extract_text_from_message,
     get_message_headers,
     parse_sender,
+    strip_control_chars,
 )
 from mailpilot.models import Account, Contact, Email
 from mailpilot.operator_log import operator_event
@@ -1020,7 +1021,7 @@ def send_email(  # noqa: PLR0913
         # markers, leaving recipients on text/plain-only clients with
         # tab-soup tables.
         html_body = render_email_html(body, theme)
-        plain_body = body
+        plain_body = strip_control_chars(body)
 
         # Build multipart/alternative MIME
         mime_message = MIMEMultipart("alternative")

--- a/src/mailpilot/sync.py
+++ b/src/mailpilot/sync.py
@@ -21,6 +21,7 @@ Usage::
 
 from __future__ import annotations
 
+import itertools
 import os
 import queue
 import signal
@@ -63,6 +64,7 @@ from mailpilot.gmail import (
     parse_sender,
 )
 from mailpilot.models import Account, Contact, Email
+from mailpilot.operator_log import operator_event
 from mailpilot.routing import route_email
 from mailpilot.settings import Settings
 
@@ -121,7 +123,7 @@ def _check_stale_sync_status(
         click.echo(f"Removing stale sync status (pid {existing.pid} is dead)")
 
 
-def start_sync_loop(
+def start_sync_loop(  # noqa: PLR0915
     connection: psycopg.Connection[dict[str, Any]],
     settings: Settings,
 ) -> None:
@@ -153,6 +155,7 @@ def start_sync_loop(
     _check_stale_sync_status(connection, pid)
     upsert_sync_status(connection, pid)
     logfire.info("sync.loop.start", pid=pid)
+    operator_event("loop.start", pid=pid, interval=settings.run_interval)
     click.echo(f"Sync loop started (pid {pid})")
     click.echo(f"Interval: {settings.run_interval}s")
     click.echo("Press Ctrl+C or send SIGTERM to stop")
@@ -228,6 +231,7 @@ def start_sync_loop(
         shutdown_event.set()  # signal listener thread
         listener_thread.join(timeout=5)
         delete_sync_status(connection)
+        operator_event("loop.stop", pid=pid)
         logfire.info("sync.loop.stop", pid=pid)
         click.echo("Sync loop stopped")
 
@@ -256,8 +260,9 @@ def _start_pubsub_logging_errors(
         future = start_subscriber(settings, callback)
         click.echo("Pub/Sub subscriber started")
         return future
-    except Exception:
+    except Exception as exc:
         logfire.exception("sync.pubsub.setup_failed")
+        operator_event("error", source="sync.pubsub.setup_failed", message=str(exc))
         click.echo("Warning: Pub/Sub setup failed, running in polling-only mode")
         return None
 
@@ -282,14 +287,23 @@ def _start_task_listener(
                 for _notify in listen_conn.notifies(timeout=30.0):
                     wakeup_event.set()
                     break
-        except Exception:
+        except Exception as exc:
             logfire.exception("sync.task_listener.error")
+            operator_event("error", source="sync.task_listener.error", message=str(exc))
         finally:
             listen_conn.close()
 
     thread = threading.Thread(target=_listen, daemon=True)
     thread.start()
     return thread
+
+
+_iteration_counter = itertools.count(1)
+
+
+def _next_iteration_count() -> int:
+    """Return a monotonically increasing iteration number for operator output."""
+    return next(_iteration_counter)
 
 
 def _run_periodic_iteration(
@@ -306,6 +320,13 @@ def _run_periodic_iteration(
     The caller (``start_sync_loop``) sets it to True at most once per
     ``run_interval`` so event-burst wakes do only the queue drain.
     """
+    iteration = _next_iteration_count()
+    operator_event(
+        "loop.tick",
+        iteration=iteration,
+        wakeup=wakeup_source,
+        full_sweep=do_full_sweep,
+    )
     with logfire.span(
         "sync.loop.iteration",
         wakeup_source=wakeup_source,
@@ -341,15 +362,19 @@ def _drain_sync_queue(
         if account is None:
             logfire.debug("sync.notification.unknown_email", email=email)
             continue
+        operator_event("pubsub.notify", email=account.email)
         try:
             client = GmailClient(account.email)
             sync_account(connection, account, client, settings)
             synced.add(email)
-        except Exception:
+        except Exception as exc:
             logfire.exception(
                 "sync.notification.sync_failed",
                 account_id=account.id,
                 email=account.email,
+            )
+            operator_event(
+                "error", source="sync.notification.sync_failed", message=str(exc)
             )
 
 
@@ -366,12 +391,13 @@ def _sync_all_accounts(
         try:
             client = GmailClient(account.email)
             sync_account(connection, account, client, settings)
-        except Exception:
+        except Exception as exc:
             logfire.exception(
                 "sync.account.sync_failed",
                 account_id=account.id,
                 email=account.email,
             )
+            operator_event("error", source="sync.account.sync_failed", message=str(exc))
 
 
 def _drain_pending_tasks(
@@ -381,9 +407,13 @@ def _drain_pending_tasks(
     """Execute all pending tasks that are due."""
     from mailpilot.run import execute_task
 
+    start = time.monotonic()
     pending = list_pending_tasks(connection)
     for task in pending:
         execute_task(connection, settings, task)
+    if pending:
+        duration_ms = int((time.monotonic() - start) * 1000)
+        operator_event("task.drain", drained=len(pending), duration_ms=duration_ms)
 
 
 def _renew_watches_logging_errors(
@@ -399,8 +429,9 @@ def _renew_watches_logging_errors(
         renewed = renew_watches(connection, settings)
         if renewed > 0:
             logfire.info("sync.watches.renewed", count=renewed)
-    except Exception:
+    except Exception as exc:
         logfire.exception("sync.watches.renewal_failed")
+        operator_event("error", source="sync.watches.renewal_failed", message=str(exc))
 
 
 def _renew_watches_if_due(
@@ -525,12 +556,20 @@ def sync_account(
                 duration_ms,
                 attributes={"account_id": account.id, "mode": mode},
             )
+            operator_event(
+                "sync.account",
+                email=account.email,
+                new=stored,
+                duplicates=duplicate_skipped_count,
+                duration_ms=int(duration_ms),
+            )
             return stored
-        except Exception:
+        except Exception as exc:
             sync_errors.add(
                 1, attributes={"account_id": account.id, "reason": "sync_exception"}
             )
             logfire.exception("sync.account.run failed", account_id=account.id)
+            operator_event("error", source="sync.account.run", message=str(exc))
             raise
 
 

--- a/tests/test_agent_invoke.py
+++ b/tests/test_agent_invoke.py
@@ -524,6 +524,74 @@ def test_invoke_span_has_usage_attributes(
     assert attrs["llm_requests"] >= 1
 
 
+def test_invoke_span_has_status_completed_on_success(
+    database_connection: psycopg.Connection[dict[str, Any]],
+    capfire: CaptureLogfire,
+) -> None:
+    """Successful agent.invoke span carries status=completed.
+
+    Operator-log parity: the ``event=agent.run`` line emits ``status=completed``
+    and the result dict has ``status=completed``. The span MUST mirror the
+    same value so Logfire queries don't need to join through ``task.status``.
+    """
+    _account, contact, workflow = _setup(database_connection)
+    settings = make_test_settings(
+        anthropic_api_key="sk-test", anthropic_model="test-model"
+    )
+    with patch("mailpilot.agent.invoke.GmailClient"):
+        invoke_workflow_agent(
+            database_connection,
+            settings,
+            workflow,
+            contact,
+            model_override=FunctionModel(_model_that_calls_noop),
+        )
+
+    invoke_spans = [
+        s
+        for s in capfire.exporter.exported_spans_as_dict()
+        if s["name"] == "agent.invoke"
+    ]
+    assert len(invoke_spans) == 1
+    assert invoke_spans[0]["attributes"]["status"] == "completed"
+
+
+def test_invoke_span_has_status_failed_on_exception(
+    database_connection: psycopg.Connection[dict[str, Any]],
+    capfire: CaptureLogfire,
+) -> None:
+    """Failed agent.invoke span carries status=failed.
+
+    When the agent raises (e.g. AgentDidNotUseToolsError) the span MUST be
+    annotated with status=failed before the exception propagates so the
+    operator log's ``event=error`` (emitted by callers) lines up with the
+    span attribute in Logfire.
+    """
+    _account, contact, workflow = _setup(database_connection)
+    settings = make_test_settings(
+        anthropic_api_key="sk-test", anthropic_model="test-model"
+    )
+    with (
+        patch("mailpilot.agent.invoke.GmailClient"),
+        pytest.raises(AgentDidNotUseToolsError),
+    ):
+        invoke_workflow_agent(
+            database_connection,
+            settings,
+            workflow,
+            contact,
+            model_override=FunctionModel(_model_no_tools),
+        )
+
+    invoke_spans = [
+        s
+        for s in capfire.exporter.exported_spans_as_dict()
+        if s["name"] == "agent.invoke"
+    ]
+    assert len(invoke_spans) == 1
+    assert invoke_spans[0]["attributes"]["status"] == "failed"
+
+
 # -- Tests: reply_email tool ---------------------------------------------------
 
 

--- a/tests/test_agent_invoke_operator_log.py
+++ b/tests/test_agent_invoke_operator_log.py
@@ -1,0 +1,86 @@
+"""Operator-log emissions from agent invocation."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import psycopg
+import pytest
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+)
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from conftest import (
+    make_test_account,
+    make_test_contact,
+    make_test_settings,
+    make_test_workflow,
+)
+from mailpilot.agent.invoke import invoke_workflow_agent
+from mailpilot.database import (
+    activate_workflow,
+    create_enrollment,
+    update_workflow,
+)
+
+
+def _activate(connection: psycopg.Connection[dict[str, Any]], workflow_id: str) -> None:
+    update_workflow(
+        connection,
+        workflow_id,
+        objective="Test objective",
+        instructions="Send a follow-up to the contact.",
+    )
+    activate_workflow(connection, workflow_id)
+
+
+def _model_that_calls_noop(
+    messages: list[ModelMessage], info: AgentInfo
+) -> ModelResponse:
+    del info
+    for msg in messages:
+        for part in msg.parts if hasattr(msg, "parts") else []:
+            if isinstance(part, ToolCallPart):
+                return ModelResponse(parts=[TextPart(content="Done.")])
+    return ModelResponse(
+        parts=[ToolCallPart(tool_name="noop", args={"reason": "no action"})]
+    )
+
+
+def test_invoke_workflow_agent_emits_agent_run(
+    capsys: pytest.CaptureFixture[str],
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    account = make_test_account(database_connection, email="agent@example.com")
+    contact = make_test_contact(
+        database_connection, email="lead@acme.com", domain="acme.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+    create_enrollment(database_connection, workflow.id, contact.id)
+
+    settings = make_test_settings(
+        anthropic_api_key="sk-test", anthropic_model="test-model"
+    )
+
+    capsys.readouterr()
+    with patch("mailpilot.agent.invoke.GmailClient"):
+        invoke_workflow_agent(
+            database_connection,
+            settings,
+            workflow,
+            contact,
+            model_override=FunctionModel(_model_that_calls_noop),
+        )
+
+    out = capsys.readouterr().out
+    assert "event=agent.run" in out
+    assert f"workflow_id={workflow.id}" in out
+    assert f"contact_id={contact.id}" in out
+    assert "status=completed" in out
+    assert "tool_calls=1" in out

--- a/tests/test_gmail_utils.py
+++ b/tests/test_gmail_utils.py
@@ -106,6 +106,46 @@ def test_extract_empty_payload():
     assert extract_text_from_message({"payload": {}}) == ""
 
 
+def test_extract_strips_control_characters():
+    """C0 control bytes (NUL, BEL, ESC, ...) break strict JSON parsers."""
+    raw = "Hello\x00world\x07\x1bend"
+    message = {
+        "payload": {
+            "mimeType": "text/plain",
+            "body": {"data": _b64(raw)},
+        }
+    }
+    assert extract_text_from_message(message) == "Helloworldend"
+
+
+def test_extract_preserves_tabs_and_newlines():
+    raw = "Line 1\tcol\nLine 2"
+    message = {
+        "payload": {
+            "mimeType": "text/plain",
+            "body": {"data": _b64(raw)},
+        }
+    }
+    assert extract_text_from_message(message) == "Line 1\tcol\nLine 2"
+
+
+def test_extract_round_trips_through_json_strict_mode():
+    """Body must be safe to embed in a JSON document with strict parsing."""
+    import json
+
+    raw = "Header\x00\x01\x02body\x1ftrailer\nDone"
+    message = {
+        "payload": {
+            "mimeType": "text/plain",
+            "body": {"data": _b64(raw)},
+        }
+    }
+    body = extract_text_from_message(message)
+    payload = json.dumps({"body_text": body})
+    parsed = json.loads(payload)  # strict by default
+    assert parsed["body_text"] == body
+
+
 def test_get_message_headers():
     message = {
         "payload": {

--- a/tests/test_operator_log.py
+++ b/tests/test_operator_log.py
@@ -1,0 +1,79 @@
+"""Tests for the operator_log module."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+
+from mailpilot.operator_log import operator_event
+
+
+def test_emits_single_line_with_event_and_fields(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    operator_event("loop.tick", iteration=3, wakeup="event", full_sweep=True)
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    line = captured.out.rstrip("\n")
+    assert "\n" not in line
+    assert re.match(r"^\d{2}:\d{2}:\d{2} event=loop\.tick ", line)
+    assert "iteration=3" in line
+    assert "wakeup=event" in line
+    assert "full_sweep=True" in line
+
+
+def test_quotes_values_with_spaces(capsys: pytest.CaptureFixture[str]) -> None:
+    operator_event("error", source="sync_account", message="Gmail timeout 504")
+    line = capsys.readouterr().out.rstrip("\n")
+    assert 'message="Gmail timeout 504"' in line
+
+
+def test_no_fields_emits_just_event(capsys: pytest.CaptureFixture[str]) -> None:
+    operator_event("loop.stop")
+    line = capsys.readouterr().out.rstrip("\n")
+    assert re.match(r"^\d{2}:\d{2}:\d{2} event=loop\.stop$", line)
+
+
+def test_flushes_stdout(monkeypatch: pytest.MonkeyPatch) -> None:
+    flushed = {"called": False}
+
+    class FakeStream:
+        def write(self, text: str) -> int:
+            return len(text)
+
+        def flush(self) -> None:
+            flushed["called"] = True
+
+    monkeypatch.setattr("sys.stdout", FakeStream())
+    operator_event("loop.tick", iteration=1)
+    assert flushed["called"] is True
+
+
+def test_escapes_double_quotes_in_quoted_values(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    operator_event("error", source="x", message='He said "hi"')
+    line = capsys.readouterr().out.rstrip("\n")
+    assert 'message="He said \\"hi\\""' in line
+
+
+def test_collapses_newlines_to_spaces(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    operator_event("error", source="x", message="line one\nline two\rline three")
+    out = capsys.readouterr().out
+    assert out.count("\n") == 1
+    assert '"line one line two line three"' in out
+
+
+def test_accepts_non_string_field_values(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload: dict[str, Any] = {"count": 42, "ratio": 0.5, "flag": False}
+    operator_event("metric", **payload)
+    line = capsys.readouterr().out.rstrip("\n")
+    assert "count=42" in line
+    assert "ratio=0.5" in line
+    assert "flag=False" in line

--- a/tests/test_routing_operator_log.py
+++ b/tests/test_routing_operator_log.py
@@ -1,0 +1,204 @@
+"""Operator-log emissions from the routing pipeline."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg
+import pytest
+from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from conftest import (
+    make_test_account,
+    make_test_settings,
+    make_test_workflow,
+)
+from mailpilot.agent import classify as classify_module
+from mailpilot.database import (
+    activate_workflow,
+    create_email,
+    update_workflow,
+)
+from mailpilot.routing import route_email
+
+
+def _activate_workflow(
+    connection: psycopg.Connection[dict[str, Any]],
+    workflow_id: str,
+) -> None:
+    update_workflow(
+        connection,
+        workflow_id,
+        objective="Handle inbound inquiries",
+        instructions="Reply helpfully",
+    )
+    activate_workflow(connection, workflow_id)
+
+
+def _function_model_returning(workflow_id: str | None) -> FunctionModel:
+    def _respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        del messages, info
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="final_result",
+                    args={"workflow_id": workflow_id, "reasoning": ""},
+                ),
+            ],
+        )
+
+    return FunctionModel(_respond)
+
+
+def test_route_email_emits_match_via_thread(
+    capsys: pytest.CaptureFixture[str],
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    account = make_test_account(database_connection, email="rt@example.com")
+    workflow = make_test_workflow(
+        database_connection, account_id=account.id, workflow_type="inbound"
+    )
+    _activate_workflow(database_connection, workflow.id)
+
+    prior = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="prior",
+        gmail_thread_id="thread-z",
+        workflow_id=workflow.id,
+        is_routed=True,
+    )
+    assert prior is not None
+
+    new_email = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="reply",
+        gmail_thread_id="thread-z",
+    )
+    assert new_email is not None
+
+    capsys.readouterr()
+    route_email(
+        database_connection, new_email, "alice@example.com", make_test_settings()
+    )
+
+    out = capsys.readouterr().out
+    assert "event=route.match" in out
+    assert f"email_id={new_email.id}" in out
+    assert f"workflow_id={workflow.id}" in out
+    assert "via=thread" in out
+
+
+def test_route_email_emits_match_via_message_id(
+    capsys: pytest.CaptureFixture[str],
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """Reply that re-threads on the recipient side is routed via In-Reply-To."""
+    account = make_test_account(database_connection, email="rfcop@example.com")
+    workflow = make_test_workflow(
+        database_connection, account_id=account.id, workflow_type="inbound"
+    )
+    _activate_workflow(database_connection, workflow.id)
+
+    prior = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="initial",
+        gmail_thread_id="thread-outbound",
+        rfc2822_message_id="<orig@mailpilot.test>",
+        workflow_id=workflow.id,
+        is_routed=True,
+    )
+    assert prior is not None
+
+    reply = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Re: initial",
+        gmail_thread_id="thread-reply-different",
+        in_reply_to="<orig@mailpilot.test>",
+    )
+    assert reply is not None
+
+    capsys.readouterr()
+    route_email(database_connection, reply, "alice@example.com", make_test_settings())
+
+    out = capsys.readouterr().out
+    assert "event=route.match" in out
+    assert "via=message_id" in out
+    assert f"workflow_id={workflow.id}" in out
+
+
+def test_route_email_emits_no_match_when_classification_returns_none(
+    capsys: pytest.CaptureFixture[str],
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    account = make_test_account(database_connection, email="rt2@example.com")
+    workflow = make_test_workflow(
+        database_connection, account_id=account.id, workflow_type="inbound"
+    )
+    _activate_workflow(database_connection, workflow.id)
+
+    new_email = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="random",
+        body_text="not relevant",
+        gmail_thread_id="thread-new",
+    )
+    assert new_email is not None
+
+    settings = make_test_settings(
+        anthropic_api_key="sk-test", anthropic_model="claude-sonnet-4-6"
+    )
+    capsys.readouterr()
+    with classify_module._AGENT.override(  # pyright: ignore[reportPrivateUsage]
+        model=_function_model_returning(None)
+    ):
+        route_email(database_connection, new_email, "bob@example.com", settings)
+
+    out = capsys.readouterr().out
+    assert "event=route.no_match" in out
+    assert f"email_id={new_email.id}" in out
+
+
+def test_route_email_emits_match_via_llm_when_classifier_returns_workflow(
+    capsys: pytest.CaptureFixture[str],
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    account = make_test_account(database_connection, email="rt3@example.com")
+    workflow = make_test_workflow(
+        database_connection, account_id=account.id, workflow_type="inbound"
+    )
+    _activate_workflow(database_connection, workflow.id)
+
+    new_email = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="cold",
+        body_text="please help",
+        gmail_thread_id="thread-cold",
+    )
+    assert new_email is not None
+
+    settings = make_test_settings(
+        anthropic_api_key="sk-test", anthropic_model="claude-sonnet-4-6"
+    )
+    capsys.readouterr()
+    with classify_module._AGENT.override(  # pyright: ignore[reportPrivateUsage]
+        model=_function_model_returning(workflow.id)
+    ):
+        route_email(database_connection, new_email, "carol@example.com", settings)
+
+    out = capsys.readouterr().out
+    assert "event=route.match" in out
+    assert "via=llm" in out
+    assert f"workflow_id={workflow.id}" in out

--- a/tests/test_sync_loop_operator_log.py
+++ b/tests/test_sync_loop_operator_log.py
@@ -1,0 +1,249 @@
+"""Operator-log emissions from the sync-loop pipeline."""
+
+from __future__ import annotations
+
+import itertools
+import os
+import queue
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import psycopg
+import pytest
+
+import mailpilot.sync as sync_module
+from conftest import make_test_settings
+
+
+def _reset_iteration_counter() -> None:
+    """Reset the module-level counter so iteration=N assertions are deterministic."""
+    sync_module._iteration_counter = itertools.count(1)  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.fixture(autouse=True)
+def _reset_counter() -> None:  # pyright: ignore[reportUnusedFunction]
+    _reset_iteration_counter()
+
+
+def test_run_periodic_iteration_emits_loop_tick(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    from mailpilot.sync import (
+        _run_periodic_iteration,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    monkeypatch.setattr("mailpilot.sync._drain_sync_queue", lambda *_a, **_k: None)
+    monkeypatch.setattr("mailpilot.sync._sync_all_accounts", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        "mailpilot.sync.create_tasks_for_routed_emails", lambda *_a, **_k: 0
+    )
+    monkeypatch.setattr("mailpilot.sync._drain_pending_tasks", lambda *_a, **_k: None)
+
+    _run_periodic_iteration(
+        database_connection,
+        make_test_settings(),
+        queue.Queue(),
+        "event",
+        do_full_sweep=True,
+    )
+
+    out = capsys.readouterr().out
+    assert "event=loop.tick" in out
+    assert "iteration=1" in out
+    assert "wakeup=event" in out
+    assert "full_sweep=True" in out
+
+
+def test_run_periodic_iteration_increments_iteration_counter(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    from mailpilot.sync import (
+        _run_periodic_iteration,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    monkeypatch.setattr("mailpilot.sync._drain_sync_queue", lambda *_a, **_k: None)
+    monkeypatch.setattr("mailpilot.sync._sync_all_accounts", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        "mailpilot.sync.create_tasks_for_routed_emails", lambda *_a, **_k: 0
+    )
+    monkeypatch.setattr("mailpilot.sync._drain_pending_tasks", lambda *_a, **_k: None)
+
+    _run_periodic_iteration(
+        database_connection,
+        make_test_settings(),
+        queue.Queue(),
+        "timer",
+        do_full_sweep=False,
+    )
+    _run_periodic_iteration(
+        database_connection,
+        make_test_settings(),
+        queue.Queue(),
+        "timer",
+        do_full_sweep=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "iteration=1" in out
+    assert "iteration=2" in out
+
+
+def test_drain_sync_queue_emits_pubsub_notify(
+    capsys: pytest.CaptureFixture[str],
+    database_connection: psycopg.Connection[dict[str, Any]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_drain_sync_queue emits one event=pubsub.notify per known account."""
+    from conftest import make_test_account
+    from mailpilot.sync import (
+        _drain_sync_queue,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    account = make_test_account(database_connection, email="notify@example.com")
+
+    monkeypatch.setattr("mailpilot.sync.GmailClient", lambda *_a, **_k: MagicMock())
+    monkeypatch.setattr("mailpilot.sync.sync_account", lambda *_a, **_k: 0)
+
+    sync_queue: queue.Queue[str] = queue.Queue()
+    sync_queue.put(account.email)
+
+    _drain_sync_queue(database_connection, make_test_settings(), sync_queue)
+
+    out = capsys.readouterr().out
+    assert "event=pubsub.notify" in out
+    assert f"email={account.email}" in out
+
+
+def test_sync_account_emits_sync_account_event(
+    capsys: pytest.CaptureFixture[str],
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """sync_account emits one event=sync.account line on completion."""
+    from conftest import make_test_account
+    from mailpilot.sync import sync_account
+    from test_sync import (
+        _make_gmail_message,  # pyright: ignore[reportPrivateUsage]
+        _make_mock_client,  # pyright: ignore[reportPrivateUsage]
+        _set_get_messages,  # pyright: ignore[reportPrivateUsage]
+        _set_list_messages,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    account = make_test_account(database_connection, email="op@example.com")
+    client, service = _make_mock_client(account.email)
+    _set_list_messages(service, [{"id": "msg-1", "threadId": "thr-1"}])
+    _set_get_messages(service, [_make_gmail_message("msg-1", "thr-1")])
+
+    stored = sync_account(database_connection, account, client, make_test_settings())
+
+    assert stored == 1
+    out = capsys.readouterr().out
+    assert "event=sync.account" in out
+    assert "email=op@example.com" in out
+    assert "new=1" in out
+    assert "duplicates=0" in out
+    assert "duration_ms=" in out
+
+
+def test_drain_pending_tasks_emits_task_drain_when_tasks_executed(
+    capsys: pytest.CaptureFixture[str],
+    database_connection: psycopg.Connection[dict[str, Any]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mailpilot.sync import (
+        _drain_pending_tasks,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    fake_tasks = [MagicMock(), MagicMock(), MagicMock()]
+    monkeypatch.setattr(
+        "mailpilot.sync.list_pending_tasks", lambda *_a, **_k: fake_tasks
+    )
+    import mailpilot.run as run_module
+
+    monkeypatch.setattr(run_module, "execute_task", lambda *_a, **_k: None)
+
+    _drain_pending_tasks(database_connection, make_test_settings())
+
+    out = capsys.readouterr().out
+    assert "event=task.drain" in out
+    assert "drained=3" in out
+    assert "duration_ms=" in out
+
+
+def test_drain_sync_queue_emits_error_on_sync_failure(
+    capsys: pytest.CaptureFixture[str],
+    database_connection: psycopg.Connection[dict[str, Any]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """logfire.exception sites mirror to operator event=error lines."""
+    from conftest import make_test_account
+    from mailpilot.sync import (
+        _drain_sync_queue,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    account = make_test_account(database_connection, email="boom@example.com")
+    monkeypatch.setattr("mailpilot.sync.GmailClient", lambda *_a, **_k: MagicMock())
+
+    def _explode(*_a: Any, **_k: Any) -> int:
+        raise RuntimeError("Gmail timeout 504")
+
+    monkeypatch.setattr("mailpilot.sync.sync_account", _explode)
+
+    sync_queue: queue.Queue[str] = queue.Queue()
+    sync_queue.put(account.email)
+
+    _drain_sync_queue(database_connection, make_test_settings(), sync_queue)
+
+    out = capsys.readouterr().out
+    assert "event=error" in out
+    assert "source=sync.notification.sync_failed" in out
+    assert 'message="Gmail timeout 504"' in out
+
+
+def test_drain_pending_tasks_skips_event_when_no_tasks(
+    capsys: pytest.CaptureFixture[str],
+    database_connection: psycopg.Connection[dict[str, Any]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mailpilot.sync import (
+        _drain_pending_tasks,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    monkeypatch.setattr("mailpilot.sync.list_pending_tasks", lambda *_a, **_k: [])
+
+    _drain_pending_tasks(database_connection, make_test_settings())
+
+    out = capsys.readouterr().out
+    assert "event=task.drain" not in out
+
+
+def test_start_sync_loop_emits_loop_start_and_loop_stop(
+    capsys: pytest.CaptureFixture[str],
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    from mailpilot.sync import start_sync_loop
+
+    settings = make_test_settings()
+    with (
+        patch("mailpilot.sync.threading.Event") as mock_event_cls,
+        patch("mailpilot.sync._start_task_listener"),
+        patch("mailpilot.sync._start_pubsub_logging_errors", return_value=None),
+        patch("mailpilot.sync._run_periodic_iteration"),
+        patch("mailpilot.sync.signal.signal"),
+    ):
+        mock_shutdown = MagicMock()
+        mock_shutdown.is_set.side_effect = [False, True]
+        mock_wakeup = MagicMock()
+        mock_wakeup.wait.return_value = False
+        mock_event_cls.side_effect = [mock_shutdown, mock_wakeup]
+
+        start_sync_loop(database_connection, settings)
+
+    out = capsys.readouterr().out
+    assert "event=loop.start" in out
+    assert f"pid={os.getpid()}" in out
+    assert f"interval={settings.run_interval}" in out
+    assert "event=loop.stop" in out


### PR DESCRIPTION
## Summary

Adds a curated, always-on operator log layer for `mailpilot run` -- a small set of high-signal lifecycle lines (`loop.start`, `loop.tick`, `sync.account`, `route.match`, `agent.run`, `task.drain`, `error`, ...) written directly to stdout independent of Logfire's console exporter.

This sidesteps the silence-under-`--debug` issue (Logfire's console exporter dropping nested spans) by introducing a separate, journald-friendly layer:

- `--debug` continues to route through Logfire's console exporter for deep span output.
- The operator log is always on; format is `HH:MM:SS event=NAME k1=v1 k2=v2` (single-line ASCII).

Decision: **option (b) curated lifecycle view**, not (a) mirror Logfire -- chosen because journald rate-limits silently and a full span mirror would risk dropped lines on busy mailboxes.

## Changes

Operator-log layer:

- `src/mailpilot/operator_log.py` -- `operator_event(name, **fields)` writes a single-line stdout record, collapses newlines in field values to spaces.
- Wired lifecycle events: `loop.start`, `loop.tick`, `loop.stop`, `pubsub.notify`, `sync.account` (with duration), `route.match`, `route.no_match`, `agent.run`, `task.drain`, `error`.
- Mirrored every `logfire.exception` / `logfire.warn` site reachable from `mailpilot run` to `event=error` so the operator stream stays complete.
- `agent.invoke` span now carries a `status` attribute (`ok` / `error`).
- Documented in `docs/adr-07-observability-with-logfire.md` and CLAUDE.md Observability section.
- Smoke-test Gate A2 wording updated to reference the operator log.

Gmail body sanitisation (additional work that landed on this branch):

- `strip_control_chars()` in `gmail.py` removes C0 control bytes that break strict JSON parsing of `body_text`. Applied in `_normalize_text()` (inbound) and `send_email()` (outbound plain body).
- Implementation uses a `str.translate` table (no regex / `re` import); comment accurately describes that `\r` is dropped by the table itself, since CRLF bodies still normalise correctly because the `\n` survives.

Out of scope: fixing Logfire's console-exporter silence itself (sidestepped, not solved). No `--verbose` flag introduced.

Resolves #96