### PR TITLE
feat(crm): wire activity auto-creation into sync and send pipelines

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -108,7 +108,7 @@ Save `OUTBOUND_WORKFLOW_ID`.
 
 ### A2. Start the sync loop
 
-Start `mailpilot run` in the background using `Bash` with `run_in_background: true`. Capture the bash_id so you can read its output later. This loop runs **once for the whole test** -- it stays up through Scenario B and is only stopped at the very end (Step B7).
+Start `mailpilot run` in the background using `Bash` with `run_in_background: true`. Capture the bash_id so you can read its output later. This loop runs **once for the whole test** -- it stays up through Scenario B and is only stopped at the very end (Step B8).
 
 The loop emits curated `event=...` lifecycle lines on stdout regardless of `--debug` (`loop.tick`, `sync.account`, `route.match`, `agent.run`, `task.drain`, `error`). Use `--debug` only when you also need Logfire's full span output for deep diagnosis.
 
@@ -217,6 +217,24 @@ Wait for a task with `email_id` set to the routed reply and `status == "complete
 - **No additional outbound emails were sent.** Re-run `mailpilot email list --account-id <OUTBOUND_ACCOUNT_ID> --direction outbound --since <TEST_START_A>` and confirm only the original outbound from A3 is present. If the count > 1, the agent kept replying despite the decline signal -- record this as a defect for the report.
 
 **On failure:** If the task was never created, check that A6's email has `workflow_id` set and the run loop is alive. If the task is `failed`, `mailpilot task view <TASK_ID>` for the reason.
+
+### A8. Verify the CRM activity timeline
+
+The runtime paths emit `activity` rows automatically (no manual `activity create`). Read the inbound contact's timeline:
+
+```
+mailpilot activity list --contact-id <INBOUND_CONTACT_ID> --since <TEST_START_A>
+```
+
+**Gate A8 (activity wiring):**
+
+- `workflow_assigned` activity present with `detail.workflow_id == OUTBOUND_WORKFLOW_ID` (emitted by `enrollment add`).
+- `email_sent` activity present with `summary == SUBJECT_A` (emitted by `email_ops.send_email` when the outbound agent sent in A3).
+- `email_received` activity present with the operator-reply subject (emitted by sync's `_store_inbound_message` when the reply landed in the outbound mailbox in A6).
+- Exactly one of `workflow_completed` or `workflow_failed` present (emitted by `agent.tools.update_enrollment_status` in A7); summary equals the agent's `reason`.
+- No `tag_added` / `note_added` rows from this scenario (we did not run those CLI commands).
+
+If any expected type is missing, the runtime wiring (issue #46) regressed for that path.
 
 ### Logfire review for Scenario A
 
@@ -350,7 +368,24 @@ Match by `SUBJECT_B` (likely with a `Re:` prefix on Gmail's side).
 - **No additional inbound replies.** Re-run `mailpilot email list --account-id <INBOUND_ACCOUNT_ID> --direction outbound --since <TEST_START_B>` and confirm only the single reply from B5 exists. More than one means the inbound agent kept replying despite the terminal `update_enrollment_status` call -- record as a defect.
 - **Outbound workflow stayed quiet (concurrent-workflow check).** Re-run `mailpilot email list --account-id <OUTBOUND_ACCOUNT_ID> --direction outbound --since <TEST_START_B>` and confirm zero new outbound sends. Any non-zero count means the still-active outbound workflow reacted to B's traffic -- record as a defect.
 
-### B7. Stop the sync loop
+### B7. Verify the CRM activity timeline
+
+Read the outbound contact's timeline (this is the contact whose enrollment was driven by the inbound workflow in B):
+
+```
+mailpilot activity list --contact-id <OUTBOUND_CONTACT_ID> --since <TEST_START_B>
+```
+
+**Gate B7 (activity wiring):**
+
+- `workflow_assigned` activity present with `detail.workflow_id == INBOUND_WORKFLOW_ID` (emitted by `enrollment add` in B1).
+- `email_received` activity present with `summary == SUBJECT_B` (emitted by sync's `_store_inbound_message` when the trigger arrived in B4 on the inbound mailbox).
+- `email_sent` activity present from the agent reply in B5 (subject begins with `Re:`).
+- `workflow_completed` activity present (emitted by `agent.tools.update_enrollment_status` after B5).
+
+Also re-read the inbound contact's timeline from Scenario A and confirm no new `email_*` rows appeared during Scenario B (the outbound workflow stayed quiet). Any new entries here mirror the existing "outbound workflow stayed quiet" check in Gate B6 from the activity-table side.
+
+### B8. Stop the sync loop
 
 Send SIGTERM to the background `mailpilot run` (e.g. `kill <pid>`). Wait for `Sync loop stopped` in the captured output. Confirm the `sync_status` table is empty.
 
@@ -388,6 +423,7 @@ Scenario A: Outbound workflow (sole workflow active)
   A5 Operator reply .......... PASS
   A6 thread_match routing .... PASS
   A7 Agent processes reply ... PASS
+  A8 Activity timeline ....... PASS
 
 Scenario B: Inbound workflow (outbound workflow still active)
   B1 Create workflow ......... PASS  (workflow list shows 2 active)
@@ -396,7 +432,8 @@ Scenario B: Inbound workflow (outbound workflow still active)
   B4 classified routing ...... PASS
   B5 Agent reply ............. PASS
   B6 Gmail delivery (out) .... PASS
-  B7 Stop sync loop .......... PASS
+  B7 Activity timeline ....... PASS
+  B8 Stop sync loop .......... PASS
 
 Entity IDs (shared by both scenarios):
   Outbound account: <id>   Inbound account: <id>   Company: <id>
@@ -488,5 +525,6 @@ Expected total: ~6 minutes. Phase 0 runs once, the run loop runs once, and there
 | A6 reply round-trip    | ~10-60s  |
 | A7 / B5 task drain     | ~10-60s  |
 | B6 reply round-trip    | ~10-60s  |
-| B7 stop run loop       | ~3s      |
+| A8 / B7 activity check | ~3s      |
+| B8 stop run loop       | ~3s      |
 | Report                 | ~10s     |

--- a/src/mailpilot/agent/classify.py
+++ b/src/mailpilot/agent/classify.py
@@ -46,6 +46,7 @@ Candidate workflows will be provided in the user message.
 """
 
 _AGENT: Agent[None, ClassificationResult] = Agent(
+    name="mailpilot.classifier",
     output_type=ClassificationResult,
     instructions=_INSTRUCTIONS,
 )

--- a/src/mailpilot/agent/invoke.py
+++ b/src/mailpilot/agent/invoke.py
@@ -298,6 +298,8 @@ _TOOLS: list[Tool[AgentDeps]] = [
 _SYSTEM_PREFIX = (
     "Keep your final summary brief (2-3 sentences, plain text, no emojis).\n"
     "Email bodies may use Markdown formatting (headers, bold, tables).\n"
+    "When a trigger email is included in your prompt, its full body is "
+    "already provided -- do not call read_email to fetch it again.\n"
     "After completing the workflow objective for a contact, call "
     "update_enrollment_status with status='completed' and a brief reason.\n\n"
 )
@@ -306,6 +308,7 @@ _SYSTEM_PREFIX = (
 def _build_agent(workflow: Workflow) -> Agent[AgentDeps, str]:
     """Build a Pydantic AI agent for a workflow."""
     return Agent(
+        name="mailpilot.workflow",
         deps_type=AgentDeps,
         instructions=_SYSTEM_PREFIX + workflow.instructions,
         tools=_TOOLS,

--- a/src/mailpilot/agent/tools.py
+++ b/src/mailpilot/agent/tools.py
@@ -181,7 +181,9 @@ def update_enrollment_status(
 ) -> dict[str, str]:
     """Report outcome for an enrollment in the current workflow.
 
-    The agent -- not the system -- decides success or failure.
+    The agent -- not the system -- decides success or failure. Emits a
+    ``workflow_completed`` or ``workflow_failed`` activity on those
+    transitions so the timeline records the outcome.
 
     Args:
         connection: Open database connection.
@@ -207,6 +209,16 @@ def update_enrollment_status(
             "error": "not_found",
             "message": f"enrollment not found: {workflow_id}/{contact_id}",
         }
+    if status in ("completed", "failed"):
+        contact = database.get_contact(connection, contact_id)
+        database.create_activity(
+            connection,
+            contact_id=contact_id,
+            activity_type=f"workflow_{status}",
+            summary=reason or f"Workflow {status}",
+            detail={"workflow_id": workflow_id, "reason": reason},
+            company_id=contact.company_id if contact is not None else None,
+        )
     return {"status": enrollment.status, "reason": enrollment.reason}
 
 

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -1688,6 +1688,7 @@ def enrollment() -> None:
 def enrollment_add(workflow_id: str, contact_id: str) -> None:
     """Enroll a contact in a workflow."""
     from mailpilot.database import (
+        create_activity,
         create_enrollment,
         get_contact,
         get_enrollment,
@@ -1697,12 +1698,25 @@ def enrollment_add(workflow_id: str, contact_id: str) -> None:
 
     connection = initialize_database(_database_url())
     try:
-        if get_workflow(connection, workflow_id) is None:
+        workflow = get_workflow(connection, workflow_id)
+        if workflow is None:
             output_error(f"workflow not found: {workflow_id}", "not_found")
-        if get_contact(connection, contact_id) is None:
+        contact = get_contact(connection, contact_id)
+        if contact is None:
             output_error(f"contact not found: {contact_id}", "not_found")
         created = create_enrollment(connection, workflow_id, contact_id)
         if created is not None:
+            create_activity(
+                connection,
+                contact_id=contact_id,
+                activity_type="workflow_assigned",
+                summary=f"Assigned to {workflow.name}",
+                detail={
+                    "workflow_id": workflow_id,
+                    "workflow_name": workflow.name,
+                },
+                company_id=contact.company_id,
+            )
             output(created.model_dump(mode="json"))
             return
         existing = get_enrollment(connection, workflow_id, contact_id)
@@ -1882,7 +1896,12 @@ def enrollment_update(
     workflow_id: str, contact_id: str, status: str, reason: str | None
 ) -> None:
     """Update enrollment status and reason."""
-    from mailpilot.database import initialize_database, update_enrollment
+    from mailpilot.database import (
+        create_activity,
+        get_contact,
+        initialize_database,
+        update_enrollment,
+    )
 
     connection = initialize_database(_database_url())
     try:
@@ -1892,6 +1911,16 @@ def enrollment_update(
         updated = update_enrollment(connection, workflow_id, contact_id, **fields)
         if updated is None:
             output_error("enrollment not found", "not_found")
+        if status in ("completed", "failed"):
+            contact = get_contact(connection, contact_id)
+            create_activity(
+                connection,
+                contact_id=contact_id,
+                activity_type=f"workflow_{status}",
+                summary=reason or f"Workflow {status}",
+                detail={"workflow_id": workflow_id, "reason": reason or ""},
+                company_id=contact.company_id if contact is not None else None,
+            )
         output(updated.model_dump(mode="json"))
     finally:
         connection.close()

--- a/src/mailpilot/email_ops.py
+++ b/src/mailpilot/email_ops.py
@@ -20,7 +20,7 @@ import psycopg
 
 from mailpilot import database
 from mailpilot.gmail import GmailClient
-from mailpilot.models import Account, Email
+from mailpilot.models import Account, Contact, Email
 from mailpilot.settings import Settings
 from mailpilot.sync import send_email as sync_send_email
 
@@ -89,6 +89,26 @@ def _activate_enrollment_if_pending(
         )
 
 
+def _emit_email_sent_activity(
+    connection: psycopg.Connection[dict[str, Any]],
+    contact: Contact,
+    email: Email,
+    workflow_id: str | None,
+) -> None:
+    database.create_activity(
+        connection,
+        contact_id=contact.id,
+        activity_type="email_sent",
+        summary=email.subject,
+        detail={
+            "email_id": email.id,
+            "subject": email.subject,
+            "workflow_id": workflow_id,
+        },
+        company_id=contact.company_id,
+    )
+
+
 def send_email(  # noqa: PLR0913
     connection: psycopg.Connection[dict[str, Any]],
     account: Account,
@@ -148,6 +168,9 @@ def send_email(  # noqa: PLR0913
         cc=cc,
         bcc=bcc,
     )
+
+    if contact is not None:
+        _emit_email_sent_activity(connection, contact, email, workflow_id)
 
     if workflow_id is not None and contact_id is not None:
         _activate_enrollment_if_pending(connection, workflow_id, contact_id)
@@ -216,6 +239,8 @@ def reply_email(  # noqa: PLR0913
         bcc=bcc,
         in_reply_to=original.rfc2822_message_id,
     )
+
+    _emit_email_sent_activity(connection, contact, email, workflow_id)
 
     if workflow_id is not None:
         _activate_enrollment_if_pending(connection, workflow_id, contact.id)

--- a/src/mailpilot/routing.py
+++ b/src/mailpilot/routing.py
@@ -24,9 +24,11 @@ import psycopg
 
 from mailpilot.agent.classify import classify_email
 from mailpilot.database import (
+    create_activity,
     create_enrollment,
     disable_contact,
     find_email_by_rfc2822_message_id,
+    get_contact,
     get_emails_by_gmail_thread_id,
     get_workflow,
     list_workflows,
@@ -316,5 +318,23 @@ def _ensure_enrollment(
     workflow_id: str,
     contact_id: str,
 ) -> None:
-    """Create an enrollment entry if not already present."""
-    create_enrollment(connection, workflow_id, contact_id)
+    """Create an enrollment entry if not already present.
+
+    Emits a ``workflow_assigned`` activity only on the initial insert --
+    ``create_enrollment`` returns ``None`` on ON CONFLICT so re-routes in
+    the same thread do not duplicate the timeline entry.
+    """
+    enrollment = create_enrollment(connection, workflow_id, contact_id)
+    if enrollment is None:
+        return
+    workflow = get_workflow(connection, workflow_id)
+    contact = get_contact(connection, contact_id)
+    workflow_name = workflow.name if workflow is not None else ""
+    create_activity(
+        connection,
+        contact_id=contact_id,
+        activity_type="workflow_assigned",
+        summary=f"Assigned to {workflow_name or 'workflow'}",
+        detail={"workflow_id": workflow_id, "workflow_name": workflow_name},
+        company_id=contact.company_id if contact is not None else None,
+    )

--- a/src/mailpilot/sync.py
+++ b/src/mailpilot/sync.py
@@ -36,6 +36,7 @@ import logfire
 import psycopg
 
 from mailpilot.database import (
+    create_activity,
     create_contacts_bulk,
     create_email,
     create_or_get_contact_by_email,
@@ -773,6 +774,14 @@ def _store_inbound_message(  # noqa: PLR0913
     )
     if email is None:
         return None
+    create_activity(
+        connection,
+        contact_id=contact.id,
+        activity_type="email_received",
+        summary=email.subject,
+        detail={"email_id": email.id, "subject": email.subject},
+        company_id=contact.company_id,
+    )
     sync_messages_stored.add(
         1,
         attributes={"within_recency_window": within_window},

--- a/tests/test_agent_invoke.py
+++ b/tests/test_agent_invoke.py
@@ -26,6 +26,7 @@ from conftest import (
 from mailpilot.agent.invoke import (
     _SYSTEM_PREFIX,  # pyright: ignore[reportPrivateUsage]
     _advisory_lock_keys,  # pyright: ignore[reportPrivateUsage]
+    _build_agent,  # pyright: ignore[reportPrivateUsage]
     _wrap_create_task,  # pyright: ignore[reportPrivateUsage]
     _wrap_disable_contact,  # pyright: ignore[reportPrivateUsage]
     _wrap_update_enrollment_status,  # pyright: ignore[reportPrivateUsage]
@@ -660,6 +661,37 @@ def test_system_prefix_guides_contact_status_update() -> None:
 def test_system_prefix_allows_markdown_in_emails() -> None:
     """System prefix must not prohibit markdown in email content."""
     assert "No markdown" not in _SYSTEM_PREFIX
+
+
+def test_system_prefix_tells_agent_trigger_email_is_pre_supplied() -> None:
+    """Trigger email body is inlined in the user prompt, so the agent must
+    not waste a round-trip calling read_email to fetch it."""
+    assert "read_email" in _SYSTEM_PREFIX
+
+
+def test_workflow_agent_has_explicit_name_for_otel_traces() -> None:
+    """Pydantic AI's `agent run` span carries `gen_ai.agent.name`, derived
+    from the Agent's `name=` argument. Setting it explicitly keeps traces
+    legible when both the workflow agent and the classifier agent fire in
+    the same time window."""
+    from datetime import UTC, datetime
+
+    from mailpilot.models import Workflow
+
+    now = datetime.now(UTC)
+    workflow = Workflow(
+        id="01900000-0000-7000-8000-000000000001",
+        name="N",
+        type="outbound",
+        account_id="01900000-0000-7000-8000-000000000002",
+        status="active",
+        objective="O",
+        instructions="I",
+        created_at=now,
+        updated_at=now,
+    )
+    agent = _build_agent(workflow)
+    assert agent.name == "mailpilot.workflow"
 
 
 # -- Tests: wrapper signatures -------------------------------------------------

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -414,6 +414,80 @@ def test_update_enrollment_status_not_found(
     assert result["error"] == "not_found"
 
 
+def test_update_enrollment_status_emits_workflow_completed_activity(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Transitioning to ``completed`` must emit a workflow_completed
+    activity with the agent's reason as summary."""
+    from mailpilot.database import list_activities
+
+    account = make_test_account(database_connection)
+    contact = make_test_contact(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    create_enrollment(database_connection, workflow.id, contact.id)
+
+    update_enrollment_status(
+        connection=database_connection,
+        workflow_id=workflow.id,
+        contact_id=contact.id,
+        status="completed",
+        reason="meeting booked",
+    )
+
+    activities = list_activities(
+        database_connection, contact_id=contact.id, activity_type="workflow_completed"
+    )
+    assert len(activities) == 1
+    assert activities[0].summary == "meeting booked"
+
+
+def test_update_enrollment_status_emits_workflow_failed_activity(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    from mailpilot.database import list_activities
+
+    account = make_test_account(database_connection)
+    contact = make_test_contact(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    create_enrollment(database_connection, workflow.id, contact.id)
+
+    update_enrollment_status(
+        connection=database_connection,
+        workflow_id=workflow.id,
+        contact_id=contact.id,
+        status="failed",
+        reason="no response",
+    )
+
+    activities = list_activities(
+        database_connection, contact_id=contact.id, activity_type="workflow_failed"
+    )
+    assert len(activities) == 1
+    assert activities[0].summary == "no response"
+
+
+def test_update_enrollment_status_active_does_not_emit_activity(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Only completed/failed transitions emit; active transitions do not."""
+    from mailpilot.database import list_activities
+
+    account = make_test_account(database_connection)
+    contact = make_test_contact(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    create_enrollment(database_connection, workflow.id, contact.id)
+
+    update_enrollment_status(
+        connection=database_connection,
+        workflow_id=workflow.id,
+        contact_id=contact.id,
+        status="active",
+        reason="started",
+    )
+
+    assert list_activities(database_connection, contact_id=contact.id) == []
+
+
 # -- disable_contact -----------------------------------------------------------
 
 

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -12,8 +12,8 @@ from pydantic_ai.models.function import AgentInfo, FunctionModel
 
 from conftest import make_test_settings
 from mailpilot.agent import classify as classify_module
-from mailpilot.agent.classify import (  # pyright: ignore[reportPrivateUsage]
-    _AGENT,
+from mailpilot.agent.classify import (
+    _AGENT,  # pyright: ignore[reportPrivateUsage]
     classify_email,
 )
 from mailpilot.models import Workflow

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -12,7 +12,10 @@ from pydantic_ai.models.function import AgentInfo, FunctionModel
 
 from conftest import make_test_settings
 from mailpilot.agent import classify as classify_module
-from mailpilot.agent.classify import classify_email
+from mailpilot.agent.classify import (  # pyright: ignore[reportPrivateUsage]
+    _AGENT,
+    classify_email,
+)
 from mailpilot.models import Workflow
 
 
@@ -208,3 +211,10 @@ def test_classify_span_has_usage_attributes(capfire: CaptureLogfire) -> None:
     assert attrs["input_tokens"] >= 0
     assert attrs["output_tokens"] >= 0
     assert attrs["total_tokens"] == attrs["input_tokens"] + attrs["output_tokens"]
+
+
+def test_classifier_agent_has_explicit_name_for_otel_traces() -> None:
+    """Classifier and workflow agents both emit `agent run` spans -- giving
+    each Agent an explicit `name=` keeps `gen_ai.agent.name` legible instead
+    of leaking the private `_AGENT` variable name into telemetry."""
+    assert _AGENT.name == "mailpilot.classifier"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4280,6 +4280,7 @@ def test_enrollment_add(runner: CliRunner, mock_connection: MagicMock) -> None:
         patch(
             "mailpilot.database.create_enrollment", return_value=enrollment
         ) as mock_create,
+        patch("mailpilot.database.create_activity") as mock_activity,
     ):
         result = runner.invoke(
             main,
@@ -4295,6 +4296,10 @@ def test_enrollment_add(runner: CliRunner, mock_connection: MagicMock) -> None:
 
     assert result.exit_code == 0
     mock_create.assert_called_once_with(mock_connection, _WORKFLOW_ID, _CONTACT_ID)
+    activity_kwargs = mock_activity.call_args.kwargs
+    assert activity_kwargs["activity_type"] == "workflow_assigned"
+    assert activity_kwargs["contact_id"] == _CONTACT_ID
+    assert activity_kwargs["detail"]["workflow_id"] == _WORKFLOW_ID
     data = json.loads(result.output)
     assert data["ok"] is True
     assert data["workflow_id"] == _WORKFLOW_ID
@@ -4314,6 +4319,7 @@ def test_enrollment_add_idempotent(
         patch("mailpilot.database.get_contact", return_value=_make_contact()),
         patch("mailpilot.database.create_enrollment", return_value=None),
         patch("mailpilot.database.get_enrollment", return_value=existing),
+        patch("mailpilot.database.create_activity") as mock_activity,
     ):
         result = runner.invoke(
             main,
@@ -4328,6 +4334,7 @@ def test_enrollment_add_idempotent(
         )
 
     assert result.exit_code == 0
+    mock_activity.assert_not_called()
     data = json.loads(result.output)
     assert data["ok"] is True
     assert data["status"] == "active"
@@ -4658,6 +4665,8 @@ def test_enrollment_update(runner: CliRunner, mock_connection: MagicMock) -> Non
         patch(
             "mailpilot.database.update_enrollment", return_value=updated
         ) as mock_update,
+        patch("mailpilot.database.get_contact", return_value=_make_contact()),
+        patch("mailpilot.database.create_activity") as mock_activity,
     ):
         result = runner.invoke(
             main,
@@ -4683,6 +4692,9 @@ def test_enrollment_update(runner: CliRunner, mock_connection: MagicMock) -> Non
         status="completed",
         reason="Demo booked",
     )
+    activity_kwargs = mock_activity.call_args.kwargs
+    assert activity_kwargs["activity_type"] == "workflow_completed"
+    assert activity_kwargs["summary"] == "Demo booked"
     data = json.loads(result.output)
     assert data["ok"] is True
     assert data["status"] == "completed"
@@ -4699,6 +4711,8 @@ def test_enrollment_update_without_reason(
         patch(
             "mailpilot.database.update_enrollment", return_value=updated
         ) as mock_update,
+        patch("mailpilot.database.get_contact", return_value=_make_contact()),
+        patch("mailpilot.database.create_activity") as mock_activity,
     ):
         result = runner.invoke(
             main,
@@ -4721,6 +4735,36 @@ def test_enrollment_update_without_reason(
         _CONTACT_ID,
         status="failed",
     )
+    assert mock_activity.call_args.kwargs["activity_type"] == "workflow_failed"
+
+
+def test_enrollment_update_active_does_not_emit_activity(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    """Transitions to active or pending must not emit a workflow activity."""
+    updated = _make_enrollment(status="active")
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.update_enrollment", return_value=updated),
+        patch("mailpilot.database.create_activity") as mock_activity,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "enrollment",
+                "update",
+                "--workflow-id",
+                _WORKFLOW_ID,
+                "--contact-id",
+                _CONTACT_ID,
+                "--status",
+                "active",
+            ],
+        )
+
+    assert result.exit_code == 0
+    mock_activity.assert_not_called()
 
 
 def test_enrollment_update_not_found(

--- a/tests/test_email_ops.py
+++ b/tests/test_email_ops.py
@@ -237,6 +237,42 @@ def test_send_email_activates_pending_enrollment(
     assert enrollment.status == "active"
 
 
+def test_send_email_pending_to_active_does_not_emit_workflow_activity(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """The pending->active transition done inside email_ops must NOT emit
+    a workflow_completed/workflow_failed/workflow_assigned activity --
+    workflow_assigned and email_sent already cover the timeline."""
+    from mailpilot.database import list_activities
+
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="recipient@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+    create_enrollment(database_connection, workflow.id, contact.id)
+    gmail_client = _make_gmail_client(account)
+
+    send_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        to="recipient@example.com",
+        subject="Hello",
+        body="Hi",
+        workflow_id=workflow.id,
+    )
+
+    workflow_activities = [
+        a
+        for a in list_activities(database_connection, contact_id=contact.id)
+        if a.type in ("workflow_assigned", "workflow_completed", "workflow_failed")
+    ]
+    assert workflow_activities == []
+
+
 def test_send_email_no_workflow_id_skips_enrollment(
     database_connection: psycopg.Connection[dict[str, Any]],
 ) -> None:
@@ -507,3 +543,117 @@ def test_reply_email_activates_pending_enrollment(
     enrollment = get_enrollment(database_connection, workflow.id, contact.id)
     assert enrollment is not None
     assert enrollment.status == "active"
+
+
+# -- Activity emission ---------------------------------------------------------
+
+
+def test_send_email_emits_email_sent_activity(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """A successful send must produce one email_sent activity tied to the
+    resolved contact, with subject summary and workflow_id in the detail."""
+    from mailpilot.database import create_company, list_activities
+
+    account = make_test_account(database_connection)
+    company = create_company(
+        database_connection, name="Recipient Co", domain="example.com"
+    )
+    contact = make_test_contact(
+        database_connection,
+        email="recipient@example.com",
+        domain="example.com",
+        company_id=company.id,
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+    gmail_client = _make_gmail_client(account)
+
+    send_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        to="recipient@example.com",
+        subject="Outbound test",
+        body="Hi",
+        workflow_id=workflow.id,
+    )
+
+    activities = list_activities(
+        database_connection, contact_id=contact.id, activity_type="email_sent"
+    )
+    assert len(activities) == 1
+    assert activities[0].summary == "Outbound test"
+    assert activities[0].company_id == company.id
+
+
+def test_send_email_skips_activity_when_contact_unknown(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """Sends to a recipient with no contact row produce no activity (no
+    contact_id to anchor the timeline)."""
+    from mailpilot.database import list_activities
+
+    account = make_test_account(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+    gmail_client = _make_gmail_client(account)
+
+    send_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        to="brand-new@example.com",
+        subject="Hi",
+        body="Body",
+        workflow_id=workflow.id,
+    )
+
+    # No contact -> no activity. There is no contact_id to query by, so
+    # assert at the company-id-less catch-all level: nothing for company
+    # either.
+    contact = make_test_contact(
+        database_connection, email="brand-new@example.com", domain="example.com"
+    )
+    assert (
+        list_activities(
+            database_connection, contact_id=contact.id, activity_type="email_sent"
+        )
+        == []
+    )
+
+
+def test_reply_email_emits_email_sent_activity(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """reply_email must emit one email_sent activity using the reply subject."""
+    from mailpilot.database import list_activities
+
+    account = make_test_account(database_connection)
+    contact = make_test_contact(
+        database_connection, email="sender@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+    inbound = _make_inbound(
+        database_connection, account.id, contact.id, workflow.id, subject="Pricing"
+    )
+    gmail_client = _make_gmail_client(account)
+
+    reply_email(
+        connection=database_connection,
+        account=account,
+        gmail_client=gmail_client,
+        settings=make_test_settings(),
+        email_id=inbound.id,
+        body="Reply body",
+        workflow_id=workflow.id,
+    )
+
+    activities = list_activities(
+        database_connection, contact_id=contact.id, activity_type="email_sent"
+    )
+    assert len(activities) == 1
+    assert activities[0].summary == "Re: Pricing"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -626,6 +626,102 @@ def test_route_email_enrollment_idempotent(
     assert routed.is_routed is True
 
 
+def test_route_email_emits_workflow_assigned_activity(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """A first-time enrollment must emit a workflow_assigned activity tied
+    to the contact, with workflow id + name in the detail."""
+    from mailpilot.database import list_activities
+
+    account = make_test_account(database_connection, email="wact@example.com")
+    contact = make_test_contact(
+        database_connection, email="sender@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(
+        database_connection,
+        account_id=account.id,
+        workflow_type="inbound",
+        name="Inbound Inquiry",
+    )
+    _activate_workflow(database_connection, workflow.id)
+
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="prior",
+        gmail_thread_id="t-wact",
+        workflow_id=workflow.id,
+        is_routed=True,
+    )
+    new_email = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="reply",
+        gmail_thread_id="t-wact",
+        contact_id=contact.id,
+    )
+    assert new_email is not None
+
+    route_email(
+        database_connection, new_email, "sender@example.com", make_test_settings()
+    )
+
+    activities = list_activities(
+        database_connection, contact_id=contact.id, activity_type="workflow_assigned"
+    )
+    assert len(activities) == 1
+    assert workflow.name in activities[0].summary
+
+
+def test_route_email_workflow_assigned_only_once_on_duplicate_enrollment(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """When create_enrollment hits ON CONFLICT (returns None), no second
+    workflow_assigned activity should be emitted for the same pair."""
+    from mailpilot.database import list_activities
+
+    account = make_test_account(database_connection, email="wactdup@example.com")
+    contact = make_test_contact(
+        database_connection, email="repeat@example.com", domain="example.com"
+    )
+    workflow = make_test_workflow(
+        database_connection, account_id=account.id, workflow_type="inbound"
+    )
+    _activate_workflow(database_connection, workflow.id)
+
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="outbound",
+        subject="prior",
+        gmail_thread_id="t-wactdup",
+        workflow_id=workflow.id,
+        is_routed=True,
+    )
+
+    for index in (1, 2):
+        inbound = create_email(
+            database_connection,
+            account_id=account.id,
+            direction="inbound",
+            subject=f"reply {index}",
+            gmail_thread_id="t-wactdup",
+            gmail_message_id=f"msg-wactdup-{index}",
+            contact_id=contact.id,
+        )
+        assert inbound is not None
+        route_email(
+            database_connection, inbound, "repeat@example.com", make_test_settings()
+        )
+
+    activities = list_activities(
+        database_connection, contact_id=contact.id, activity_type="workflow_assigned"
+    )
+    assert len(activities) == 1
+
+
 # -- Span contract: route_method attribute ------------------------------------
 
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1704,6 +1704,96 @@ def test_sync_stores_sender_and_recipients(
     }
 
 
+def test_sync_inbound_emits_email_received_activity(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """_store_inbound_message must create one email_received activity per
+    stored row, with summary=subject and detail.email_id/subject set."""
+    from mailpilot.database import create_company, list_activities
+    from mailpilot.sync import (
+        _store_inbound_message,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    account = make_test_account(database_connection, email="inbox@lab5.ca")
+    company = create_company(database_connection, name="Example", domain="example.com")
+    contact = make_test_contact(
+        database_connection,
+        email="alice@example.com",
+        domain="example.com",
+        company_id=company.id,
+    )
+    message = _make_gmail_message(
+        message_id="msg_act_1",
+        thread_id="thread_act_1",
+        from_header="Alice <alice@example.com>",
+        subject="Activity wiring test",
+    )
+
+    email = _store_inbound_message(
+        database_connection,
+        account,
+        message,
+        contacts_by_email={"alice@example.com": contact},
+        settings=make_test_settings(),
+        has_active_workflows=False,
+    )
+    assert email is not None
+
+    activities = list_activities(
+        database_connection, contact_id=contact.id, activity_type="email_received"
+    )
+    assert len(activities) == 1
+    activity = activities[0]
+    assert activity.summary == "Activity wiring test"
+    assert activity.company_id == company.id
+
+
+def test_sync_inbound_skips_activity_when_create_email_returns_none(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """A duplicate Gmail message ID returns None from create_email; no
+    email_received activity must be emitted in that case."""
+    from mailpilot.database import create_email, list_activities
+    from mailpilot.sync import (
+        _store_inbound_message,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    account = make_test_account(database_connection, email="inbox@lab5.ca")
+    contact = make_test_contact(
+        database_connection, email="alice@example.com", domain="example.com"
+    )
+    # Pre-insert the same gmail_message_id so the second create_email returns None.
+    create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="prior",
+        contact_id=contact.id,
+        gmail_message_id="dup_msg_1",
+        gmail_thread_id="dup_thread_1",
+    )
+    message = _make_gmail_message(
+        message_id="dup_msg_1",
+        thread_id="dup_thread_1",
+        from_header="Alice <alice@example.com>",
+        subject="Should not duplicate",
+    )
+
+    result = _store_inbound_message(
+        database_connection,
+        account,
+        message,
+        contacts_by_email={"alice@example.com": contact},
+        settings=make_test_settings(),
+        has_active_workflows=False,
+    )
+    assert result is None
+    activities = list_activities(
+        database_connection, contact_id=contact.id, activity_type="email_received"
+    )
+    assert activities == []
+
+
 def _routing_spans(capfire: CaptureLogfire) -> list[dict[str, Any]]:
     """Return all exported spans named ``routing.route_email``."""
     return [


### PR DESCRIPTION
## Summary

Wires automatic `activity` creation into the runtime paths (sync, send, enrollment lifecycle) so the CRM timeline stays complete without manual `mailpilot activity create` calls. Also names the Pydantic AI agents for legible OTel traces and fixes a basedpyright-ignore placement in tests.

Resolves #46.

## Changes

- `sync._store_inbound_message`: emit `email_received` after `create_email` returns non-None (skips ON CONFLICT duplicates)
- `email_ops.send_email` / `reply_email`: emit `email_sent` after a successful send when a `contact_id` is resolved -- single emission point covers CLI sends and both agent tools
- `routing._ensure_enrollment` + `cli enrollment add`: emit `workflow_assigned` only when `create_enrollment` returns non-None (no double-emit on duplicate routing)
- `agent.tools.update_enrollment_status` + `cli enrollment update`: emit `workflow_completed` / `workflow_failed` on those status transitions; `pending->active` stays silent
- Named pydantic-ai agents (`mailpilot.classifier`, `mailpilot.workflow`) so `gen_ai.agent.name` in OTel spans no longer leaks the private `_AGENT` variable name
- `smoke-test SKILL.md`: added A8 + B7 verification gates that read `mailpilot activity list` and assert the expected type sequence
- All tests updated and passing (`make check`)