### PR TITLE
refactor(crm): refine ADR-08 design with typed FKs and atomic activity writes

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -10,7 +10,7 @@ description: End-to-end MailPilot smoke test against real Gmail (outbound@lab5.c
 Two scenarios share a single Phase 0 setup and a single `mailpilot run` loop. The outbound workflow created in Scenario A stays active through Scenario B, so the test exercises real concurrent multi-workflow, multi-account operation. The agent-to-agent reply loop is prevented by two structural properties, not by isolation:
 
 - Distinct subjects per scenario, so each Gmail thread is owned by exactly one workflow type (Scenario A's thread routes via `thread_match` to the outbound workflow; Scenario B's fresh thread routes via classification to the inbound workflow).
-- Enrollments terminating with `update_enrollment_status`, so the agent stops replying once a scenario reaches its outcome.
+- Enrollments terminating with `record_enrollment_outcome`, so the agent stops replying once a scenario reaches its outcome.
 
 | Scenario | Active workflows                       | Trigger                                  | Verifies                                                                                                        |
 | -------- | -------------------------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
@@ -33,7 +33,7 @@ Default: run **both** scenarios in sequence. `make clean` runs **only once**, at
 
 - **Test start ISO timestamp.** Capture before each scenario; reuse for `--since` filters and Logfire time windows.
 - **Polling.** When waiting for sync, routing, or agent results: poll up to **12 attempts, 5 seconds apart (~60s total)**. Do not call `mailpilot account sync` directly -- the background `mailpilot run` loop owns sync.
-- **CLI parsing.** All commands use `uv run mailpilot`. Parse the JSON output of every command and extract IDs for the next step.
+- **CLI parsing.** All commands use `uv run mailpilot`. Parse the JSON output of every command and extract IDs for the next step. Do not capture into a shell variable and re-emit with `echo "$VAR" | python3 -c ...` -- zsh's built-in `echo` interprets backslash escapes in the JSON (e.g. converts the literal two-char `\n` inside `body_text` into a real newline) and the resulting stream is no longer valid strict JSON. Either pipe `mailpilot ... | python3 -c ...` directly, or use `printf '%s' "$VAR"` to feed a captured value verbatim.
 - **ASCII only.** No emojis. Use `->`, `--`, plain pipes.
 
 ## Prerequisites
@@ -95,7 +95,7 @@ mailpilot workflow create \
   --type outbound \
   --account-id <OUTBOUND_ACCOUNT_ID> \
   --objective "Send a single email about <TOPIC_A> and mark the enrollment completed or failed based on the reply" \
-  --instructions "You are a sales rep for Lab5. Send ONE email to the contact about <TOPIC_A>. Subject MUST be exactly '<SUBJECT_A>'. Body MUST use Markdown (greeting, 2-3 sentence paragraph, a 3-row 2-column table). When you receive a reply, do not send another email -- read the reply and call update_enrollment_status with status='completed' if the reply expresses interest or status='failed' if it declines, then stop. Do not call disable_contact -- this is per-workflow outcome tracking, not a global contact block. Do not create follow-up tasks."
+  --instructions "You are a sales rep for Lab5. Send ONE email to the contact about <TOPIC_A>. Subject MUST be exactly '<SUBJECT_A>'. Body MUST use Markdown (greeting, 2-3 sentence paragraph, a 3-row 2-column table). When you receive a reply, do not send another email -- read the reply and call record_enrollment_outcome with status='completed' if the reply expresses interest or status='failed' if it declines, then stop. Do not call disable_contact -- this is per-workflow outcome tracking, not a global contact block. Do not create follow-up tasks."
 ```
 
 Activate it if creation does not auto-activate:
@@ -136,7 +136,7 @@ mailpilot enrollment run --workflow-id <OUTBOUND_WORKFLOW_ID> --contact-id <INBO
 - `enrollment run` output: `"status": "completed"` and `"tool_calls" >= 1`.
 - `mailpilot email list --account-id <OUTBOUND_ACCOUNT_ID> --direction outbound` shows the outbound email with `subject == SUBJECT_A`.
 - The email's `body_text` contains `|` (table) and either `**` or `#` (Markdown).
-- `mailpilot enrollment list --workflow-id <OUTBOUND_WORKFLOW_ID>` shows enrollment status `active` or `completed`.
+- `mailpilot enrollment list --workflow-id <OUTBOUND_WORKFLOW_ID>` shows enrollment status `active`. Per ADR-08 `enrollment.status` is operational only (`active` / `paused`); the agent never mutates it directly. The send-completion outcome lives in the activity timeline (verified in A8), not on the enrollment row.
 
 Save `OUTBOUND_EMAIL_ID`.
 
@@ -169,7 +169,7 @@ mailpilot email view <INBOUND_SIDE_EMAIL_ID>
 
 Claude Code sends the reply directly via CLI -- no inbound agent is involved at this point because no inbound workflow has been created yet. The reply lands in the outbound mailbox, where it will be picked up by `thread_match` and handed to the outbound agent for terminal processing.
 
-Choose reply content that gives the outbound agent a clear terminal signal so it marks the enrollment outcome and stops. Phrase the decline as "this opportunity is not a fit for our current priorities" rather than "remove us from your list" -- the latter steers the agent toward `disable_contact` (a global contact block) when we want it to call `update_enrollment_status` (the per-workflow outcome). Recommended template:
+Choose reply content that gives the outbound agent a clear terminal signal so it marks the enrollment outcome and stops. Phrase the decline as "this opportunity is not a fit for our current priorities" rather than "remove us from your list" -- the latter steers the agent toward `disable_contact` (a global contact block) when we want it to call `record_enrollment_outcome` (the per-workflow outcome). Recommended template:
 
 ```
 mailpilot email reply \
@@ -213,7 +213,7 @@ Wait for a task with `email_id` set to the routed reply and `status == "complete
 **Gate A7:**
 
 - Task exists with `email_id == <routed reply id>` and `status == "completed"`.
-- `mailpilot enrollment list --workflow-id <OUTBOUND_WORKFLOW_ID>` shows enrollment status is `completed` or `failed` (terminal, agent-driven).
+- `mailpilot enrollment list --workflow-id <OUTBOUND_WORKFLOW_ID>` still shows status `active` -- by design (ADR-08, `enrollment.status` is operational only). The terminal outcome is recorded as an `enrollment_completed` or `enrollment_failed` activity row, verified in A8.
 - **No additional outbound emails were sent.** Re-run `mailpilot email list --account-id <OUTBOUND_ACCOUNT_ID> --direction outbound --since <TEST_START_A>` and confirm only the original outbound from A3 is present. If the count > 1, the agent kept replying despite the decline signal -- record this as a defect for the report.
 
 **On failure:** If the task was never created, check that A6's email has `workflow_id` set and the run loop is alive. If the task is `failed`, `mailpilot task view <TASK_ID>` for the reason.
@@ -226,22 +226,22 @@ The runtime paths emit `activity` rows automatically (no manual `activity create
 mailpilot activity list --contact-id <INBOUND_CONTACT_ID> --since <TEST_START_A>
 ```
 
-**Gate A8 (activity wiring):**
+**Gate A8 (activity wiring):** activity types follow the `enrollment_*` vocabulary defined in ADR-08.
 
-- `workflow_assigned` activity present with `detail.workflow_id == OUTBOUND_WORKFLOW_ID` (emitted by `enrollment add`).
+- `enrollment_added` activity present with `detail.workflow_id == OUTBOUND_WORKFLOW_ID` (emitted by `enrollment add`).
 - `email_sent` activity present with `summary == SUBJECT_A` (emitted by `email_ops.send_email` when the outbound agent sent in A3).
 - `email_received` activity present with the operator-reply subject (emitted by sync's `_store_inbound_message` when the reply landed in the outbound mailbox in A6).
-- Exactly one of `workflow_completed` or `workflow_failed` present (emitted by `agent.tools.update_enrollment_status` in A7); summary equals the agent's `reason`.
+- Exactly one of `enrollment_completed` or `enrollment_failed` present (emitted by `agent.tools.record_enrollment_outcome` in A7); summary equals the agent's `reason`.
 - No `tag_added` / `note_added` rows from this scenario (we did not run those CLI commands).
 
-If any expected type is missing, the runtime wiring (issue #46) regressed for that path.
+If any expected type is missing, the runtime activity wiring regressed for that path.
 
 ### Logfire review for Scenario A
 
 Do this review now, before starting Scenario B, so the time window cleanly bounds A's spans. Use `/logfire:debug` with project=`mailpilot` and time window `[TEST_START_A, now]`. Spans to verify:
 
-- `agent.invoke` -- exactly **2** invocations (A3 send + A7 reply handling). More than 2 means the agent kept replying (loop regression).
-- `running tool` -- in A3 expect `send_email` plus optional context-gathering reads (`read_contact`, `read_company`); `update_enrollment_status` is **not** expected here (it fires after a reply, not on initial send). In A7 expect `update_enrollment_status` and **no** `send_email` or `reply_email`.
+- `agent.invoke` -- exactly **2** invocations across all processes (A3 send invoked by foreground `enrollment run`, A7 reply handling drained by the background `mailpilot run` loop). The bg run-loop's stdout will only show the A7 invocation -- the A3 invocation lives in the fg `enrollment run` process. Logfire (or any process-agnostic trace store) shows both. More than 2 total means the agent kept replying (loop regression).
+- `running tool` -- in A3 expect `send_email` plus optional context-gathering reads (`read_contact`, `read_company`); `record_enrollment_outcome` is **not** expected here (it fires after a reply, not on initial send). In A7 expect `record_enrollment_outcome` and **no** `send_email` or `reply_email`.
 - `routing.route_email` -- the reply (A6) should show `route_method=thread_match` and `workflow_id == OUTBOUND_WORKFLOW_ID`. The inbound-side email from A4 should show `route_method=skipped_no_workflows` (no inbound workflow at the time).
 - `gmail.send_message` -- 2 calls total (A3 by agent + A5 by operator).
 - Any `is_exception=true` or `level=warn` spans -- record them.
@@ -270,7 +270,7 @@ mailpilot workflow create \
   --type inbound \
   --account-id <INBOUND_ACCOUNT_ID> \
   --objective "Answer product questions about Lab5 services" \
-  --instructions "You are a customer service rep for Lab5. Reply briefly to product questions about Lab5's services. Body MUST use Markdown (greeting, 2-3 sentence response, a 2-row 2-column table of services or next steps). Subject MUST preserve the incoming thread subject. After replying, call update_enrollment_status with status='completed'. Do not create follow-up tasks."
+  --instructions "You are a customer service rep for Lab5. Reply briefly to product questions about Lab5's services. Body MUST use Markdown (greeting, 2-3 sentence response, a 2-row 2-column table of services or next steps). Subject MUST preserve the incoming thread subject. After replying, call record_enrollment_outcome with status='completed'. Do not create follow-up tasks."
 ```
 
 Activate if needed:
@@ -344,7 +344,7 @@ Wait for a task with `email_id == ROUTED_EMAIL_ID` and `status == "completed"`.
 - `mailpilot email list --account-id <INBOUND_ACCOUNT_ID> --direction outbound --since <TEST_START_B>` returns at least 1 reply.
 - The reply's `gmail_thread_id` matches the inbound side's thread of the routed email (in-thread via `reply_email`).
 - The reply's `body_text` contains `|` (Markdown table preserved).
-- `mailpilot enrollment list --workflow-id <INBOUND_WORKFLOW_ID>` shows enrollment status `completed`.
+- `mailpilot enrollment list --workflow-id <INBOUND_WORKFLOW_ID>` still shows status `active` -- by design (ADR-08, `enrollment.status` is operational only). The terminal outcome is recorded as an `enrollment_completed` activity row, verified in B7.
 
 Save `INBOUND_REPLY_EMAIL_ID`.
 
@@ -365,7 +365,7 @@ Match by `SUBJECT_B` (likely with a `Re:` prefix on Gmail's side).
 - Email present in outbound account's inbound emails.
 - `is_routed == true`.
 - `workflow_id == null` -- the outbound workflow exists and is active, but it does not own B's thread (no `thread_match`) and outbound workflows do not classify, so the reply correctly lands with `route_method=skipped_no_workflows`.
-- **No additional inbound replies.** Re-run `mailpilot email list --account-id <INBOUND_ACCOUNT_ID> --direction outbound --since <TEST_START_B>` and confirm only the single reply from B5 exists. More than one means the inbound agent kept replying despite the terminal `update_enrollment_status` call -- record as a defect.
+- **No additional inbound replies.** Re-run `mailpilot email list --account-id <INBOUND_ACCOUNT_ID> --direction outbound --since <TEST_START_B>` and confirm only the single reply from B5 exists. More than one means the inbound agent kept replying despite the terminal `record_enrollment_outcome` call -- record as a defect.
 - **Outbound workflow stayed quiet (concurrent-workflow check).** Re-run `mailpilot email list --account-id <OUTBOUND_ACCOUNT_ID> --direction outbound --since <TEST_START_B>` and confirm zero new outbound sends. Any non-zero count means the still-active outbound workflow reacted to B's traffic -- record as a defect.
 
 ### B7. Verify the CRM activity timeline
@@ -376,14 +376,14 @@ Read the outbound contact's timeline (this is the contact whose enrollment was d
 mailpilot activity list --contact-id <OUTBOUND_CONTACT_ID> --since <TEST_START_B>
 ```
 
-**Gate B7 (activity wiring):**
+**Gate B7 (activity wiring):** activity types follow the `enrollment_*` vocabulary defined in ADR-08.
 
-- `workflow_assigned` activity present with `detail.workflow_id == INBOUND_WORKFLOW_ID` (emitted by `enrollment add` in B1).
+- `enrollment_added` activity present with `detail.workflow_id == INBOUND_WORKFLOW_ID` (emitted by `enrollment add` in B1).
 - `email_received` activity present with `summary == SUBJECT_B` (emitted by sync's `_store_inbound_message` when the trigger arrived in B4 on the inbound mailbox).
 - `email_sent` activity present from the agent reply in B5 (subject begins with `Re:`).
-- `workflow_completed` activity present (emitted by `agent.tools.update_enrollment_status` after B5).
+- `enrollment_completed` activity present (emitted by `agent.tools.record_enrollment_outcome` after B5).
 
-Also re-read the inbound contact's timeline from Scenario A and confirm no new `email_*` rows appeared during Scenario B (the outbound workflow stayed quiet). Any new entries here mirror the existing "outbound workflow stayed quiet" check in Gate B6 from the activity-table side.
+Note: re-reading the inbound contact's timeline from Scenario A is **not** a useful concurrent-quiet check. The inbound contact (recipient of A's outbound mail and counterparty for B's traffic on the outbound mailbox) will naturally accumulate `email_sent` / `email_received` rows during B because B's trigger and the agent's round-tripped reply both involve that contact. The authoritative concurrent-quiet check is Gate B6's "0 new outbound sends from the outbound account" assertion -- that is what proves the outbound workflow did not act.
 
 ### B8. Stop the sync loop
 
@@ -398,7 +398,7 @@ Time window `[TEST_START_B, now]`. Spans to verify:
 - `agent.invoke` -- exactly **1** invocation (B5). More than 1 means either the inbound agent re-fired or the outbound workflow reacted to B's traffic.
 - `routing.route_email` -- the inbound-side email (B4) should be `route_method=classified`. The outbound-side reply (B6) should be `route_method=skipped_no_workflows`.
 - `classify_email` -- 1 invocation (B4). Check `result` matches `INBOUND_WORKFLOW_ID`.
-- `running tool` (B5) -- expect `reply_email` and `update_enrollment_status`.
+- `running tool` (B5) -- expect `reply_email` and `record_enrollment_outcome`.
 - Any `is_exception=true` or `level=warn` spans -- record them.
 
 ---
@@ -504,7 +504,7 @@ Write findings directly into the report. Do not file external tickets unless the
 
 1. **CLI usability** -- commands that needed awkward sequencing or workarounds; missing fields in JSON output; error messages that did not point at the cause.
 2. **Logfire observability** -- missing spans, missing attributes on existing spans, noisy span families (quantify with the volume query), broken parent-child causality, agent token/cost visibility.
-3. **Agent behavior** -- did the agents follow instructions (subject, brevity, no extra tool calls)? Was `agent_reasoning` useful? Did `update_enrollment_status` get called when expected? In Scenario A, did the agent hold the line on "do not reply again"?
+3. **Agent behavior** -- did the agents follow instructions (subject, brevity, no extra tool calls)? Was `agent_reasoning` useful? Did `record_enrollment_outcome` get called when expected? In Scenario A, did the agent hold the line on "do not reply again"?
 4. **Concurrent workflow safety** -- with both workflows active during Scenario B, did the outbound workflow stay quiet (zero new sends, no `agent.invoke` outside Scenario A's window)? Did the inbound workflow correctly leave A's lingering thread alone? Excess `agent.invoke` spans here are the high-priority signal from this run, since they would indicate that two simultaneously active workflows can interfere with each other.
 5. **Other deficiencies** -- timing, race conditions, data integrity, performance.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ mailpilot enrollment add --workflow-id ID --contact-id ID
 mailpilot enrollment remove --workflow-id ID --contact-id ID
 mailpilot enrollment view --workflow-id ID --contact-id ID
 mailpilot enrollment list [--workflow-id ID] [--contact-id ID] [--status pending|active|completed|failed] [--limit N] [--since ISO]
-mailpilot enrollment update --workflow-id ID --contact-id ID --status S [--reason R]
+mailpilot enrollment update --workflow-id ID --contact-id ID --status active|paused [--reason R]
 mailpilot enrollment run --workflow-id ID --contact-id ID
 
 mailpilot task list [--workflow-id ID] [--contact-id ID] [--status pending|completed|failed|cancelled] [--limit N] [--since ISO]
@@ -121,7 +121,7 @@ mailpilot email reply --account-id ID --email-id ID --body B [--workflow-id ID] 
 
 mailpilot activity list --contact-id ID [--type TYPE] [--limit N] [--since ISO]
 mailpilot activity list --company-id ID [--type TYPE] [--limit N] [--since ISO]
-mailpilot activity create --contact-id ID --type TYPE --summary TEXT [--detail JSON] [--company-id ID]
+mailpilot activity create [--contact-id ID] [--company-id ID] --type TYPE --summary TEXT [--detail JSON]
 
 mailpilot tag add --contact-id ID NAME
 mailpilot tag add --company-id ID NAME
@@ -177,9 +177,10 @@ MailPilot is a CRM with Gmail as the communication channel. Core concepts:
 
 - **Contact** -- a person with an email address. May belong to a company.
 - **Company** -- an organization identified by domain.
-- **Tag** -- flexible label on contacts or companies for segmentation. Convention: lowercase, hyphenated (e.g., `prospect`, `logistics`, `cold`). No formal pipeline stages -- tags are freeform.
-- **Note** -- freeform text annotation on a contact or company. Append-only.
-- **Activity** -- chronological event log per contact. All significant interactions (emails, notes, tags, status changes, workflow events) are recorded as activities. This is the unified timeline Claude Code queries for relationship health and reporting.
+- **Tag** -- flexible label on a contact or company. Each row sets exactly one of `contact_id` or `company_id` (XOR). Tag names are strictly normalized to `[a-z0-9][a-z0-9-]*`; invalid names raise. Convention: lowercase, hyphenated (e.g., `prospect`, `logistics`, `cold`). No formal pipeline stages -- tags are freeform.
+- **Note** -- freeform text annotation on a contact or company. Same XOR pattern as Tag. Append-only.
+- **Activity** -- chronological event log per contact and/or company. At least one of `contact_id` / `company_id` must be set. Structured FK columns (`email_id`, `workflow_id`, `task_id`) let reports join without parsing `detail` JSON. Activities are append-only.
+- **Enrollment** -- contact's binding to a workflow. Status is operational state only: `active` (agent runs against it) or `paused`. Outcomes (`completed`, `failed`) are recorded as activity events via the agent's `record_enrollment_outcome` tool, not as enrollment state.
 - **Workflow** -- binds an account to agent instructions for email communication (inbound or outbound). Unchanged from prior design (see `docs/adr-03-workflow-model.md`).
 
 ### Reporting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Email body stored as plain text only (see `docs/adr-02-email-body-storage-strate
 
 ### Workflows
 
-Workflow is the central abstraction for both outbound campaigns and inbound auto-reply (see `docs/adr-03-workflow-model.md`). Each workflow is executed by a Pydantic AI agent with tool access. Inbound emails are routed via thread matching then LLM classification. Agent plans multi-step work via deferred tasks. See `docs/email-flow.md` for execution flows. See `docs/adr-08-crm-evolution.md` for the CRM evolution design.
+Workflow is the central abstraction for both outbound campaigns and inbound auto-reply (see `docs/adr-03-workflow-model.md`). Each workflow is executed by a Pydantic AI agent with tool access. Inbound emails are routed via thread matching then LLM classification. Agent plans multi-step work via deferred tasks. See `docs/email-flow.md` for execution flows. See `docs/adr-08-crm-design.md` for the CRM design.
 
 ### Email Rendering
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ make py-test  # pytest -x
 - [Schema Migration](docs/adr-05-schema-migration-strategy.md)
 - [Workflow Field Definitions](docs/adr-06-workflow-field-definitions.md)
 - [Observability with Logfire](docs/adr-07-observability-with-logfire.md)
-- [CRM Evolution](docs/adr-08-crm-evolution.md)
+- [CRM Design](docs/adr-08-crm-design.md)
 - [Email Flow](docs/email-flow.md)
 
 ## License

--- a/docs/adr-08-crm-design.md
+++ b/docs/adr-08-crm-design.md
@@ -6,59 +6,83 @@ Accepted.
 
 ## Context
 
-The system has two layers of intelligence:
+MailPilot is a CRM with Gmail as the primary communication channel. Claude Code is the strategic orchestrator and primary operator; an internal Pydantic AI agent handles real-time tactical work within workflows.
 
-1. **Claude Code** -- strategic orchestrator. Creates workflows, assigns contacts, reviews outcomes, generates reports. Operates via CLI.
-2. **Internal Pydantic AI agent** -- subordinate tactical executor. Handles real-time reactive work (inbound classification, auto-replies, follow-ups).
+To support relationship reporting, segmentation, and freeform annotation, the schema includes three tables beyond the core (account, company, contact, workflow, enrollment, email, task, sync_status):
 
-Claude Code needs:
-
-- A unified timeline of all interactions per contact (for relationship health monitoring)
-- Flexible segmentation (no formal pipeline -- tags like "prospect", "contacted", "client")
-- Freeform annotations on contacts and companies
-- Efficient query paths for reporting (activity summaries, campaign effectiveness, pipeline snapshots)
-
-The existing schema (account, company, contact, workflow, enrollment, email, task, sync_status) lacks these CRM capabilities.
+- `activity` -- unified per-contact and per-company timeline.
+- `tag` -- flexible label on contacts or companies.
+- `note` -- freeform text annotation on contacts or companies.
 
 ## Decision
 
 ### Identity
 
-Reframe MailPilot from "AI email platform" to "CRM with Gmail as the primary communication channel." The Project Overview in CLAUDE.md reflects this shift.
+MailPilot is a CRM. Gmail is the channel. The CLI is the operator surface for Claude Code.
 
-### Three new tables
+### `activity` -- typed FKs, contact-or-company
 
-**`activity`** -- unified per-contact timeline. Every significant event (email sent/received, note added, tag changed, status changed, workflow assigned/completed/failed) is recorded as an immutable row. `contact_id` is NOT NULL (primary query axis). `summary` holds a human-readable one-liner. `detail` is a JSONB bag for type-specific data. Append-only -- no updates, no deletes.
+Every significant event is an immutable row. Either `contact_id` or `company_id` (or both) is set. Structured FK columns -- `email_id`, `workflow_id`, `task_id` -- let reports join activity to source records without parsing JSON. `detail` JSONB remains for type-specific metadata that does not need to be queryable as a column.
 
-**`tag`** -- flexible segmentation. Polymorphic table (`entity_type` + `entity_id`) for labeling contacts and companies. Tags replace formal pipeline stages. Convention: lowercase, hyphenated names. UNIQUE constraint prevents duplicates. `create_tag` normalizes names via `name.strip().lower()`.
+Composite indexes `idx_activity_contact_timeline (contact_id, created_at DESC)` and `idx_activity_company_timeline (company_id, created_at DESC)` serve the common "newest-first timeline for this entity" query.
 
-**`note`** -- freeform annotations. Same polymorphic pattern as tags. Append-only. Creating a note also creates a `note_added` activity.
+Activity vocabulary:
 
-### No changes to existing tables
+- `email_sent`, `email_received` -- send/receive on the Gmail channel.
+- `note_added` -- note created on contact or company.
+- `tag_added`, `tag_removed` -- tag mutations.
+- `status_changed` -- contact-level lifecycle (bounced, unsubscribed).
+- `enrollment_added` -- contact joined a workflow.
+- `enrollment_completed`, `enrollment_failed` -- agent-declared outcomes (timeline-only, not state on enrollment).
+- `enrollment_paused`, `enrollment_resumed` -- operator pause/resume.
 
-All eight existing tables retain their current schema. No columns added, no constraints modified. The new tables extend the system without altering what works.
+### `tag` -- typed nullable FKs (no polymorphism)
 
-### No formal pipeline
+`tag.contact_id` and `tag.company_id` are both nullable. A CHECK constraint enforces XOR (exactly one is set). Two partial unique indexes on `(contact_id, name)` and `(company_id, name)` prevent duplicates within an owner.
 
-Tags serve as lightweight status markers (prospect, contacted, interested, client). No ordered stages, no deal values, no win/loss tracking. If patterns emerge from usage, frequently-used tags can be promoted to structured fields in a future migration.
+Tag names are normalized to lowercase, hyphenated form via `_normalize_tag_name`: whitespace and underscores collapse to single hyphens, repeated hyphens collapse, leading/trailing hyphens are trimmed. The result must match `[a-z0-9][a-z0-9-]*`. Names that fail validation raise `ValueError` -- there is no silent salvage.
 
-### Activity creation
+### `note` -- typed nullable FKs
 
-Initially manual -- Claude Code creates activities via CLI (`activity create`) and tag/note commands auto-create corresponding activities. Auto-creation from the sync pipeline and send function is deferred to a follow-up.
+Same XOR pattern as `tag`. Notes are append-only.
+
+### `enrollment.status` -- operational only
+
+States: `active` (agent considers this contact when the workflow runs) and `paused` (operator/agent has suspended). Outcomes (`completed`, `failed`) live entirely in the activity timeline as `enrollment_completed` / `enrollment_failed` events. The relationship persists across declared outcomes -- a late inbound reply does not require a state transition.
+
+### Atomic timeline writes
+
+Combined helpers in `database.py` write the domain row and its activity in a single transaction:
+
+- `add_contact_tag` / `add_company_tag` / `remove_contact_tag` / `remove_company_tag`
+- `add_contact_note` / `add_company_note`
+
+CLI commands and other callers use these helpers instead of two separate writes.
+
+### Activity creation in runtime paths
+
+| Trigger                          | Module                                       | Activity                                                        |
+| -------------------------------- | -------------------------------------------- | --------------------------------------------------------------- |
+| Outbound send                    | `email_ops.py`                               | `email_sent` (with `email_id`, `workflow_id` FKs)               |
+| Inbound store                    | `sync.py`                                    | `email_received` (with `email_id` FK)                           |
+| Routing -> enrollment created    | `routing.py`                                 | `enrollment_added` (with `workflow_id` FK)                      |
+| Agent declares outcome           | `agent/tools.py` `record_enrollment_outcome` | `enrollment_completed` / `enrollment_failed`                    |
+| CLI `enrollment update`          | `cli.py`                                     | `enrollment_paused` / `enrollment_resumed` (on transition only) |
+| CLI `tag add/remove`, `note add` | `cli.py` via atomic helper                   | `tag_added` / `tag_removed` / `note_added`                      |
 
 ## Consequences
 
 ### Positive
 
-- Unified timeline gives Claude Code a single query target for all relationship reporting
-- Tags are maximally flexible -- no premature commitment to pipeline stages
-- Polymorphic entity pattern reuses one table for contacts and companies (two tables instead of four)
-- Append-only activity and note tables are simple -- no concurrency concerns, no update conflicts
-- No changes to existing modules -- zero risk of regression
+- One unified timeline for relationship reporting, joinable to source records via real FKs.
+- Maximum segmentation flexibility through tags; no premature commitment to pipeline stages.
+- Database-level referential integrity on every CRM relationship (no orphans from polymorphic FKs).
+- Simple enrollment state -- two states, no terminal/reactivation problem; outcomes are timeline events.
+- Atomic timeline writes prevent CRM/timeline divergence on partial failures.
+- Strict tag normalization prevents operational drift (`Hot Lead`, `hot_lead`, `hot--lead` collapse to a single canonical form).
 
 ### Negative
 
-- Polymorphic FK on tag and note means no database-level referential integrity on `entity_id`. Orphaned rows from deleted contacts/companies are possible but harmless and easily cleaned up.
-- Activity table grows unboundedly. Acceptable for solo consultant volume. If it exceeds 100K rows, add a retention policy or archival.
-- Manual activity creation initially means the timeline is incomplete until auto-creation is wired in. The CLI `activity create` command provides a manual workaround.
-- Tag names are freeform -- no enforcement of a controlled vocabulary. Convention (documented in CLAUDE.md) mitigates inconsistency. Claude Code can audit and normalize.
+- "Which enrollments completed?" requires querying the activity timeline rather than filtering enrollment.status. Acceptable at solo-consultant volume; can be optimized with a materialized view if it becomes a bottleneck.
+- Activity table grows unboundedly. Acceptable for current volume; if it exceeds 100K rows, add retention or archival.
+- Tag normalization rejects some inputs that the previous lenient `strip().lower()` would have silently accepted. CLI surfaces a `validation_error` so the operator can correct.

--- a/docs/adr-08-crm-design.md
+++ b/docs/adr-08-crm-design.md
@@ -1,4 +1,4 @@
-# ADR-08: CRM Evolution -- Activity Timeline, Tags, and Notes
+# ADR-08: CRM Design -- Activity Timeline, Tags, and Notes
 
 ## Status
 

--- a/docs/superpowers/plans/2026-04-28-adr-08-refinements.md
+++ b/docs/superpowers/plans/2026-04-28-adr-08-refinements.md
@@ -1,0 +1,2977 @@
+# ADR-08 Refinements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply the design refinements proposed in GitHub issue #102 plus the enrollment-status collapse from comment [#4334976677](https://github.com/kborovik/mailpilot/issues/102#issuecomment-4334976677). Replace polymorphic tag/note FKs with nullable typed FKs, allow company-only activity rows, add structured FK columns and composite timeline indexes on activity, rename `workflow_*` activity types to `enrollment_*`, collapse `enrollment.status` to `(active, paused)`, replace the agent's `update_enrollment_status` tool with `record_enrollment_outcome` (activity-only), make tag/note + activity writes atomic, tighten tag normalization, and rewrite ADR-08 to match implemented behavior.
+
+**Architecture:** Bottom-up. Two slices keep the build green at boundaries:
+
+- **Slice A** rewrites `schema.sql` and `models.py` together, since the type changes propagate.
+- **Slice B** rewrites the affected `database.py` functions (Tag, Note, Activity, Enrollment) and adds atomic helpers.
+- **Slice C** updates every caller (`routing.py`, `email_ops.py`, `sync.py`, `cli.py`, `agent/tools.py`, `agent/invoke.py`).
+- **Slice D** rewrites the ADR, updates `CLAUDE.md`, and runs end-to-end verification.
+
+Schema changes are applied via direct edits to `src/mailpilot/schema.sql` plus `make clean` (the project does not yet have a migration runner -- see ADR-05). This matches the precedent set by `docs/superpowers/plans/2026-04-25-enrollment-rename.md`.
+
+**Tech Stack:** Python 3.14, PostgreSQL 18, psycopg, Pydantic, Click, basedpyright strict, ruff, pytest.
+
+**Spec:** GitHub issue #102 (`gh issue view 102`) + comment [#4334976677](https://github.com/kborovik/mailpilot/issues/102#issuecomment-4334976677). Renamed ADR file: `docs/adr-08-crm-design.md`.
+
+---
+
+## Conventions for this plan
+
+**Refactor TDD pattern.** Existing tests already cover Tag, Note, Activity, and Enrollment behavior. For renames and shape changes, the cycle is: update the test (it fails because the impl still uses the old shape), update the impl (test passes), commit. For genuinely new behavior (atomic helpers, tag normalization regex, company-only activity rows, `record_enrollment_outcome`, `enrollment_paused`/`resumed` activity types), write the failing test first.
+
+**Schema-coupled tests.** Some tasks change schema, models, and DB functions in a single coordinated edit. Within Slice A and B, intermediate commits may temporarily break unrelated tests -- that's expected. Each slice ends with `make check` clean.
+
+**Migration via `make clean`.** After `schema.sql` changes, run:
+
+```bash
+make clean
+DATABASE_URL=postgresql://localhost/mailpilot_test \
+    uv run python -c "from mailpilot.database import initialize_database; initialize_database('postgresql://localhost/mailpilot_test').close()"
+```
+
+This drops and recreates both the dev DB (`mailpilot`) and the test DB (`mailpilot_test`). Only required after Task A1.
+
+**Commit cadence.** Commit at the end of every task. Use Conventional Commits: `refactor(area): ...` for renames, `feat(area): ...` for new behavior, `fix(area): ...` for genuine bug fixes that surface during the refactor, `docs(adr): ...` for ADR rewrites.
+
+---
+
+## File Structure
+
+| File                            | Disposition                                                                                                                                           |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/mailpilot/schema.sql`      | Modify -- tag/note FKs, activity columns + indexes, enrollment status                                                                                 |
+| `src/mailpilot/models.py`       | Modify -- Tag/Note/Activity/Enrollment model shapes, type unions                                                                                      |
+| `src/mailpilot/database.py`     | Modify -- Tag/Note/Activity/Enrollment CRUD; new atomic helpers; new `_normalize_tag_name`                                                            |
+| `src/mailpilot/routing.py`      | Modify -- `workflow_assigned` -> `enrollment_added`, pass `workflow_id` FK                                                                            |
+| `src/mailpilot/email_ops.py`    | Modify -- drop `_activate_enrollment_if_pending`; pass `email_id`/`workflow_id` FKs in `email_sent` activity                                          |
+| `src/mailpilot/sync.py`         | Modify -- pass `email_id` FK in `email_received` activity                                                                                             |
+| `src/mailpilot/agent/tools.py`  | Modify -- replace `update_enrollment_status` with `record_enrollment_outcome` (activity only)                                                         |
+| `src/mailpilot/agent/invoke.py` | Modify -- wrapper rename, `_TOOLS`, `_SYSTEM_PREFIX`                                                                                                  |
+| `src/mailpilot/cli.py`          | Modify -- `_ACTIVITY_TYPES`, tag/note commands use atomic helpers, activity create supports company-only, enrollment update only allows active/paused |
+| `tests/test_database.py`        | Modify -- Tag/Note/Activity/Enrollment tests                                                                                                          |
+| `tests/test_cli.py`             | Modify -- tag/note/activity/enrollment CLI tests                                                                                                      |
+| `tests/test_routing.py`         | Modify -- `enrollment_added` activity assertions                                                                                                      |
+| `tests/test_email_ops.py`       | Modify -- drop pending-state activation expectations; assert `email_id`/`workflow_id` in email_sent activity                                          |
+| `tests/test_sync.py`            | Modify -- assert `email_id` in email_received activity                                                                                                |
+| `tests/test_agent_tools.py`     | Modify -- `record_enrollment_outcome` tests                                                                                                           |
+| `tests/test_agent_invoke.py`    | Modify -- tool registration, prompt prefix                                                                                                            |
+| `tests/test_models.py`          | Modify -- model shape tests                                                                                                                           |
+| `docs/adr-08-crm-design.md`     | Rewrite -- match implemented behavior, document new FK columns and tag normalization                                                                  |
+| `CLAUDE.md`                     | Modify -- CRM Model section, CLI reference block                                                                                                      |
+
+---
+
+## Slice A: Schema + Models
+
+### Task A1: Rewrite `schema.sql` for tag/note/activity/enrollment
+
+**Files:**
+
+- Modify: `src/mailpilot/schema.sql:150-193` (activity, tag, note tables) and `src/mailpilot/schema.sql:73-84` (enrollment table)
+
+- [ ] **Step 1: Rewrite the activity table block**
+
+Replace lines 150-169 with:
+
+```sql
+CREATE TABLE IF NOT EXISTS activity (
+    id              TEXT PRIMARY KEY,
+    contact_id      TEXT REFERENCES contact(id),
+    company_id      TEXT REFERENCES company(id),
+    email_id        TEXT REFERENCES email(id),
+    workflow_id     TEXT REFERENCES workflow(id),
+    task_id         TEXT REFERENCES task(id),
+    type            TEXT NOT NULL
+                    CHECK (type IN (
+                        'email_sent', 'email_received',
+                        'note_added', 'tag_added', 'tag_removed',
+                        'status_changed',
+                        'enrollment_added',
+                        'enrollment_completed', 'enrollment_failed',
+                        'enrollment_paused', 'enrollment_resumed'
+                    )),
+    summary         TEXT NOT NULL DEFAULT '',
+    detail          JSONB NOT NULL DEFAULT '{}',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (contact_id IS NOT NULL OR company_id IS NOT NULL)
+);
+
+CREATE INDEX IF NOT EXISTS idx_activity_contact_timeline
+    ON activity(contact_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_activity_company_timeline
+    ON activity(company_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_activity_type ON activity(type);
+```
+
+Notes:
+
+- `contact_id` is now nullable; CHECK enforces at least one of contact/company.
+- `email_id`, `workflow_id`, `task_id` are real nullable FKs (suggestion #5).
+- Composite indexes replace the single-column `idx_activity_contact_id`, `idx_activity_company_id`, and `idx_activity_created_at` (suggestion #6). Type index is kept for `--type` filters.
+- Activity type list is the new vocabulary -- `workflow_*` removed, `enrollment_*` added.
+
+- [ ] **Step 2: Rewrite the tag table block**
+
+Replace lines 171-182 with:
+
+```sql
+CREATE TABLE IF NOT EXISTS tag (
+    id              TEXT PRIMARY KEY,
+    contact_id      TEXT REFERENCES contact(id),
+    company_id      TEXT REFERENCES company(id),
+    name            TEXT NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (
+        (contact_id IS NOT NULL AND company_id IS NULL)
+        OR
+        (contact_id IS NULL AND company_id IS NOT NULL)
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tag_contact_unique
+    ON tag(contact_id, name) WHERE contact_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tag_company_unique
+    ON tag(company_id, name) WHERE company_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_tag_name ON tag(name);
+```
+
+The XOR CHECK enforces exactly one of contact/company. Two partial unique indexes replace the polymorphic UNIQUE constraint.
+
+- [ ] **Step 3: Rewrite the note table block**
+
+Replace lines 184-193 with:
+
+```sql
+CREATE TABLE IF NOT EXISTS note (
+    id              TEXT PRIMARY KEY,
+    contact_id      TEXT REFERENCES contact(id),
+    company_id      TEXT REFERENCES company(id),
+    body            TEXT NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (
+        (contact_id IS NOT NULL AND company_id IS NULL)
+        OR
+        (contact_id IS NULL AND company_id IS NOT NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_note_contact_id ON note(contact_id) WHERE contact_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_note_company_id ON note(company_id) WHERE company_id IS NOT NULL;
+```
+
+- [ ] **Step 4: Tighten the enrollment status check**
+
+Replace the enrollment table block (lines 73-84) with:
+
+```sql
+CREATE TABLE IF NOT EXISTS enrollment (
+    workflow_id   TEXT NOT NULL REFERENCES workflow(id),
+    contact_id    TEXT NOT NULL REFERENCES contact(id),
+    status        TEXT NOT NULL DEFAULT 'active'
+                  CHECK (status IN ('active', 'paused')),
+    reason        TEXT NOT NULL DEFAULT '',
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (workflow_id, contact_id)
+);
+```
+
+Default flips from `'pending'` to `'active'`. Outcomes (`completed`, `failed`) move to the activity timeline.
+
+- [ ] **Step 5: Drop and reapply schema for both DBs**
+
+Run:
+
+```bash
+make clean
+DATABASE_URL=postgresql://localhost/mailpilot_test \
+    uv run python -c "from mailpilot.database import initialize_database; initialize_database('postgresql://localhost/mailpilot_test').close()"
+```
+
+Expected: no error from either run. The dev DB (`mailpilot`) is dropped and recreated with the new schema; the test DB is initialized for the upcoming pytest runs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/mailpilot/schema.sql
+git commit -m "refactor(schema): nullable FKs on tag/note/activity, enrollment status collapse"
+```
+
+---
+
+### Task A2: Update `models.py` shapes and type unions
+
+**Files:**
+
+- Modify: `src/mailpilot/models.py:129-140` (Enrollment), `:228-294` (Activity, Tag, Note, EntityType)
+
+- [ ] **Step 1: Update the test for `EnrollmentStatus`**
+
+Edit `tests/test_models.py`. Find the existing test asserting that `EnrollmentStatus` accepts `"pending"` / `"completed"` / `"failed"` and rewrite it to assert only `"active"` and `"paused"` are accepted:
+
+```python
+def test_enrollment_status_literal_is_active_or_paused() -> None:
+    """EnrollmentStatus collapsed to operational state only (#102)."""
+    from typing import get_args
+
+    from mailpilot.models import EnrollmentStatus
+
+    assert set(get_args(EnrollmentStatus)) == {"active", "paused"}
+```
+
+If a similar test exists with the old set, replace it. If none exists, add this one.
+
+- [ ] **Step 2: Update the test for `ActivityType`**
+
+In the same file, replace any `ActivityType` test with:
+
+```python
+def test_activity_type_literal_uses_enrollment_vocabulary() -> None:
+    """workflow_* renamed to enrollment_*; pause/resume added (#102)."""
+    from typing import get_args
+
+    from mailpilot.models import ActivityType
+
+    assert set(get_args(ActivityType)) == {
+        "email_sent",
+        "email_received",
+        "note_added",
+        "tag_added",
+        "tag_removed",
+        "status_changed",
+        "enrollment_added",
+        "enrollment_completed",
+        "enrollment_failed",
+        "enrollment_paused",
+        "enrollment_resumed",
+    }
+```
+
+- [ ] **Step 3: Update the test for `Tag` shape**
+
+In the same file:
+
+```python
+def test_tag_uses_nullable_contact_company_fks() -> None:
+    """Polymorphic entity_type/entity_id replaced with typed FKs (#102 suggestion 1)."""
+    from datetime import UTC, datetime
+
+    from mailpilot.models import Tag
+
+    contact_tag = Tag(
+        id="t1",
+        contact_id="c1",
+        company_id=None,
+        name="prospect",
+        created_at=datetime.now(UTC),
+    )
+    assert contact_tag.contact_id == "c1"
+    assert contact_tag.company_id is None
+    assert not hasattr(contact_tag, "entity_type")
+    assert not hasattr(contact_tag, "entity_id")
+```
+
+- [ ] **Step 4: Update the test for `Note` shape**
+
+```python
+def test_note_uses_nullable_contact_company_fks() -> None:
+    """Polymorphic entity_type/entity_id replaced with typed FKs (#102 suggestion 1)."""
+    from datetime import UTC, datetime
+
+    from mailpilot.models import Note
+
+    note = Note(
+        id="n1",
+        company_id="co1",
+        contact_id=None,
+        body="Met at conf",
+        created_at=datetime.now(UTC),
+    )
+    assert note.company_id == "co1"
+    assert note.contact_id is None
+```
+
+- [ ] **Step 5: Update the test for `Activity` shape**
+
+```python
+def test_activity_supports_company_only_and_structured_fks() -> None:
+    """contact_id is nullable; email_id/workflow_id/task_id added (#102 suggestions 2, 5)."""
+    from datetime import UTC, datetime
+
+    from mailpilot.models import Activity
+
+    company_activity = Activity(
+        id="a1",
+        contact_id=None,
+        company_id="co1",
+        type="note_added",
+        summary="Company note",
+        detail={},
+        created_at=datetime.now(UTC),
+    )
+    assert company_activity.contact_id is None
+    assert company_activity.company_id == "co1"
+
+    email_activity = Activity(
+        id="a2",
+        contact_id="c1",
+        company_id=None,
+        email_id="e1",
+        workflow_id="wf1",
+        type="email_sent",
+        summary="Subject",
+        detail={},
+        created_at=datetime.now(UTC),
+    )
+    assert email_activity.email_id == "e1"
+    assert email_activity.workflow_id == "wf1"
+    assert email_activity.task_id is None
+```
+
+- [ ] **Step 6: Run the model tests, expect failures**
+
+Run: `uv run pytest tests/test_models.py -v`
+Expected: the four new tests fail (old shapes still in place).
+
+- [ ] **Step 7: Update `Enrollment` and `EnrollmentStatus` in `models.py`**
+
+Replace lines 129-140:
+
+```python
+EnrollmentStatus = Literal["active", "paused"]
+
+
+class Enrollment(BaseModel):
+    """A contact's binding to a workflow.
+
+    Status is operational state only -- ``active`` (agent considers this
+    contact when the workflow runs) or ``paused`` (operator/agent has
+    suspended). Outcomes (completed/failed) live in the activity timeline,
+    not in this row.
+    """
+
+    workflow_id: str
+    contact_id: str
+    status: EnrollmentStatus = "active"
+    reason: str = ""
+    created_at: datetime
+    updated_at: datetime
+```
+
+`EnrollmentSummary` already uses `EnrollmentStatus` -- no change to its shape but it now reflects the collapsed set automatically.
+
+- [ ] **Step 8: Update `ActivityType` in `models.py`**
+
+Replace lines 228-238:
+
+```python
+ActivityType = Literal[
+    "email_sent",
+    "email_received",
+    "note_added",
+    "tag_added",
+    "tag_removed",
+    "status_changed",
+    "enrollment_added",
+    "enrollment_completed",
+    "enrollment_failed",
+    "enrollment_paused",
+    "enrollment_resumed",
+]
+```
+
+- [ ] **Step 9: Update `Activity` and `ActivitySummary` in `models.py`**
+
+Replace lines 241-261:
+
+```python
+class Activity(BaseModel):
+    """Chronological event in a contact or company timeline.
+
+    Either ``contact_id`` or ``company_id`` must be set (or both, for
+    contact events that should also surface in the company timeline).
+    Structured FK columns (``email_id``, ``workflow_id``, ``task_id``)
+    let reports join activity to source records without parsing
+    ``detail`` JSON.
+    """
+
+    id: str
+    contact_id: str | None = None
+    company_id: str | None = None
+    email_id: str | None = None
+    workflow_id: str | None = None
+    task_id: str | None = None
+    type: ActivityType
+    summary: str = ""
+    detail: dict[str, object] = {}
+    created_at: datetime
+
+
+class ActivitySummary(BaseModel):
+    """List-view projection of `Activity`."""
+
+    id: str
+    contact_id: str | None
+    company_id: str | None
+    type: ActivityType
+    summary: str
+    created_at: datetime
+```
+
+- [ ] **Step 10: Replace `Tag`, `Note`, `NoteSummary`, drop `EntityType`**
+
+Replace lines 264-294:
+
+```python
+class Tag(BaseModel):
+    """Flexible label on a contact or company for segmentation.
+
+    Exactly one of ``contact_id`` or ``company_id`` is set (XOR enforced
+    at the schema level).
+    """
+
+    id: str
+    contact_id: str | None = None
+    company_id: str | None = None
+    name: str
+    created_at: datetime
+
+
+class Note(BaseModel):
+    """Freeform text annotation on a contact or company.
+
+    Exactly one of ``contact_id`` or ``company_id`` is set (XOR enforced
+    at the schema level).
+    """
+
+    id: str
+    contact_id: str | None = None
+    company_id: str | None = None
+    body: str
+    created_at: datetime
+
+
+class NoteSummary(BaseModel):
+    """List-view projection of `Note` with truncated body preview."""
+
+    id: str
+    contact_id: str | None
+    company_id: str | None
+    body_preview: str
+    created_at: datetime
+```
+
+`EntityType` is removed entirely. If anything outside `models.py` imports it, those imports fail -- they will be fixed in subsequent tasks.
+
+- [ ] **Step 11: Run the model tests**
+
+Run: `uv run pytest tests/test_models.py -v`
+Expected: the four new tests pass. Other tests in the file may fail temporarily because they reference the old shapes -- those are fixed in this same step or in subsequent slices. Spot-check the failures: any failure in `tests/test_models.py` mentioning `entity_type`, `entity_id`, or old `EnrollmentStatus` values (`pending`/`completed`/`failed`) needs the test updated to the new shape. Update them inline.
+
+- [ ] **Step 12: Run full test suite (expected to have widespread failures)**
+
+Run: `uv run pytest -x 2>&1 | head -80`
+Expected: many failures across `test_database.py`, `test_cli.py`, `test_routing.py`, `test_email_ops.py`, `test_sync.py`, `test_agent_tools.py`, `test_agent_invoke.py`. These are the call sites we will fix in slices B and C. Do **not** try to fix them in this task.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add src/mailpilot/models.py tests/test_models.py
+git commit -m "refactor(models): nullable FKs on tag/note/activity; collapse EnrollmentStatus"
+```
+
+---
+
+## Slice B: Database layer
+
+### Task B1: Tag CRUD with nullable FKs and strict normalization
+
+**Files:**
+
+- Modify: `src/mailpilot/database.py:2103-2280` (Tag section)
+- Test: `tests/test_database.py` (Tag tests)
+
+- [ ] **Step 1: Write failing tests for `_normalize_tag_name`**
+
+Add to `tests/test_database.py`:
+
+```python
+def test_normalize_tag_name_accepts_valid_inputs() -> None:
+    """Lowercase, hyphenated, alphanumeric tags pass through unchanged."""
+    from mailpilot.database import _normalize_tag_name
+
+    assert _normalize_tag_name("prospect") == "prospect"
+    assert _normalize_tag_name("hot-lead") == "hot-lead"
+    assert _normalize_tag_name("q4-2025") == "q4-2025"
+
+
+def test_normalize_tag_name_collapses_separators_and_case() -> None:
+    """Whitespace, underscores, and uppercase are normalized; hyphens collapse."""
+    from mailpilot.database import _normalize_tag_name
+
+    assert _normalize_tag_name("Hot Lead") == "hot-lead"
+    assert _normalize_tag_name("hot_lead") == "hot-lead"
+    assert _normalize_tag_name("HOT--LEAD") == "hot-lead"
+    assert _normalize_tag_name("  spaced  ") == "spaced"
+    assert _normalize_tag_name("-leading-trailing-") == "leading-trailing"
+
+
+def test_normalize_tag_name_rejects_invalid() -> None:
+    """Names that cannot be normalized to [a-z0-9][a-z0-9-]* raise ValueError."""
+    import pytest
+
+    from mailpilot.database import _normalize_tag_name
+
+    with pytest.raises(ValueError):
+        _normalize_tag_name("")
+    with pytest.raises(ValueError):
+        _normalize_tag_name("---")
+    with pytest.raises(ValueError):
+        _normalize_tag_name("hot/lead")
+    with pytest.raises(ValueError):
+        _normalize_tag_name("emoji-rocket")  # ok actually
+    # Valid sanity:
+    assert _normalize_tag_name("emoji-rocket") == "emoji-rocket"
+```
+
+(The `emoji-rocket` line is a sanity guard against over-rejecting -- delete the third `with pytest.raises(...)` if it leads to confusion; the regex `[a-z0-9][a-z0-9-]*` does accept it. Keep only the genuine invalid cases above.)
+
+Final form:
+
+```python
+def test_normalize_tag_name_rejects_invalid() -> None:
+    """Names that cannot be normalized to [a-z0-9][a-z0-9-]* raise ValueError."""
+    import pytest
+
+    from mailpilot.database import _normalize_tag_name
+
+    with pytest.raises(ValueError):
+        _normalize_tag_name("")
+    with pytest.raises(ValueError):
+        _normalize_tag_name("---")
+    with pytest.raises(ValueError):
+        _normalize_tag_name("hot/lead")
+    with pytest.raises(ValueError):
+        _normalize_tag_name("hot.lead")
+```
+
+- [ ] **Step 2: Write failing tests for the new tag CRUD shape**
+
+Replace existing `create_tag` / `delete_tag` / `list_tags` / `search_tags` / `list_entities_by_tag` tests with:
+
+```python
+def test_create_contact_tag_and_company_tag(database_connection) -> None:
+    """create_tag accepts contact_id XOR company_id."""
+    from mailpilot.database import (
+        create_company,
+        create_contact,
+        create_tag,
+    )
+
+    company = create_company(database_connection, name="Acme", domain="acme.test")
+    contact = create_contact(
+        database_connection, email="a@acme.test", first_name="A"
+    )
+
+    contact_tag = create_tag(database_connection, contact_id=contact.id, name="prospect")
+    assert contact_tag is not None
+    assert contact_tag.contact_id == contact.id
+    assert contact_tag.company_id is None
+    assert contact_tag.name == "prospect"
+
+    company_tag = create_tag(database_connection, company_id=company.id, name="enterprise")
+    assert company_tag is not None
+    assert company_tag.company_id == company.id
+    assert company_tag.contact_id is None
+
+
+def test_create_tag_requires_exactly_one_owner(database_connection) -> None:
+    """contact_id XOR company_id; passing both or neither raises."""
+    import pytest
+
+    from mailpilot.database import create_tag
+
+    with pytest.raises(ValueError, match="exactly one"):
+        create_tag(database_connection, name="x")
+    with pytest.raises(ValueError, match="exactly one"):
+        create_tag(database_connection, contact_id="c1", company_id="co1", name="x")
+
+
+def test_create_tag_normalizes_name(database_connection) -> None:
+    """create_tag applies _normalize_tag_name."""
+    from mailpilot.database import create_contact, create_tag
+
+    contact = create_contact(database_connection, email="b@acme.test")
+    tag = create_tag(database_connection, contact_id=contact.id, name="Hot Lead")
+    assert tag is not None
+    assert tag.name == "hot-lead"
+
+
+def test_create_tag_idempotent_on_duplicate(database_connection) -> None:
+    """Duplicate insert returns None thanks to ON CONFLICT DO NOTHING."""
+    from mailpilot.database import create_contact, create_tag
+
+    contact = create_contact(database_connection, email="c@acme.test")
+    first = create_tag(database_connection, contact_id=contact.id, name="prospect")
+    second = create_tag(database_connection, contact_id=contact.id, name="prospect")
+    assert first is not None
+    assert second is None
+
+
+def test_delete_tag_by_owner(database_connection) -> None:
+    from mailpilot.database import create_contact, create_tag, delete_tag
+
+    contact = create_contact(database_connection, email="d@acme.test")
+    create_tag(database_connection, contact_id=contact.id, name="cold")
+    assert delete_tag(database_connection, contact_id=contact.id, name="cold") is True
+    assert delete_tag(database_connection, contact_id=contact.id, name="cold") is False
+
+
+def test_list_tags_by_owner(database_connection) -> None:
+    from mailpilot.database import create_contact, create_tag, list_tags
+
+    contact = create_contact(database_connection, email="e@acme.test")
+    create_tag(database_connection, contact_id=contact.id, name="prospect")
+    create_tag(database_connection, contact_id=contact.id, name="cold")
+    tags = list_tags(database_connection, contact_id=contact.id)
+    assert {t.name for t in tags} == {"prospect", "cold"}
+
+
+def test_list_contacts_by_tag_name(database_connection) -> None:
+    from mailpilot.database import create_contact, create_tag, list_contacts_by_tag
+
+    a = create_contact(database_connection, email="x1@acme.test")
+    b = create_contact(database_connection, email="x2@acme.test")
+    create_tag(database_connection, contact_id=a.id, name="hot")
+    create_tag(database_connection, contact_id=b.id, name="hot")
+    ids = list_contacts_by_tag(database_connection, name="hot")
+    assert set(ids) == {a.id, b.id}
+
+
+def test_list_companies_by_tag_name(database_connection) -> None:
+    from mailpilot.database import (
+        create_company,
+        create_tag,
+        list_companies_by_tag,
+    )
+
+    a = create_company(database_connection, name="A", domain="a.test")
+    b = create_company(database_connection, name="B", domain="b.test")
+    create_tag(database_connection, company_id=a.id, name="enterprise")
+    create_tag(database_connection, company_id=b.id, name="enterprise")
+    ids = list_companies_by_tag(database_connection, name="enterprise")
+    assert set(ids) == {a.id, b.id}
+```
+
+- [ ] **Step 3: Run the new tests, expect failures**
+
+Run: `uv run pytest tests/test_database.py -k "tag or normalize" -v`
+Expected: all of the above fail with `AttributeError`, `TypeError`, or `ImportError` because the new functions don't exist yet.
+
+- [ ] **Step 4: Add `_normalize_tag_name` and rewrite Tag CRUD in `database.py`**
+
+In `src/mailpilot/database.py`, near the top of the Tag section (around line 2103), add:
+
+```python
+import re
+
+_TAG_NAME_RE = re.compile(r"[a-z0-9][a-z0-9-]*")
+
+
+def _normalize_tag_name(name: str) -> str:
+    """Normalize a tag name to lowercase hyphenated form.
+
+    Strips whitespace, lowercases, replaces whitespace and underscores
+    with hyphens, collapses repeated hyphens, trims leading/trailing
+    hyphens, and validates against ``[a-z0-9][a-z0-9-]*``.
+
+    Raises:
+        ValueError: If the result is empty or contains disallowed
+        characters.
+    """
+    cleaned = name.strip().lower()
+    cleaned = re.sub(r"[\s_]+", "-", cleaned)
+    cleaned = re.sub(r"-+", "-", cleaned).strip("-")
+    if not _TAG_NAME_RE.fullmatch(cleaned):
+        raise ValueError(f"invalid tag name: {name!r} (normalized to {cleaned!r})")
+    return cleaned
+```
+
+(If `re` is already imported at the top of `database.py`, drop the `import re` line and place `_TAG_NAME_RE` and `_normalize_tag_name` together.)
+
+- [ ] **Step 5: Replace `create_tag`**
+
+Replace the existing `create_tag` function with:
+
+```python
+def create_tag(
+    connection: psycopg.Connection[dict[str, Any]],
+    name: str,
+    contact_id: str | None = None,
+    company_id: str | None = None,
+) -> Tag | None:
+    """Create a tag on a contact or company.
+
+    Exactly one of ``contact_id`` or ``company_id`` must be provided.
+    The name is normalized via ``_normalize_tag_name``. Uses ON CONFLICT
+    DO NOTHING -- returns None if the tag already exists.
+
+    Raises:
+        ValueError: If neither or both of contact_id/company_id are set,
+        or if the tag name fails normalization.
+    """
+    if (contact_id is None) == (company_id is None):
+        raise ValueError("exactly one of contact_id or company_id is required")
+    normalized = _normalize_tag_name(name)
+    row = connection.execute(
+        """\
+        INSERT INTO tag (id, contact_id, company_id, name)
+        VALUES (%(id)s, %(contact_id)s, %(company_id)s, %(name)s)
+        ON CONFLICT DO NOTHING
+        RETURNING *
+        """,
+        {
+            "id": _new_id(),
+            "contact_id": contact_id,
+            "company_id": company_id,
+            "name": normalized,
+        },
+    ).fetchone()
+    connection.commit()
+    if row is None:
+        return None
+    return Tag.model_validate(row)
+```
+
+- [ ] **Step 6: Replace `delete_tag`**
+
+```python
+def delete_tag(
+    connection: psycopg.Connection[dict[str, Any]],
+    name: str,
+    contact_id: str | None = None,
+    company_id: str | None = None,
+) -> bool:
+    """Remove a tag from a contact or company.
+
+    Raises:
+        ValueError: If neither or both of contact_id/company_id are set.
+    """
+    if (contact_id is None) == (company_id is None):
+        raise ValueError("exactly one of contact_id or company_id is required")
+    normalized = _normalize_tag_name(name)
+    if contact_id is not None:
+        cursor = connection.execute(
+            "DELETE FROM tag WHERE contact_id = %(contact_id)s AND name = %(name)s",
+            {"contact_id": contact_id, "name": normalized},
+        )
+    else:
+        cursor = connection.execute(
+            "DELETE FROM tag WHERE company_id = %(company_id)s AND name = %(name)s",
+            {"company_id": company_id, "name": normalized},
+        )
+    connection.commit()
+    return cursor.rowcount > 0
+```
+
+- [ ] **Step 7: Replace `list_tags`**
+
+```python
+def list_tags(
+    connection: psycopg.Connection[dict[str, Any]],
+    contact_id: str | None = None,
+    company_id: str | None = None,
+    limit: int = 100,
+    since: str | None = None,
+) -> list[Tag]:
+    """List tags on a contact or company.
+
+    Tag has no Summary projection -- the full row already matches the
+    summary contract.
+
+    Raises:
+        ValueError: If neither or both of contact_id/company_id are set.
+    """
+    if (contact_id is None) == (company_id is None):
+        raise ValueError("exactly one of contact_id or company_id is required")
+    params: dict[str, object] = {"limit": limit}
+    where_parts: list[Composed | SQL] = []
+    if contact_id is not None:
+        where_parts.append(SQL("contact_id = %(contact_id)s"))
+        params["contact_id"] = contact_id
+    else:
+        where_parts.append(SQL("company_id = %(company_id)s"))
+        params["company_id"] = company_id
+    if since is not None:
+        where_parts.append(SQL("created_at >= %(since)s"))
+        params["since"] = since
+    where = SQL("WHERE ") + SQL(" AND ").join(where_parts)
+    query = SQL("SELECT * FROM tag {} ORDER BY name LIMIT %(limit)s").format(where)
+    rows = connection.execute(query, params).fetchall()
+    return [Tag.model_validate(row) for row in rows]
+```
+
+- [ ] **Step 8: Replace `list_entities_by_tag` with `list_contacts_by_tag` and `list_companies_by_tag`**
+
+Delete `list_entities_by_tag`. Add:
+
+```python
+def list_contacts_by_tag(
+    connection: psycopg.Connection[dict[str, Any]],
+    name: str,
+    limit: int = 100,
+) -> list[str]:
+    """Return contact IDs with the given tag (normalized)."""
+    normalized = _normalize_tag_name(name)
+    rows = connection.execute(
+        """\
+        SELECT contact_id FROM tag
+        WHERE contact_id IS NOT NULL AND name = %(name)s
+        ORDER BY created_at
+        LIMIT %(limit)s
+        """,
+        {"name": normalized, "limit": limit},
+    ).fetchall()
+    return [row["contact_id"] for row in rows]
+
+
+def list_companies_by_tag(
+    connection: psycopg.Connection[dict[str, Any]],
+    name: str,
+    limit: int = 100,
+) -> list[str]:
+    """Return company IDs with the given tag (normalized)."""
+    normalized = _normalize_tag_name(name)
+    rows = connection.execute(
+        """\
+        SELECT company_id FROM tag
+        WHERE company_id IS NOT NULL AND name = %(name)s
+        ORDER BY created_at
+        LIMIT %(limit)s
+        """,
+        {"name": normalized, "limit": limit},
+    ).fetchall()
+    return [row["company_id"] for row in rows]
+```
+
+- [ ] **Step 9: Replace `search_tags`**
+
+```python
+def search_tags(
+    connection: psycopg.Connection[dict[str, Any]],
+    name: str,
+    owner: str | None = None,
+    limit: int = 100,
+) -> list[Tag]:
+    """Search tags by name pattern with optional owner filter.
+
+    Args:
+        owner: ``"contact"`` to limit to contact tags, ``"company"`` to
+            limit to company tags, ``None`` for both.
+    """
+    if owner not in (None, "contact", "company"):
+        raise ValueError("owner must be 'contact', 'company', or None")
+    pattern = f"%{name.strip().lower()}%"
+    params: dict[str, object] = {"pattern": pattern, "limit": limit}
+    owner_filter = SQL("")
+    if owner == "contact":
+        owner_filter = SQL("AND contact_id IS NOT NULL")
+    elif owner == "company":
+        owner_filter = SQL("AND company_id IS NOT NULL")
+    query = SQL(
+        "SELECT * FROM tag WHERE name LIKE %(pattern)s {} "
+        "ORDER BY name LIMIT %(limit)s"
+    ).format(owner_filter)
+    rows = connection.execute(query, params).fetchall()
+    return [Tag.model_validate(row) for row in rows]
+```
+
+- [ ] **Step 10: Run the tag tests**
+
+Run: `uv run pytest tests/test_database.py -k "tag or normalize" -v`
+Expected: PASS for all the tests added in Steps 1 and 2.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/mailpilot/database.py tests/test_database.py
+git commit -m "refactor(db): tag CRUD uses nullable FKs; add strict normalization"
+```
+
+---
+
+### Task B2: Note CRUD with nullable FKs
+
+**Files:**
+
+- Modify: `src/mailpilot/database.py:2283-` (Note section)
+- Test: `tests/test_database.py` (Note tests)
+
+- [ ] **Step 1: Write failing tests for the new note CRUD shape**
+
+Replace existing `create_note` / `list_notes` tests in `tests/test_database.py`:
+
+```python
+def test_create_contact_note_and_company_note(database_connection) -> None:
+    from mailpilot.database import (
+        create_company,
+        create_contact,
+        create_note,
+    )
+
+    contact = create_contact(database_connection, email="n1@acme.test")
+    contact_note = create_note(
+        database_connection, contact_id=contact.id, body="Met at conf"
+    )
+    assert contact_note.contact_id == contact.id
+    assert contact_note.company_id is None
+
+    company = create_company(database_connection, name="Acme", domain="acme.test")
+    company_note = create_note(
+        database_connection, company_id=company.id, body="Tier 1 account"
+    )
+    assert company_note.company_id == company.id
+    assert company_note.contact_id is None
+
+
+def test_create_note_requires_exactly_one_owner(database_connection) -> None:
+    import pytest
+
+    from mailpilot.database import create_note
+
+    with pytest.raises(ValueError, match="exactly one"):
+        create_note(database_connection, body="x")
+    with pytest.raises(ValueError, match="exactly one"):
+        create_note(
+            database_connection, contact_id="c1", company_id="co1", body="x"
+        )
+
+
+def test_list_notes_by_owner(database_connection) -> None:
+    from mailpilot.database import (
+        create_contact,
+        create_note,
+        list_notes,
+    )
+
+    contact = create_contact(database_connection, email="n2@acme.test")
+    create_note(database_connection, contact_id=contact.id, body="first")
+    create_note(database_connection, contact_id=contact.id, body="second")
+    summaries = list_notes(database_connection, contact_id=contact.id)
+    assert len(summaries) == 2
+    assert all(s.contact_id == contact.id for s in summaries)
+```
+
+- [ ] **Step 2: Run, expect failures**
+
+Run: `uv run pytest tests/test_database.py -k note -v`
+Expected: failures.
+
+- [ ] **Step 3: Replace `create_note`**
+
+```python
+def create_note(
+    connection: psycopg.Connection[dict[str, Any]],
+    body: str,
+    contact_id: str | None = None,
+    company_id: str | None = None,
+) -> Note:
+    """Create a freeform note on a contact or company.
+
+    Raises:
+        ValueError: If neither or both of contact_id/company_id are set.
+    """
+    if (contact_id is None) == (company_id is None):
+        raise ValueError("exactly one of contact_id or company_id is required")
+    row = connection.execute(
+        """\
+        INSERT INTO note (id, contact_id, company_id, body)
+        VALUES (%(id)s, %(contact_id)s, %(company_id)s, %(body)s)
+        RETURNING *
+        """,
+        {
+            "id": _new_id(),
+            "contact_id": contact_id,
+            "company_id": company_id,
+            "body": body,
+        },
+    ).fetchone()
+    connection.commit()
+    return Note.model_validate(row)
+```
+
+- [ ] **Step 4: Replace `list_notes`**
+
+```python
+def list_notes(
+    connection: psycopg.Connection[dict[str, Any]],
+    contact_id: str | None = None,
+    company_id: str | None = None,
+    limit: int = 100,
+    since: str | None = None,
+) -> list[NoteSummary]:
+    """List notes on a contact or company as summaries with body previews.
+
+    Raises:
+        ValueError: If neither or both of contact_id/company_id are set.
+    """
+    if (contact_id is None) == (company_id is None):
+        raise ValueError("exactly one of contact_id or company_id is required")
+    params: dict[str, object] = {"limit": limit}
+    where_parts: list[Composed | SQL] = []
+    if contact_id is not None:
+        where_parts.append(SQL("contact_id = %(contact_id)s"))
+        params["contact_id"] = contact_id
+    else:
+        where_parts.append(SQL("company_id = %(company_id)s"))
+        params["company_id"] = company_id
+    if since is not None:
+        where_parts.append(SQL("created_at >= %(since)s"))
+        params["since"] = since
+    where = SQL("WHERE ") + SQL(" AND ").join(where_parts)
+    query = SQL(
+        "SELECT id, contact_id, company_id, "
+        "CASE WHEN length(body) > 80 THEN substring(body, 1, 80) || '...' "
+        "     ELSE body END AS body_preview, "
+        "created_at "
+        "FROM note {} ORDER BY created_at DESC LIMIT %(limit)s"
+    ).format(where)
+    rows = connection.execute(query, params).fetchall()
+    return [NoteSummary.model_validate(row) for row in rows]
+```
+
+(Confirm the existing implementation already does the body-preview computation in SQL. If it instead does it in Python after `SELECT *`, keep that style and just swap the WHERE clauses. Read the current implementation before editing.)
+
+- [ ] **Step 5: Run note tests, expect pass**
+
+Run: `uv run pytest tests/test_database.py -k note -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/mailpilot/database.py tests/test_database.py
+git commit -m "refactor(db): note CRUD uses nullable FKs"
+```
+
+---
+
+### Task B3: Activity CRUD with structured FK columns and company-only support
+
+**Files:**
+
+- Modify: `src/mailpilot/database.py:2008-2100` (Activity section)
+- Test: `tests/test_database.py` (Activity tests)
+
+- [ ] **Step 1: Write failing tests for the new activity shape**
+
+Add to `tests/test_database.py` (replacing equivalent older tests):
+
+```python
+def test_create_activity_with_structured_fks(database_connection) -> None:
+    """email_id, workflow_id, task_id are first-class FK columns (#102 sugg 5)."""
+    from mailpilot.database import (
+        create_account,
+        create_activity,
+        create_contact,
+        create_email,
+        create_workflow,
+    )
+
+    account = create_account(
+        database_connection, email="op@example.test", display_name="Op"
+    )
+    contact = create_contact(database_connection, email="ct@example.test")
+    workflow = create_workflow(
+        database_connection,
+        account_id=account.id,
+        type="outbound",
+        name="Test WF",
+    )
+    email = create_email(
+        database_connection,
+        account_id=account.id,
+        contact_id=contact.id,
+        direction="outbound",
+        subject="Hi",
+        body_text="hi",
+    )
+    assert email is not None
+
+    activity = create_activity(
+        database_connection,
+        contact_id=contact.id,
+        activity_type="email_sent",
+        summary="Hi",
+        email_id=email.id,
+        workflow_id=workflow.id,
+    )
+    assert activity.email_id == email.id
+    assert activity.workflow_id == workflow.id
+    assert activity.task_id is None
+
+
+def test_create_activity_company_only(database_connection) -> None:
+    """contact_id is nullable when company_id is provided (#102 sugg 2)."""
+    from mailpilot.database import create_activity, create_company
+
+    company = create_company(database_connection, name="Acme", domain="acme.test")
+    activity = create_activity(
+        database_connection,
+        company_id=company.id,
+        activity_type="note_added",
+        summary="Company note",
+    )
+    assert activity.contact_id is None
+    assert activity.company_id == company.id
+
+
+def test_create_activity_requires_contact_or_company(database_connection) -> None:
+    import pytest
+
+    from mailpilot.database import create_activity
+
+    with pytest.raises(ValueError, match="contact_id or company_id"):
+        create_activity(
+            database_connection,
+            activity_type="note_added",
+            summary="orphan",
+        )
+```
+
+- [ ] **Step 2: Run, expect failures**
+
+Run: `uv run pytest tests/test_database.py -k activity -v`
+Expected: failures.
+
+- [ ] **Step 3: Replace `create_activity`**
+
+```python
+def create_activity(
+    connection: psycopg.Connection[dict[str, Any]],
+    activity_type: str,
+    summary: str = "",
+    detail: dict[str, object] | None = None,
+    contact_id: str | None = None,
+    company_id: str | None = None,
+    email_id: str | None = None,
+    workflow_id: str | None = None,
+    task_id: str | None = None,
+) -> Activity:
+    """Create an activity event.
+
+    At least one of ``contact_id`` or ``company_id`` must be set.
+    Structured FK columns (``email_id``, ``workflow_id``, ``task_id``)
+    let reports join activity to source records without parsing
+    ``detail`` JSON.
+
+    Raises:
+        ValueError: If neither contact_id nor company_id is provided.
+    """
+    if contact_id is None and company_id is None:
+        raise ValueError("at least one of contact_id or company_id is required")
+    row = connection.execute(
+        """\
+        INSERT INTO activity (
+            id, contact_id, company_id, email_id, workflow_id, task_id,
+            type, summary, detail
+        )
+        VALUES (
+            %(id)s, %(contact_id)s, %(company_id)s, %(email_id)s,
+            %(workflow_id)s, %(task_id)s,
+            %(type)s, %(summary)s, %(detail)s
+        )
+        RETURNING *
+        """,
+        {
+            "id": _new_id(),
+            "contact_id": contact_id,
+            "company_id": company_id,
+            "email_id": email_id,
+            "workflow_id": workflow_id,
+            "task_id": task_id,
+            "type": activity_type,
+            "summary": summary,
+            "detail": Json(detail or {}),
+        },
+    ).fetchone()
+    connection.commit()
+    return Activity.model_validate(row)
+```
+
+- [ ] **Step 4: `list_activities` -- no signature change required**
+
+The existing `list_activities` already accepts `contact_id` and `company_id` filters and returns `ActivitySummary`. The summary now has a nullable `contact_id` (already handled by the model change in A2). No code change here unless the SQL projection lists columns that no longer match -- if so, update the `SELECT` clause to match the new `ActivitySummary` shape:
+
+```python
+"SELECT id, contact_id, company_id, type, summary, created_at "
+"FROM activity {} ORDER BY created_at DESC LIMIT %(limit)s"
+```
+
+(Verify line 2095-2098. The existing projection already matches.)
+
+- [ ] **Step 5: Run activity tests, expect pass**
+
+Run: `uv run pytest tests/test_database.py -k activity -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/mailpilot/database.py tests/test_database.py
+git commit -m "refactor(db): activity supports company-only and structured FK columns"
+```
+
+---
+
+### Task B4: Atomic helpers for tag/note + activity writes
+
+**Files:**
+
+- Modify: `src/mailpilot/database.py` (Tag and Note sections, after the basic CRUD)
+- Test: `tests/test_database.py`
+
+These helpers combine the tag/note insert and the corresponding activity insert in a single transaction, addressing suggestion #4.
+
+- [ ] **Step 1: Write failing tests for the atomic helpers**
+
+Add to `tests/test_database.py`:
+
+```python
+def test_add_contact_tag_emits_activity_atomically(database_connection) -> None:
+    """add_contact_tag writes tag + tag_added activity in one transaction."""
+    from mailpilot.database import (
+        add_contact_tag,
+        create_contact,
+        list_activities,
+        list_tags,
+    )
+
+    contact = create_contact(database_connection, email="atomic@acme.test")
+    tag = add_contact_tag(database_connection, contact_id=contact.id, name="prospect")
+    assert tag is not None
+    assert tag.name == "prospect"
+    assert [t.name for t in list_tags(database_connection, contact_id=contact.id)] == [
+        "prospect"
+    ]
+    activities = list_activities(database_connection, contact_id=contact.id)
+    assert len(activities) == 1
+    assert activities[0].type == "tag_added"
+    assert activities[0].summary == "Tagged as prospect"
+
+
+def test_add_contact_tag_returns_none_on_duplicate_no_activity(
+    database_connection,
+) -> None:
+    """Duplicate tag insert returns None and emits no activity."""
+    from mailpilot.database import (
+        add_contact_tag,
+        create_contact,
+        list_activities,
+    )
+
+    contact = create_contact(database_connection, email="dup@acme.test")
+    add_contact_tag(database_connection, contact_id=contact.id, name="prospect")
+    second = add_contact_tag(
+        database_connection, contact_id=contact.id, name="prospect"
+    )
+    assert second is None
+    activities = list_activities(database_connection, contact_id=contact.id)
+    assert len(activities) == 1  # only the first tag's activity
+
+
+def test_remove_contact_tag_emits_activity_atomically(database_connection) -> None:
+    from mailpilot.database import (
+        add_contact_tag,
+        create_contact,
+        list_activities,
+        remove_contact_tag,
+    )
+
+    contact = create_contact(database_connection, email="rm@acme.test")
+    add_contact_tag(database_connection, contact_id=contact.id, name="cold")
+    assert (
+        remove_contact_tag(database_connection, contact_id=contact.id, name="cold")
+        is True
+    )
+    types = [a.type for a in list_activities(database_connection, contact_id=contact.id)]
+    assert "tag_removed" in types
+
+
+def test_add_company_tag_emits_company_activity(database_connection) -> None:
+    from mailpilot.database import (
+        add_company_tag,
+        create_company,
+        list_activities,
+    )
+
+    company = create_company(database_connection, name="Acme", domain="acme.test")
+    add_company_tag(database_connection, company_id=company.id, name="enterprise")
+    activities = list_activities(database_connection, company_id=company.id)
+    assert len(activities) == 1
+    assert activities[0].type == "tag_added"
+    assert activities[0].company_id == company.id
+    assert activities[0].contact_id is None
+
+
+def test_add_contact_note_emits_activity_atomically(database_connection) -> None:
+    from mailpilot.database import (
+        add_contact_note,
+        create_contact,
+        list_activities,
+        list_notes,
+    )
+
+    contact = create_contact(database_connection, email="note@acme.test")
+    note = add_contact_note(
+        database_connection, contact_id=contact.id, body="quick note"
+    )
+    notes = list_notes(database_connection, contact_id=contact.id)
+    assert [n.id for n in notes] == [note.id]
+    activities = list_activities(database_connection, contact_id=contact.id)
+    assert len(activities) == 1
+    assert activities[0].type == "note_added"
+
+
+def test_add_company_note_emits_company_activity(database_connection) -> None:
+    from mailpilot.database import (
+        add_company_note,
+        create_company,
+        list_activities,
+    )
+
+    company = create_company(database_connection, name="Acme", domain="acme.test")
+    add_company_note(database_connection, company_id=company.id, body="ent")
+    activities = list_activities(database_connection, company_id=company.id)
+    assert len(activities) == 1
+    assert activities[0].type == "note_added"
+    assert activities[0].company_id == company.id
+```
+
+- [ ] **Step 2: Run tests, expect failures (functions don't exist)**
+
+Run: `uv run pytest tests/test_database.py -k "add_contact or add_company or remove_contact or remove_company" -v`
+Expected: failures with `AttributeError` or `ImportError`.
+
+- [ ] **Step 3: Implement `add_contact_tag`**
+
+In the Tag section of `database.py`, after `create_tag`:
+
+```python
+def add_contact_tag(
+    connection: psycopg.Connection[dict[str, Any]],
+    contact_id: str,
+    name: str,
+) -> Tag | None:
+    """Add a tag to a contact and emit a `tag_added` activity atomically.
+
+    The two writes share one transaction. Returns ``None`` if the tag
+    already exists -- in that case no activity is written.
+    """
+    normalized = _normalize_tag_name(name)
+    contact_row = connection.execute(
+        "SELECT company_id FROM contact WHERE id = %s", (contact_id,)
+    ).fetchone()
+    if contact_row is None:
+        raise ValueError(f"contact not found: {contact_id}")
+    tag_row = connection.execute(
+        """\
+        INSERT INTO tag (id, contact_id, company_id, name)
+        VALUES (%(id)s, %(contact_id)s, NULL, %(name)s)
+        ON CONFLICT DO NOTHING
+        RETURNING *
+        """,
+        {"id": _new_id(), "contact_id": contact_id, "name": normalized},
+    ).fetchone()
+    if tag_row is None:
+        connection.commit()
+        return None
+    connection.execute(
+        """\
+        INSERT INTO activity (
+            id, contact_id, company_id, type, summary, detail
+        )
+        VALUES (
+            %(id)s, %(contact_id)s, %(company_id)s,
+            'tag_added', %(summary)s, %(detail)s
+        )
+        """,
+        {
+            "id": _new_id(),
+            "contact_id": contact_id,
+            "company_id": contact_row["company_id"],
+            "summary": f"Tagged as {normalized}",
+            "detail": Json({"tag": normalized}),
+        },
+    )
+    connection.commit()
+    return Tag.model_validate(tag_row)
+```
+
+- [ ] **Step 4: Implement `add_company_tag`**
+
+```python
+def add_company_tag(
+    connection: psycopg.Connection[dict[str, Any]],
+    company_id: str,
+    name: str,
+) -> Tag | None:
+    """Add a tag to a company and emit a `tag_added` company activity atomically."""
+    normalized = _normalize_tag_name(name)
+    if (
+        connection.execute(
+            "SELECT 1 FROM company WHERE id = %s", (company_id,)
+        ).fetchone()
+        is None
+    ):
+        raise ValueError(f"company not found: {company_id}")
+    tag_row = connection.execute(
+        """\
+        INSERT INTO tag (id, contact_id, company_id, name)
+        VALUES (%(id)s, NULL, %(company_id)s, %(name)s)
+        ON CONFLICT DO NOTHING
+        RETURNING *
+        """,
+        {"id": _new_id(), "company_id": company_id, "name": normalized},
+    ).fetchone()
+    if tag_row is None:
+        connection.commit()
+        return None
+    connection.execute(
+        """\
+        INSERT INTO activity (
+            id, contact_id, company_id, type, summary, detail
+        )
+        VALUES (
+            %(id)s, NULL, %(company_id)s,
+            'tag_added', %(summary)s, %(detail)s
+        )
+        """,
+        {
+            "id": _new_id(),
+            "company_id": company_id,
+            "summary": f"Tagged as {normalized}",
+            "detail": Json({"tag": normalized}),
+        },
+    )
+    connection.commit()
+    return Tag.model_validate(tag_row)
+```
+
+- [ ] **Step 5: Implement `remove_contact_tag` and `remove_company_tag`**
+
+```python
+def remove_contact_tag(
+    connection: psycopg.Connection[dict[str, Any]],
+    contact_id: str,
+    name: str,
+) -> bool:
+    """Remove a tag from a contact and emit a `tag_removed` activity atomically."""
+    normalized = _normalize_tag_name(name)
+    contact_row = connection.execute(
+        "SELECT company_id FROM contact WHERE id = %s", (contact_id,)
+    ).fetchone()
+    if contact_row is None:
+        raise ValueError(f"contact not found: {contact_id}")
+    cursor = connection.execute(
+        "DELETE FROM tag WHERE contact_id = %s AND name = %s",
+        (contact_id, normalized),
+    )
+    if cursor.rowcount == 0:
+        connection.commit()
+        return False
+    connection.execute(
+        """\
+        INSERT INTO activity (
+            id, contact_id, company_id, type, summary, detail
+        )
+        VALUES (
+            %(id)s, %(contact_id)s, %(company_id)s,
+            'tag_removed', %(summary)s, %(detail)s
+        )
+        """,
+        {
+            "id": _new_id(),
+            "contact_id": contact_id,
+            "company_id": contact_row["company_id"],
+            "summary": f"Removed tag {normalized}",
+            "detail": Json({"tag": normalized}),
+        },
+    )
+    connection.commit()
+    return True
+
+
+def remove_company_tag(
+    connection: psycopg.Connection[dict[str, Any]],
+    company_id: str,
+    name: str,
+) -> bool:
+    """Remove a tag from a company and emit a `tag_removed` activity atomically."""
+    normalized = _normalize_tag_name(name)
+    cursor = connection.execute(
+        "DELETE FROM tag WHERE company_id = %s AND name = %s",
+        (company_id, normalized),
+    )
+    if cursor.rowcount == 0:
+        connection.commit()
+        return False
+    connection.execute(
+        """\
+        INSERT INTO activity (
+            id, contact_id, company_id, type, summary, detail
+        )
+        VALUES (
+            %(id)s, NULL, %(company_id)s,
+            'tag_removed', %(summary)s, %(detail)s
+        )
+        """,
+        {
+            "id": _new_id(),
+            "company_id": company_id,
+            "summary": f"Removed tag {normalized}",
+            "detail": Json({"tag": normalized}),
+        },
+    )
+    connection.commit()
+    return True
+```
+
+- [ ] **Step 6: Implement `add_contact_note` and `add_company_note`**
+
+In the Note section of `database.py`, after `create_note`:
+
+```python
+def add_contact_note(
+    connection: psycopg.Connection[dict[str, Any]],
+    contact_id: str,
+    body: str,
+) -> Note:
+    """Add a note to a contact and emit a `note_added` activity atomically."""
+    contact_row = connection.execute(
+        "SELECT company_id FROM contact WHERE id = %s", (contact_id,)
+    ).fetchone()
+    if contact_row is None:
+        raise ValueError(f"contact not found: {contact_id}")
+    note_row = connection.execute(
+        """\
+        INSERT INTO note (id, contact_id, company_id, body)
+        VALUES (%(id)s, %(contact_id)s, NULL, %(body)s)
+        RETURNING *
+        """,
+        {"id": _new_id(), "contact_id": contact_id, "body": body},
+    ).fetchone()
+    note = Note.model_validate(note_row)
+    connection.execute(
+        """\
+        INSERT INTO activity (
+            id, contact_id, company_id, type, summary, detail
+        )
+        VALUES (
+            %(id)s, %(contact_id)s, %(company_id)s,
+            'note_added', %(summary)s, %(detail)s
+        )
+        """,
+        {
+            "id": _new_id(),
+            "contact_id": contact_id,
+            "company_id": contact_row["company_id"],
+            "summary": "Note added",
+            "detail": Json({"note_id": note.id}),
+        },
+    )
+    connection.commit()
+    return note
+
+
+def add_company_note(
+    connection: psycopg.Connection[dict[str, Any]],
+    company_id: str,
+    body: str,
+) -> Note:
+    """Add a note to a company and emit a `note_added` company activity atomically."""
+    if (
+        connection.execute(
+            "SELECT 1 FROM company WHERE id = %s", (company_id,)
+        ).fetchone()
+        is None
+    ):
+        raise ValueError(f"company not found: {company_id}")
+    note_row = connection.execute(
+        """\
+        INSERT INTO note (id, contact_id, company_id, body)
+        VALUES (%(id)s, NULL, %(company_id)s, %(body)s)
+        RETURNING *
+        """,
+        {"id": _new_id(), "company_id": company_id, "body": body},
+    ).fetchone()
+    note = Note.model_validate(note_row)
+    connection.execute(
+        """\
+        INSERT INTO activity (
+            id, contact_id, company_id, type, summary, detail
+        )
+        VALUES (
+            %(id)s, NULL, %(company_id)s,
+            'note_added', %(summary)s, %(detail)s
+        )
+        """,
+        {
+            "id": _new_id(),
+            "company_id": company_id,
+            "summary": "Note added",
+            "detail": Json({"note_id": note.id}),
+        },
+    )
+    connection.commit()
+    return note
+```
+
+- [ ] **Step 7: Run atomic-helper tests, expect pass**
+
+Run: `uv run pytest tests/test_database.py -k "add_contact or add_company or remove_contact or remove_company" -v`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/mailpilot/database.py tests/test_database.py
+git commit -m "feat(db): atomic helpers for tag/note + activity writes"
+```
+
+---
+
+### Task B5: Drop pending-state activation in enrollment update
+
+**Files:**
+
+- Modify: `src/mailpilot/database.py:1144-1170` (`list_enrollments`), and any test fixture that defaulted enrollment status to `'pending'`
+- Test: `tests/test_database.py`
+
+The schema default is now `'active'`. `list_enrollments` already accepts an optional `status` filter -- the only change is that callers can no longer pass `'pending'`/`'completed'`/`'failed'`.
+
+- [ ] **Step 1: Update enrollment-status tests**
+
+In `tests/test_database.py`, find any test that asserts `enrollment.status == "pending"` after `create_enrollment` and update it:
+
+```python
+def test_create_enrollment_defaults_to_active(database_connection) -> None:
+    """Enrollment defaults to 'active' (status collapse, comment #4334976677)."""
+    from mailpilot.database import (
+        create_account,
+        create_contact,
+        create_enrollment,
+        create_workflow,
+    )
+
+    account = create_account(
+        database_connection, email="op2@example.test", display_name="Op"
+    )
+    workflow = create_workflow(
+        database_connection,
+        account_id=account.id,
+        type="outbound",
+        name="Test WF B5",
+    )
+    contact = create_contact(database_connection, email="b5@acme.test")
+
+    enrollment = create_enrollment(
+        database_connection, workflow_id=workflow.id, contact_id=contact.id
+    )
+    assert enrollment is not None
+    assert enrollment.status == "active"
+```
+
+Find any tests asserting `enrollment.status == "completed"` after `update_enrollment`. Replace with assertions that `update_enrollment` only allows `'active'`/`'paused'` (the schema CHECK enforces this; the test verifies the call raises a `psycopg.errors.CheckViolation` or equivalent on bad input).
+
+```python
+def test_update_enrollment_rejects_legacy_statuses(database_connection) -> None:
+    """`completed`/`failed`/`pending` are no longer valid enrollment statuses."""
+    import psycopg
+
+    from mailpilot.database import (
+        create_account,
+        create_contact,
+        create_enrollment,
+        create_workflow,
+        update_enrollment,
+    )
+
+    account = create_account(
+        database_connection, email="op3@example.test", display_name="Op"
+    )
+    workflow = create_workflow(
+        database_connection,
+        account_id=account.id,
+        type="outbound",
+        name="Test WF B5b",
+    )
+    contact = create_contact(database_connection, email="b5b@acme.test")
+    create_enrollment(
+        database_connection, workflow_id=workflow.id, contact_id=contact.id
+    )
+
+    for bad in ("pending", "completed", "failed"):
+        with pytest.raises((psycopg.errors.CheckViolation, ValueError)):
+            update_enrollment(
+                database_connection,
+                workflow.id,
+                contact.id,
+                status=bad,
+            )
+        database_connection.rollback()
+```
+
+(`pytest` import may already be at the top of the file; if not, add it.)
+
+- [ ] **Step 2: Run enrollment tests**
+
+Run: `uv run pytest tests/test_database.py -k enrollment -v`
+Expected: PASS, given the schema CHECK from Task A1.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_database.py
+git commit -m "test(db): enrollment defaults to active; legacy statuses rejected"
+```
+
+---
+
+## Slice C: Callers (routing, sync, email_ops, agent, CLI)
+
+### Task C1: Update routing to emit `enrollment_added` with workflow FK
+
+**Files:**
+
+- Modify: `src/mailpilot/routing.py:316-340` (`_ensure_enrollment`)
+- Test: `tests/test_routing.py`
+
+- [ ] **Step 1: Update the routing test**
+
+Find the test in `tests/test_routing.py` that asserts a `workflow_assigned` activity is created. Replace `workflow_assigned` with `enrollment_added` and add an assertion that `workflow_id` is populated as a column (not just inside `detail`):
+
+```python
+def test_route_email_emits_enrollment_added_activity(...) -> None:
+    ...
+    activities = list_activities(connection, contact_id=contact.id)
+    assert any(
+        a.type == "enrollment_added" for a in activities
+    )
+    full = get_activity(connection, activities[0].id) if False else None  # see note
+    # If list_activities returns summaries, hydrate via a direct SELECT:
+    row = connection.execute(
+        "SELECT workflow_id FROM activity WHERE type = 'enrollment_added' "
+        "AND contact_id = %s",
+        (contact.id,),
+    ).fetchone()
+    assert row is not None
+    assert row["workflow_id"] == workflow.id
+```
+
+(Adjust the test to whatever fixture/setup already exists. The minimum required change is renaming the activity type and asserting `workflow_id` is present in the row.)
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `uv run pytest tests/test_routing.py -k enrollment -v`
+Expected: FAIL because routing still emits `workflow_assigned` and doesn't pass `workflow_id` to `create_activity`.
+
+- [ ] **Step 3: Update `_ensure_enrollment` in `routing.py`**
+
+Replace lines 316-340:
+
+```python
+def _ensure_enrollment(
+    connection: psycopg.Connection[dict[str, Any]],
+    workflow_id: str,
+    contact_id: str,
+) -> None:
+    """Create an enrollment entry if not already present.
+
+    Emits an ``enrollment_added`` activity only on the initial insert --
+    ``create_enrollment`` returns ``None`` on ON CONFLICT so re-routes
+    in the same thread do not duplicate the timeline entry.
+    """
+    enrollment = create_enrollment(connection, workflow_id, contact_id)
+    if enrollment is None:
+        return
+    workflow = get_workflow(connection, workflow_id)
+    contact = get_contact(connection, contact_id)
+    workflow_name = workflow.name if workflow is not None else ""
+    create_activity(
+        connection,
+        contact_id=contact_id,
+        activity_type="enrollment_added",
+        summary=f"Assigned to {workflow_name or 'workflow'}",
+        detail={"workflow_name": workflow_name},
+        company_id=contact.company_id if contact is not None else None,
+        workflow_id=workflow_id,
+    )
+```
+
+`workflow_id` moves out of `detail` and into the structured FK column.
+
+- [ ] **Step 4: Run routing tests, expect pass**
+
+Run: `uv run pytest tests/test_routing.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mailpilot/routing.py tests/test_routing.py
+git commit -m "refactor(routing): emit enrollment_added activity with workflow FK"
+```
+
+---
+
+### Task C2: Drop pending-state activation in `email_ops.py`; pass FKs in `email_sent` activity
+
+**Files:**
+
+- Modify: `src/mailpilot/email_ops.py:76-109`
+- Test: `tests/test_email_ops.py`
+
+- [ ] **Step 1: Update email_ops tests**
+
+In `tests/test_email_ops.py`:
+
+1. Delete any test that asserts `enrollment.status` transitions from `"pending"` to `"active"` on send (this state no longer exists).
+2. Update the `email_sent` activity test to assert `email_id` and `workflow_id` are present as FK columns:
+
+```python
+def test_send_email_emits_email_sent_activity_with_fks(...) -> None:
+    ...
+    row = connection.execute(
+        "SELECT contact_id, email_id, workflow_id FROM activity "
+        "WHERE type = 'email_sent' AND contact_id = %s",
+        (contact.id,),
+    ).fetchone()
+    assert row is not None
+    assert row["email_id"] == email.id
+    assert row["workflow_id"] == workflow.id
+```
+
+- [ ] **Step 2: Run, expect failures**
+
+Run: `uv run pytest tests/test_email_ops.py -v`
+Expected: failures because of the dropped pending behavior and missing FK columns.
+
+- [ ] **Step 3: Remove `_activate_enrollment_if_pending` and update `_emit_email_sent_activity`**
+
+In `src/mailpilot/email_ops.py`:
+
+1. Delete the `_activate_enrollment_if_pending` function entirely (lines 76-89).
+2. Remove every call site of `_activate_enrollment_if_pending` in this file -- the call disappears completely; sending no longer touches enrollment status.
+3. Replace `_emit_email_sent_activity` with:
+
+```python
+def _emit_email_sent_activity(
+    connection: psycopg.Connection[dict[str, Any]],
+    contact: Contact,
+    email: Email,
+    workflow_id: str | None,
+) -> None:
+    database.create_activity(
+        connection,
+        contact_id=contact.id,
+        activity_type="email_sent",
+        summary=email.subject,
+        detail={"subject": email.subject},
+        company_id=contact.company_id,
+        email_id=email.id,
+        workflow_id=workflow_id,
+    )
+```
+
+`email_id` and `workflow_id` move out of `detail` into structured columns.
+
+- [ ] **Step 4: Run email_ops tests, expect pass**
+
+Run: `uv run pytest tests/test_email_ops.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mailpilot/email_ops.py tests/test_email_ops.py
+git commit -m "refactor(email_ops): drop pending-state activation; add structured activity FKs"
+```
+
+---
+
+### Task C3: Pass `email_id` FK in `email_received` activity (sync.py)
+
+**Files:**
+
+- Modify: `src/mailpilot/sync.py:777-784`
+- Test: `tests/test_sync.py`
+
+- [ ] **Step 1: Update sync test**
+
+In `tests/test_sync.py`, find the test asserting `email_received` activity creation and add an FK column assertion:
+
+```python
+row = connection.execute(
+    "SELECT email_id FROM activity "
+    "WHERE type = 'email_received' AND contact_id = %s",
+    (contact.id,),
+).fetchone()
+assert row is not None
+assert row["email_id"] == stored_email.id
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `uv run pytest tests/test_sync.py -k received -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Update the call site**
+
+Replace lines 777-784 in `src/mailpilot/sync.py`:
+
+```python
+    create_activity(
+        connection,
+        contact_id=contact.id,
+        activity_type="email_received",
+        summary=email.subject,
+        detail={"subject": email.subject},
+        company_id=contact.company_id,
+        email_id=email.id,
+    )
+```
+
+- [ ] **Step 4: Run sync tests, expect pass**
+
+Run: `uv run pytest tests/test_sync.py -k received -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mailpilot/sync.py tests/test_sync.py
+git commit -m "refactor(sync): pass email_id FK in email_received activity"
+```
+
+---
+
+### Task C4: Replace `update_enrollment_status` agent tool with `record_enrollment_outcome`
+
+**Files:**
+
+- Modify: `src/mailpilot/agent/tools.py:175-222`
+- Modify: `src/mailpilot/agent/invoke.py:181-310`
+- Test: `tests/test_agent_tools.py`, `tests/test_agent_invoke.py`
+
+- [ ] **Step 1: Write failing tests for `record_enrollment_outcome`**
+
+In `tests/test_agent_tools.py`, replace the existing `update_enrollment_status` tests with:
+
+```python
+def test_record_enrollment_outcome_completed_writes_activity_only(
+    database_connection,
+) -> None:
+    """outcome='completed' emits enrollment_completed activity, no status change."""
+    from mailpilot.agent.tools import record_enrollment_outcome
+    from mailpilot.database import (
+        create_account,
+        create_contact,
+        create_enrollment,
+        create_workflow,
+        get_enrollment,
+        list_activities,
+    )
+
+    account = create_account(
+        database_connection, email="op4@example.test", display_name="Op"
+    )
+    workflow = create_workflow(
+        database_connection,
+        account_id=account.id,
+        type="outbound",
+        name="C4 WF",
+    )
+    contact = create_contact(database_connection, email="c4@acme.test")
+    create_enrollment(database_connection, workflow.id, contact.id)
+
+    result = record_enrollment_outcome(
+        database_connection,
+        workflow_id=workflow.id,
+        contact_id=contact.id,
+        outcome="completed",
+        reason="meeting booked",
+    )
+    assert result == {"outcome": "completed", "reason": "meeting booked"}
+
+    enrollment = get_enrollment(database_connection, workflow.id, contact.id)
+    assert enrollment is not None
+    assert enrollment.status == "active"  # unchanged
+
+    activities = list_activities(database_connection, contact_id=contact.id)
+    types = [a.type for a in activities]
+    assert "enrollment_completed" in types
+
+
+def test_record_enrollment_outcome_failed(database_connection) -> None:
+    """outcome='failed' emits enrollment_failed activity."""
+    from mailpilot.agent.tools import record_enrollment_outcome
+    from mailpilot.database import (
+        create_account,
+        create_contact,
+        create_enrollment,
+        create_workflow,
+        list_activities,
+    )
+
+    account = create_account(
+        database_connection, email="op5@example.test", display_name="Op"
+    )
+    workflow = create_workflow(
+        database_connection,
+        account_id=account.id,
+        type="outbound",
+        name="C4 WF B",
+    )
+    contact = create_contact(database_connection, email="c4b@acme.test")
+    create_enrollment(database_connection, workflow.id, contact.id)
+
+    record_enrollment_outcome(
+        database_connection,
+        workflow_id=workflow.id,
+        contact_id=contact.id,
+        outcome="failed",
+        reason="no response",
+    )
+    types = [
+        a.type for a in list_activities(database_connection, contact_id=contact.id)
+    ]
+    assert "enrollment_failed" in types
+
+
+def test_record_enrollment_outcome_rejects_invalid_outcome(database_connection) -> None:
+    from mailpilot.agent.tools import record_enrollment_outcome
+
+    result = record_enrollment_outcome(
+        database_connection,
+        workflow_id="wf1",
+        contact_id="c1",
+        outcome="cancelled",
+        reason="x",
+    )
+    assert result.get("error") == "invalid_outcome"
+
+
+def test_record_enrollment_outcome_missing_enrollment(database_connection) -> None:
+    from mailpilot.agent.tools import record_enrollment_outcome
+
+    result = record_enrollment_outcome(
+        database_connection,
+        workflow_id="wf-nonexistent",
+        contact_id="c-nonexistent",
+        outcome="completed",
+        reason="x",
+    )
+    assert result.get("error") == "not_found"
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `uv run pytest tests/test_agent_tools.py -k record_enrollment_outcome -v`
+Expected: ImportError (function doesn't exist).
+
+- [ ] **Step 3: Replace the tool implementation in `agent/tools.py`**
+
+Replace `update_enrollment_status` (lines 175-222) with:
+
+```python
+def record_enrollment_outcome(
+    connection: psycopg.Connection[dict[str, Any]],
+    workflow_id: str,
+    contact_id: str,
+    outcome: str,
+    reason: str,
+) -> dict[str, str]:
+    """Record an outcome (completed or failed) on the activity timeline.
+
+    Outcome is purely a timeline event -- the enrollment row's status is
+    not modified. The agent declares the engagement done; if a later
+    inbound reply arrives, the agent can react without first
+    "reactivating" anything.
+
+    Args:
+        connection: Open database connection.
+        workflow_id: Current workflow FK.
+        contact_id: Contact ID.
+        outcome: "completed" or "failed".
+        reason: Agent's explanation (e.g., "meeting booked", "no response").
+
+    Returns:
+        Dict with the recorded outcome, or an error dict if the
+        enrollment is missing or the outcome is invalid.
+    """
+    valid_outcomes = ("completed", "failed")
+    if outcome not in valid_outcomes:
+        return {
+            "error": "invalid_outcome",
+            "message": f"outcome must be one of {valid_outcomes}, got: {outcome}",
+        }
+    enrollment = database.get_enrollment(connection, workflow_id, contact_id)
+    if enrollment is None:
+        return {
+            "error": "not_found",
+            "message": f"enrollment not found: {workflow_id}/{contact_id}",
+        }
+    contact = database.get_contact(connection, contact_id)
+    database.create_activity(
+        connection,
+        contact_id=contact_id,
+        activity_type=f"enrollment_{outcome}",
+        summary=reason or f"Enrollment {outcome}",
+        detail={"reason": reason},
+        company_id=contact.company_id if contact is not None else None,
+        workflow_id=workflow_id,
+    )
+    return {"outcome": outcome, "reason": reason}
+```
+
+Also update the module docstring (lines 12-22) to replace `update_enrollment_status` with `record_enrollment_outcome`.
+
+- [ ] **Step 4: Update `agent/invoke.py` wrapper, registration, and prompt**
+
+In `src/mailpilot/agent/invoke.py`:
+
+1. Rename `_wrap_update_enrollment_status` -> `_wrap_record_enrollment_outcome`. Update its body to call `agent_tools.record_enrollment_outcome` with `outcome` instead of `status`:
+
+```python
+def _wrap_record_enrollment_outcome(
+    ctx: RunContext[AgentDeps], outcome: str, reason: str
+) -> dict[str, str]:
+    """Record an enrollment outcome (completed or failed) on the timeline."""
+    return agent_tools.record_enrollment_outcome(
+        ctx.deps.connection,
+        workflow_id=ctx.deps.workflow_id,
+        contact_id=ctx.deps.contact_id,
+        outcome=outcome,
+        reason=reason,
+    )
+```
+
+2. Update the `_TOOLS` registration:
+
+```python
+Tool(_wrap_record_enrollment_outcome, name="record_enrollment_outcome"),
+```
+
+3. Update `_SYSTEM_PREFIX` -- the existing line that mentions `update_enrollment_status with status='completed'` becomes:
+
+```python
+"record_enrollment_outcome with outcome='completed' and a brief reason.\n\n"
+```
+
+- [ ] **Step 5: Update `tests/test_agent_invoke.py`**
+
+Find any test asserting that `update_enrollment_status` is registered or that the system prompt mentions it. Replace with `record_enrollment_outcome`. Run: `grep -n update_enrollment_status tests/test_agent_invoke.py` to find the exact lines.
+
+- [ ] **Step 6: Run agent tests, expect pass**
+
+Run: `uv run pytest tests/test_agent_tools.py tests/test_agent_invoke.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/mailpilot/agent/tools.py src/mailpilot/agent/invoke.py \
+        tests/test_agent_tools.py tests/test_agent_invoke.py
+git commit -m "refactor(agent): replace update_enrollment_status with record_enrollment_outcome"
+```
+
+---
+
+### Task C5: CLI tag commands use atomic helpers
+
+**Files:**
+
+- Modify: `src/mailpilot/cli.py:1086-1254` (tag group)
+- Test: `tests/test_cli.py`
+
+- [ ] **Step 1: Update CLI tag tests**
+
+In `tests/test_cli.py`, find tag-related tests. Update patches:
+
+- Replace `mailpilot.database.create_tag` patches with `mailpilot.database.add_contact_tag` and `mailpilot.database.add_company_tag`.
+- Replace `mailpilot.database.delete_tag` patches with `remove_contact_tag` / `remove_company_tag`.
+- Existing tests asserting that `create_activity` is also called separately should be removed -- the activity is now part of the atomic helper.
+
+Add a new test for invalid tag names:
+
+```python
+def test_tag_add_rejects_invalid_name(runner, patch_database) -> None:
+    result = runner.invoke(cli.main, ["tag", "add", "--contact-id", "c1", "hot/lead"])
+    assert result.exit_code != 0
+    assert "invalid tag" in result.output.lower()
+```
+
+- [ ] **Step 2: Rewrite the `tag add` CLI command**
+
+Replace lines 1086-1143 in `src/mailpilot/cli.py`:
+
+```python
+@tag.command("add")
+@click.option("--contact-id", default=None, help="Contact ID.")
+@click.option("--company-id", default=None, help="Company ID.")
+@click.argument("name")
+def tag_add(contact_id: str | None, company_id: str | None, name: str) -> None:
+    """Add a tag to a contact or company."""
+    from mailpilot.database import (
+        add_company_tag,
+        add_contact_tag,
+        get_company,
+        get_contact,
+        initialize_database,
+    )
+
+    if not name.strip():
+        output_error("tag name cannot be empty", "validation_error")
+    if (contact_id is None) == (company_id is None):
+        output_error(
+            "exactly one of --contact-id or --company-id is required",
+            "validation_error",
+        )
+    connection = initialize_database(_database_url())
+    try:
+        if contact_id is not None:
+            if get_contact(connection, contact_id) is None:
+                output_error(f"contact {contact_id} not found", "not_found")
+            try:
+                created = add_contact_tag(connection, contact_id=contact_id, name=name)
+            except ValueError as exc:
+                output_error(str(exc), "validation_error")
+            owner = ("contact", contact_id)
+        else:
+            assert company_id is not None
+            if get_company(connection, company_id) is None:
+                output_error(f"company {company_id} not found", "not_found")
+            try:
+                created = add_company_tag(connection, company_id=company_id, name=name)
+            except ValueError as exc:
+                output_error(str(exc), "validation_error")
+            owner = ("company", company_id)
+        if created is None:
+            from mailpilot.database import _normalize_tag_name
+
+            normalized = _normalize_tag_name(name)
+            output_error(
+                f"tag '{normalized}' already exists on {owner[0]} {owner[1]}",
+                "already_exists",
+            )
+        output(created.model_dump(mode="json"))
+    finally:
+        connection.close()
+```
+
+- [ ] **Step 3: Rewrite the `tag remove` CLI command**
+
+Replace lines 1146-1193:
+
+```python
+@tag.command("remove")
+@click.option("--contact-id", default=None, help="Contact ID.")
+@click.option("--company-id", default=None, help="Company ID.")
+@click.argument("name")
+def tag_remove(contact_id: str | None, company_id: str | None, name: str) -> None:
+    """Remove a tag from a contact or company."""
+    from mailpilot.database import (
+        get_company,
+        get_contact,
+        initialize_database,
+        remove_company_tag,
+        remove_contact_tag,
+    )
+
+    if (contact_id is None) == (company_id is None):
+        output_error(
+            "exactly one of --contact-id or --company-id is required",
+            "validation_error",
+        )
+    connection = initialize_database(_database_url())
+    try:
+        if contact_id is not None:
+            if get_contact(connection, contact_id) is None:
+                output_error(f"contact {contact_id} not found", "not_found")
+            try:
+                deleted = remove_contact_tag(
+                    connection, contact_id=contact_id, name=name
+                )
+            except ValueError as exc:
+                output_error(str(exc), "validation_error")
+            owner = ("contact", contact_id)
+        else:
+            assert company_id is not None
+            if get_company(connection, company_id) is None:
+                output_error(f"company {company_id} not found", "not_found")
+            try:
+                deleted = remove_company_tag(
+                    connection, company_id=company_id, name=name
+                )
+            except ValueError as exc:
+                output_error(str(exc), "validation_error")
+            owner = ("company", company_id)
+        from mailpilot.database import _normalize_tag_name
+
+        normalized = _normalize_tag_name(name)
+        if not deleted:
+            output_error(
+                f"tag '{normalized}' not found on {owner[0]} {owner[1]}",
+                "not_found",
+            )
+        output({"removed": True, "tag": normalized, "owner_type": owner[0]})
+    finally:
+        connection.close()
+```
+
+- [ ] **Step 4: Update `tag list` and `tag search`**
+
+Replace `entity_type` / `entity_id` plumbing in `tag list` (lines 1196-1232):
+
+```python
+@tag.command("list")
+@click.option("--contact-id", default=None, help="Contact ID.")
+@click.option("--company-id", default=None, help="Company ID.")
+@click.option("--limit", default=100, help="Maximum results.")
+@click.option("--since", default=None, help="ISO datetime lower bound on created_at.")
+def tag_list(
+    contact_id: str | None,
+    company_id: str | None,
+    limit: int,
+    since: str | None,
+) -> None:
+    """List tags on a contact or company."""
+    from mailpilot.database import (
+        get_company,
+        get_contact,
+        initialize_database,
+        list_tags,
+    )
+
+    if (contact_id is None) == (company_id is None):
+        output_error(
+            "exactly one of --contact-id or --company-id is required",
+            "validation_error",
+        )
+    connection = initialize_database(_database_url())
+    try:
+        if contact_id is not None:
+            if get_contact(connection, contact_id) is None:
+                output_error(f"contact {contact_id} not found", "not_found")
+            tags = list_tags(
+                connection, contact_id=contact_id, limit=limit, since=since
+            )
+        else:
+            assert company_id is not None
+            if get_company(connection, company_id) is None:
+                output_error(f"company {company_id} not found", "not_found")
+            tags = list_tags(
+                connection, company_id=company_id, limit=limit, since=since
+            )
+        output({"tags": [t.model_dump(mode="json") for t in tags]})
+    finally:
+        connection.close()
+```
+
+Update `tag search` to map `--type` -> `owner` parameter on `search_tags`:
+
+```python
+@tag.command("search")
+@click.argument("name")
+@click.option(
+    "--type",
+    "owner",
+    default=None,
+    type=click.Choice(["contact", "company"]),
+    help="Filter by owner type.",
+)
+@click.option("--limit", default=100, help="Maximum results.")
+def tag_search(name: str, owner: str | None, limit: int) -> None:
+    """Search tags by name."""
+    from mailpilot.database import initialize_database, search_tags
+
+    connection = initialize_database(_database_url())
+    try:
+        tags = search_tags(connection, name=name, owner=owner, limit=limit)
+        output({"tags": [t.model_dump(mode="json") for t in tags]})
+    finally:
+        connection.close()
+```
+
+- [ ] **Step 5: Delete the now-unused `_resolve_entity` helper**
+
+If `_resolve_entity` (lines around 1075-1083) is no longer referenced after the changes above, delete it. Run `grep -n _resolve_entity src/mailpilot/cli.py` to confirm; if note commands still reference it, leave it for now and remove in Task C6.
+
+- [ ] **Step 6: Run CLI tag tests**
+
+Run: `uv run pytest tests/test_cli.py -k tag -v`
+Expected: PASS (with patches updated in Step 1).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/mailpilot/cli.py tests/test_cli.py
+git commit -m "refactor(cli): tag commands use atomic helpers; XOR contact/company"
+```
+
+---
+
+### Task C6: CLI note commands use atomic helpers
+
+**Files:**
+
+- Modify: `src/mailpilot/cli.py:1265-1316` (`note add`) and `note list` block
+
+- [ ] **Step 1: Update CLI note tests**
+
+In `tests/test_cli.py`, update patches: `create_note` -> `add_contact_note`/`add_company_note`. Drop assertions that `create_activity` is called separately for note adds.
+
+- [ ] **Step 2: Rewrite `note add`**
+
+Replace lines 1265-1316 in `src/mailpilot/cli.py`:
+
+```python
+@note.command("add")
+@click.option("--contact-id", default=None, help="Contact ID.")
+@click.option("--company-id", default=None, help="Company ID.")
+@click.option("--body", required=True, help="Note text.")
+def note_add(contact_id: str | None, company_id: str | None, body: str) -> None:
+    """Add a note to a contact or company."""
+    from mailpilot.database import (
+        add_company_note,
+        add_contact_note,
+        get_company,
+        get_contact,
+        initialize_database,
+    )
+
+    if not body.strip():
+        output_error("note body cannot be empty", "validation_error")
+    if (contact_id is None) == (company_id is None):
+        output_error(
+            "exactly one of --contact-id or --company-id is required",
+            "validation_error",
+        )
+    connection = initialize_database(_database_url())
+    try:
+        if contact_id is not None:
+            if get_contact(connection, contact_id) is None:
+                output_error(f"contact {contact_id} not found", "not_found")
+            created = add_contact_note(
+                connection, contact_id=contact_id, body=body
+            )
+        else:
+            assert company_id is not None
+            if get_company(connection, company_id) is None:
+                output_error(f"company {company_id} not found", "not_found")
+            created = add_company_note(
+                connection, company_id=company_id, body=body
+            )
+        output(created.model_dump(mode="json"))
+    finally:
+        connection.close()
+```
+
+- [ ] **Step 3: Rewrite `note list`**
+
+Find the existing `note list` command (around line 1319+) and replace its `_resolve_entity` plumbing with the same XOR pattern, calling `list_notes(connection, contact_id=...)` or `list_notes(connection, company_id=...)`.
+
+- [ ] **Step 4: Delete `_resolve_entity` if unused**
+
+After `tag` and `note` no longer call it, delete `_resolve_entity`. Run `grep -n _resolve_entity src/mailpilot/cli.py`; if zero matches, delete the function.
+
+- [ ] **Step 5: Run CLI note tests**
+
+Run: `uv run pytest tests/test_cli.py -k note -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/mailpilot/cli.py tests/test_cli.py
+git commit -m "refactor(cli): note commands use atomic helpers; XOR contact/company"
+```
+
+---
+
+### Task C7: CLI activity commands -- new vocabulary, company-only support
+
+**Files:**
+
+- Modify: `src/mailpilot/cli.py:18-30` (`_ACTIVITY_TYPES`), `:962-1014` (`activity create`)
+
+- [ ] **Step 1: Update `_ACTIVITY_TYPES` constant**
+
+Replace lines 18-30 (the `_ACTIVITY_TYPES` tuple) with:
+
+```python
+_ACTIVITY_TYPES = (
+    "email_sent",
+    "email_received",
+    "note_added",
+    "tag_added",
+    "tag_removed",
+    "status_changed",
+    "enrollment_added",
+    "enrollment_completed",
+    "enrollment_failed",
+    "enrollment_paused",
+    "enrollment_resumed",
+)
+```
+
+- [ ] **Step 2: Update CLI activity tests**
+
+In `tests/test_cli.py`, find tests that pass `--type workflow_assigned` etc. to `activity create`. Replace with `enrollment_added`. Add a test for company-only:
+
+```python
+def test_activity_create_supports_company_only(runner, patch_database) -> None:
+    result = runner.invoke(
+        cli.main,
+        [
+            "activity",
+            "create",
+            "--company-id",
+            "co1",
+            "--type",
+            "note_added",
+            "--summary",
+            "Company note",
+        ],
+    )
+    assert result.exit_code == 0
+```
+
+- [ ] **Step 3: Rewrite `activity create`**
+
+Replace lines 967-1013:
+
+```python
+@activity.command("create")
+@click.option("--contact-id", default=None, help="Contact ID.")
+@click.option("--company-id", default=None, help="Optional company ID.")
+@click.option(
+    "--type",
+    "activity_type",
+    required=True,
+    type=click.Choice(_ACTIVITY_TYPES),
+    help="Activity type.",
+)
+@click.option("--summary", required=True, help="One-line description.")
+@click.option("--detail", default=None, help="JSON detail payload.")
+def activity_create(
+    contact_id: str | None,
+    company_id: str | None,
+    activity_type: str,
+    summary: str,
+    detail: str | None,
+) -> None:
+    """Create an activity event. At least one of --contact-id / --company-id."""
+    from mailpilot.database import (
+        create_activity,
+        get_company,
+        get_contact,
+        initialize_database,
+    )
+
+    if not summary.strip():
+        output_error("summary cannot be empty", "validation_error")
+    if contact_id is None and company_id is None:
+        output_error(
+            "at least one of --contact-id or --company-id is required",
+            "validation_error",
+        )
+    detail_dict: dict[str, object] = json.loads(detail) if detail else {}
+    connection = initialize_database(_database_url())
+    try:
+        if contact_id is not None and get_contact(connection, contact_id) is None:
+            output_error(f"contact not found: {contact_id}", "not_found")
+        if company_id is not None and get_company(connection, company_id) is None:
+            output_error(f"company not found: {company_id}", "not_found")
+        created = create_activity(
+            connection,
+            contact_id=contact_id,
+            company_id=company_id,
+            activity_type=activity_type,
+            summary=summary,
+            detail=detail_dict,
+        )
+        output(created.model_dump(mode="json"))
+    finally:
+        connection.close()
+```
+
+- [ ] **Step 4: Run CLI activity tests**
+
+Run: `uv run pytest tests/test_cli.py -k activity -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mailpilot/cli.py tests/test_cli.py
+git commit -m "refactor(cli): activity vocabulary uses enrollment_*; allow company-only create"
+```
+
+---
+
+### Task C8: CLI enrollment update -- active/paused only; emit pause/resume activity
+
+**Files:**
+
+- Modify: `src/mailpilot/cli.py:1840-1926` (enrollment list and update)
+
+- [ ] **Step 1: Update CLI enrollment tests**
+
+In `tests/test_cli.py`:
+
+1. Replace any `--status pending|completed|failed` invocations with `--status active|paused`.
+2. Update assertions that previously checked `workflow_completed`/`workflow_failed` activity emission via `enrollment update` -- those are gone (the agent records outcomes now). The CLI's `enrollment update` only emits `enrollment_paused` / `enrollment_resumed` activities on transitions.
+3. Add tests:
+
+```python
+def test_enrollment_update_paused_emits_activity(runner, patch_database) -> None:
+    ...
+    # invoke enrollment update --status paused
+    # assert enrollment_paused activity present
+
+
+def test_enrollment_update_active_emits_resumed_activity(runner, patch_database) -> None:
+    ...
+    # paused -> active emits enrollment_resumed
+```
+
+- [ ] **Step 2: Rewrite `enrollment list` status choice**
+
+Replace the `--status` choice at line 1843-1848 with:
+
+```python
+@click.option(
+    "--status",
+    default=None,
+    type=click.Choice(["active", "paused"]),
+    help="Filter by enrollment status.",
+)
+```
+
+- [ ] **Step 3: Rewrite `enrollment update`**
+
+Replace lines 1885-1926 with:
+
+```python
+@enrollment.command("update")
+@click.option("--workflow-id", required=True, help="Workflow ID.")
+@click.option("--contact-id", required=True, help="Contact ID.")
+@click.option(
+    "--status",
+    required=True,
+    type=click.Choice(["active", "paused"]),
+    help="New enrollment status (active or paused).",
+)
+@click.option("--reason", default=None, help="Status reason.")
+def enrollment_update(
+    workflow_id: str, contact_id: str, status: str, reason: str | None
+) -> None:
+    """Update enrollment operational status (active or paused).
+
+    Outcomes (completed, failed) are recorded as activity by the agent
+    via record_enrollment_outcome -- not via this command.
+    """
+    from mailpilot.database import (
+        create_activity,
+        get_contact,
+        get_enrollment,
+        initialize_database,
+        update_enrollment,
+    )
+
+    connection = initialize_database(_database_url())
+    try:
+        before = get_enrollment(connection, workflow_id, contact_id)
+        if before is None:
+            output_error("enrollment not found", "not_found")
+        fields: dict[str, object] = {"status": status}
+        if reason is not None:
+            fields["reason"] = reason
+        updated = update_enrollment(connection, workflow_id, contact_id, **fields)
+        if updated is None:
+            output_error("enrollment not found", "not_found")
+        if before.status != status:
+            contact = get_contact(connection, contact_id)
+            activity_type = (
+                "enrollment_paused" if status == "paused" else "enrollment_resumed"
+            )
+            create_activity(
+                connection,
+                contact_id=contact_id,
+                activity_type=activity_type,
+                summary=reason or f"Enrollment {status}",
+                detail={"reason": reason or ""},
+                company_id=contact.company_id if contact is not None else None,
+                workflow_id=workflow_id,
+            )
+        output(updated.model_dump(mode="json"))
+    finally:
+        connection.close()
+```
+
+- [ ] **Step 4: Run CLI enrollment tests**
+
+Run: `uv run pytest tests/test_cli.py -k enrollment -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest -v 2>&1 | tail -30`
+Expected: 0 failures. If any remain, they're stragglers from the earlier slices -- fix in this commit.
+
+- [ ] **Step 6: Run lint and types**
+
+Run: `uv run ruff format && uv run ruff check --fix && uv run basedpyright`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/mailpilot/cli.py tests/test_cli.py
+git commit -m "refactor(cli): enrollment update accepts active|paused only"
+```
+
+---
+
+## Slice D: ADR rewrite, CLAUDE.md, and verification
+
+### Task D1: Rewrite `docs/adr-08-crm-design.md`
+
+**Files:**
+
+- Modify: `docs/adr-08-crm-design.md`
+
+- [ ] **Step 1: Rewrite the ADR body**
+
+Replace the existing content with the structure below. Keep the existing H1 (`# ADR-08: CRM Design -- Activity Timeline, Tags, and Notes`) and Status sections.
+
+```markdown
+## Status
+
+Accepted.
+
+## Context
+
+MailPilot is a CRM with Gmail as the primary communication channel. Claude Code is the strategic orchestrator and primary operator; an internal Pydantic AI agent handles real-time tactical work within workflows.
+
+To support relationship reporting, segmentation, and freeform annotation, the schema includes three tables beyond the core (account, company, contact, workflow, enrollment, email, task, sync_status):
+
+- `activity` -- unified per-contact and per-company timeline.
+- `tag` -- flexible label on contacts or companies.
+- `note` -- freeform text annotation on contacts or companies.
+
+## Decision
+
+### Identity
+
+MailPilot is a CRM. Gmail is the channel. The CLI is the operator surface for Claude Code.
+
+### `activity` -- typed FKs, contact-or-company
+
+Every significant event is an immutable row. Either `contact_id` or `company_id` (or both) is set. Structured FK columns -- `email_id`, `workflow_id`, `task_id` -- let reports join activity to source records without parsing JSON. `detail` JSONB remains for type-specific metadata that does not need to be queryable as a column.
+
+Composite indexes `idx_activity_contact_timeline (contact_id, created_at DESC)` and `idx_activity_company_timeline (company_id, created_at DESC)` serve the common "newest-first timeline for this entity" query.
+
+Activity vocabulary:
+
+- `email_sent`, `email_received` -- send/receive on the Gmail channel.
+- `note_added` -- note created on contact or company.
+- `tag_added`, `tag_removed` -- tag mutations.
+- `status_changed` -- contact-level lifecycle (bounced, unsubscribed).
+- `enrollment_added` -- contact joined a workflow.
+- `enrollment_completed`, `enrollment_failed` -- agent-declared outcomes (timeline-only, not state on enrollment).
+- `enrollment_paused`, `enrollment_resumed` -- operator pause/resume.
+
+### `tag` -- typed nullable FKs (no polymorphism)
+
+`tag.contact_id` and `tag.company_id` are both nullable. A CHECK constraint enforces XOR (exactly one is set). Two partial unique indexes on `(contact_id, name)` and `(company_id, name)` prevent duplicates within an owner.
+
+Tag names are normalized to lowercase, hyphenated form via `_normalize_tag_name`: whitespace and underscores collapse to single hyphens, repeated hyphens collapse, leading/trailing hyphens are trimmed. The result must match `[a-z0-9][a-z0-9-]*`. Names that fail validation raise `ValueError` -- there is no silent salvage.
+
+### `note` -- typed nullable FKs
+
+Same XOR pattern as `tag`. Notes are append-only.
+
+### `enrollment.status` -- operational only
+
+States: `active` (agent considers this contact when the workflow runs) and `paused` (operator/agent has suspended). Outcomes (`completed`, `failed`) live entirely in the activity timeline as `enrollment_completed` / `enrollment_failed` events. The relationship persists across declared outcomes -- a late inbound reply does not require a state transition.
+
+### Atomic timeline writes
+
+Combined helpers in `database.py` write the domain row and its activity in a single transaction:
+
+- `add_contact_tag` / `add_company_tag` / `remove_contact_tag` / `remove_company_tag`
+- `add_contact_note` / `add_company_note`
+
+CLI commands and other callers use these helpers instead of two separate writes.
+
+### Activity creation in runtime paths
+
+| Trigger                          | Module                                       | Activity                                                        |
+| -------------------------------- | -------------------------------------------- | --------------------------------------------------------------- |
+| Outbound send                    | `email_ops.py`                               | `email_sent` (with `email_id`, `workflow_id` FKs)               |
+| Inbound store                    | `sync.py`                                    | `email_received` (with `email_id` FK)                           |
+| Routing -> enrollment created    | `routing.py`                                 | `enrollment_added` (with `workflow_id` FK)                      |
+| Agent declares outcome           | `agent/tools.py` `record_enrollment_outcome` | `enrollment_completed` / `enrollment_failed`                    |
+| CLI `enrollment update`          | `cli.py`                                     | `enrollment_paused` / `enrollment_resumed` (on transition only) |
+| CLI `tag add/remove`, `note add` | `cli.py` via atomic helper                   | `tag_added` / `tag_removed` / `note_added`                      |
+
+## Consequences
+
+### Positive
+
+- One unified timeline for relationship reporting, joinable to source records via real FKs.
+- Maximum segmentation flexibility through tags; no premature commitment to pipeline stages.
+- Database-level referential integrity on every CRM relationship (no orphans from polymorphic FKs).
+- Simple enrollment state -- two states, no terminal/reactivation problem; outcomes are timeline events.
+- Atomic timeline writes prevent CRM/timeline divergence on partial failures.
+- Strict tag normalization prevents operational drift (`Hot Lead`, `hot_lead`, `hot--lead` collapse to a single canonical form).
+
+### Negative
+
+- "Which enrollments completed?" requires querying the activity timeline rather than filtering enrollment.status. Acceptable at solo-consultant volume; can be optimized with a materialized view if it becomes a bottleneck.
+- Activity table grows unboundedly. Acceptable for current volume; if it exceeds 100K rows, add retention or archival.
+- Tag normalization rejects some inputs that the previous lenient `strip().lower()` would have silently accepted. CLI surfaces a `validation_error` so the operator can correct.
+```
+
+(Replace existing body. Keep top-level H1 and Status sections.)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/adr-08-crm-design.md
+git commit -m "docs(adr): rewrite ADR-08 to match implemented CRM design"
+```
+
+---
+
+### Task D2: Update `CLAUDE.md`
+
+**Files:**
+
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Update the CRM Model section**
+
+Find the `### CRM Model` section in `CLAUDE.md`. Update the paragraphs about Tag, Note, Activity, and add a paragraph about enrollment status:
+
+```markdown
+- **Contact** -- a person with an email address. May belong to a company.
+- **Company** -- an organization identified by domain.
+- **Tag** -- flexible label on a contact or company. Each row sets exactly one of `contact_id` or `company_id` (XOR). Tag names are strictly normalized to `[a-z0-9][a-z0-9-]*`; invalid names raise. Convention: lowercase, hyphenated (e.g., `prospect`, `logistics`, `cold`). No formal pipeline stages -- tags are freeform.
+- **Note** -- freeform text annotation on a contact or company. Same XOR pattern as Tag. Append-only.
+- **Activity** -- chronological event log per contact and/or company. At least one of `contact_id` / `company_id` must be set. Structured FK columns (`email_id`, `workflow_id`, `task_id`) let reports join without parsing `detail` JSON. Activities are append-only.
+- **Enrollment** -- contact's binding to a workflow. Status is operational state only: `active` (agent runs against it) or `paused`. Outcomes (`completed`, `failed`) are recorded as activity events via the agent's `record_enrollment_outcome` tool, not as enrollment state.
+- **Workflow** -- binds an account to agent instructions for email communication (inbound or outbound). Unchanged from prior design (see `docs/adr-03-workflow-model.md`).
+```
+
+- [ ] **Step 2: Update the CLI command reference**
+
+Find `mailpilot enrollment update` in the CLI block. Replace its options block with:
+
+```
+mailpilot enrollment update --workflow-id ID --contact-id ID --status active|paused [--reason R]
+```
+
+(Drop `pending`, `completed`, `failed` from the help text. The agent's outcome path is documented separately if needed.)
+
+Find `mailpilot activity create` and update to reflect company-only support:
+
+```
+mailpilot activity create [--contact-id ID] [--company-id ID] --type TYPE --summary TEXT [--detail JSON]
+```
+
+(At least one of `--contact-id` / `--company-id` is required.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(claude): reflect ADR-08 refinements in project instructions"
+```
+
+---
+
+### Task D3: End-to-end verification
+
+- [ ] **Step 1: Reset both DBs cleanly**
+
+```bash
+make clean
+DATABASE_URL=postgresql://localhost/mailpilot_test \
+    uv run python -c "from mailpilot.database import initialize_database; initialize_database('postgresql://localhost/mailpilot_test').close()"
+```
+
+Expected: no error.
+
+- [ ] **Step 2: Run the full check**
+
+```bash
+make check
+```
+
+Expected: lint + types + tests all green.
+
+- [ ] **Step 3: Run the smoke test**
+
+Invoke the `/smoke-test` skill (see `.claude/skills/smoke-test/SKILL.md`). It exercises the full agent loop against `outbound@lab5.ca` <-> `inbound@lab5.ca`. Verify:
+
+- An outbound `email_sent` activity exists for the test contact, with `email_id` and `workflow_id` set as columns (not just inside `detail`).
+- An inbound `email_received` activity exists, with `email_id` set.
+- An `enrollment_added` activity was emitted on the first route, with `workflow_id` set.
+- If the agent declares an outcome, an `enrollment_completed` or `enrollment_failed` activity exists; the enrollment row's status remains `active`.
+- Tag/note add operations on a test contact create the domain row and the corresponding activity in one transaction (no orphan tag/note without an activity).
+
+Verify by running:
+
+```bash
+mailpilot activity list --contact-id <TEST_CONTACT_ID> --limit 50
+```
+
+- [ ] **Step 4: Open the PR**
+
+Use `/github-pr-create` with issue 102 referenced. The PR title should be along the lines of `refactor(crm): apply ADR-08 refinements (#102)`. Body should list each suggestion (1-8) plus the enrollment-status collapse, marking each as implemented.
+
+---
+
+## Self-Review
+
+**Spec coverage** (each of #102's eight suggestions plus the enrollment collapse):
+
+1. Polymorphic tag/note -> nullable FKs: A1 (schema), A2 (models), B1 (tag CRUD), B2 (note CRUD), C5 (CLI tag), C6 (CLI note).
+2. Company-only activity rows: A1 (schema), A2 (Activity model), B3 (CRUD), C7 (CLI).
+3. Rename `workflow_*` -> `enrollment_*`: A1 (schema CHECK), A2 (`ActivityType`), C1 (routing), C4 (agent), C7 (CLI), C8 (CLI).
+4. Atomic timeline writes: B4 (helpers), C5/C6 (CLI uses helpers).
+5. Structured FK columns on activity: A1 (schema), A2 (model), B3 (CRUD), C1/C2/C3/C4/C8 (callers pass FKs).
+6. Composite timeline indexes: A1.
+7. Strict tag normalization: B1 (regex + helper).
+8. Update ADR-08 to reflect implemented behavior: file rename done; D1 rewrites content; D2 updates CLAUDE.md.
+
+Plus enrollment-status collapse from comment #4334976677: A1 (schema), A2 (`EnrollmentStatus`), B5 (tests), C2 (drop `_activate_enrollment_if_pending`), C4 (agent tool replacement), C8 (CLI).
+
+**Placeholder scan:** No `TBD`, `TODO`, "implement later", or "similar to Task N" without code. Each step that changes code shows the code. Bash commands include expected output where relevant.
+
+**Type consistency:**
+
+- `Tag.contact_id` / `Tag.company_id`, `Note.contact_id` / `Note.company_id`, `Activity.contact_id` / `Activity.company_id`, `Activity.email_id` / `Activity.workflow_id` / `Activity.task_id` -- consistent across A2, B1-B4, C1-C7.
+- `EnrollmentStatus = Literal["active", "paused"]` consistent across A2, B5, C8.
+- New tool name: `record_enrollment_outcome(connection, workflow_id, contact_id, outcome, reason)` consistent across C4 (tools), C4 (invoke wrapper), C4 (tests), C4 (system prompt).
+- New helper names: `add_contact_tag`, `add_company_tag`, `remove_contact_tag`, `remove_company_tag`, `add_contact_note`, `add_company_note`, `list_contacts_by_tag`, `list_companies_by_tag` -- consistent across B1, B4, C5, C6.
+
+No gaps detected.

--- a/src/mailpilot/agent/invoke.py
+++ b/src/mailpilot/agent/invoke.py
@@ -178,17 +178,17 @@ def _wrap_cancel_task(
     )
 
 
-def _wrap_update_enrollment_status(
+def _wrap_record_enrollment_outcome(
     ctx: RunContext[AgentDeps],
-    status: str,
+    outcome: str,
     reason: str,
 ) -> dict[str, str]:
-    """Report outcome for the current contact's enrollment in this workflow."""
-    return agent_tools.update_enrollment_status(
+    """Record an enrollment outcome (completed or failed) on the timeline."""
+    return agent_tools.record_enrollment_outcome(
         connection=ctx.deps.connection,
         workflow_id=ctx.deps.workflow_id,
         contact_id=ctx.deps.contact_id,
-        status=status,
+        outcome=outcome,
         reason=reason,
     )
 
@@ -284,7 +284,7 @@ _TOOLS: list[Tool[AgentDeps]] = [
     Tool(_wrap_reply_email, name="reply_email"),
     Tool(_wrap_create_task, name="create_task"),
     Tool(_wrap_cancel_task, name="cancel_task"),
-    Tool(_wrap_update_enrollment_status, name="update_enrollment_status"),
+    Tool(_wrap_record_enrollment_outcome, name="record_enrollment_outcome"),
     Tool(_wrap_disable_contact, name="disable_contact"),
     Tool(_wrap_list_enrollments, name="list_enrollments"),
     Tool(_wrap_search_emails, name="search_emails"),
@@ -301,7 +301,7 @@ _SYSTEM_PREFIX = (
     "When a trigger email is included in your prompt, its full body is "
     "already provided -- do not call read_email to fetch it again.\n"
     "After completing the workflow objective for a contact, call "
-    "update_enrollment_status with status='completed' and a brief reason.\n\n"
+    "record_enrollment_outcome with outcome='completed' and a brief reason.\n\n"
 )
 
 

--- a/src/mailpilot/agent/tools.py
+++ b/src/mailpilot/agent/tools.py
@@ -13,7 +13,7 @@ Tools per ADR-03:
     - ``reply_email`` -- reply in-thread with auto-resolved recipient and subject
     - ``create_task`` -- schedule deferred work
     - ``cancel_task`` -- cancel a pending task
-    - ``update_enrollment_status`` -- report per-workflow outcome
+    - ``record_enrollment_outcome`` -- record per-workflow outcome on timeline
     - ``disable_contact`` -- set global contact block (bounced/unsubscribed)
     - ``search_emails`` -- query email history
     - ``list_enrollments`` -- list enrollments in workflow with status
@@ -172,54 +172,54 @@ def cancel_task(
     return {"id": task.id, "status": task.status}
 
 
-def update_enrollment_status(
+def record_enrollment_outcome(
     connection: psycopg.Connection[dict[str, Any]],
     workflow_id: str,
     contact_id: str,
-    status: str,
+    outcome: str,
     reason: str,
 ) -> dict[str, str]:
-    """Report outcome for an enrollment in the current workflow.
+    """Record an outcome (completed or failed) on the activity timeline.
 
-    The agent -- not the system -- decides success or failure. Emits a
-    ``workflow_completed`` or ``workflow_failed`` activity on those
-    transitions so the timeline records the outcome.
+    Outcome is purely a timeline event -- the enrollment row's status is
+    not modified. The agent declares the engagement done; if a later
+    inbound reply arrives, the agent can react without first
+    "reactivating" anything.
 
     Args:
         connection: Open database connection.
         workflow_id: Current workflow FK.
         contact_id: Contact ID.
-        status: "active", "completed", or "failed".
+        outcome: "completed" or "failed".
         reason: Agent's explanation (e.g., "meeting booked", "no response").
 
     Returns:
-        Dict with updated status, or error if enrollment not found.
+        Dict with the recorded outcome, or an error dict if the
+        enrollment is missing or the outcome is invalid.
     """
-    valid_statuses = ("active", "completed", "failed")
-    if status not in valid_statuses:
+    valid_outcomes = ("completed", "failed")
+    if outcome not in valid_outcomes:
         return {
-            "error": "invalid_status",
-            "message": f"status must be one of {valid_statuses}, got: {status}",
+            "error": "invalid_outcome",
+            "message": f"outcome must be one of {valid_outcomes}, got: {outcome}",
         }
-    enrollment = database.update_enrollment(
-        connection, workflow_id, contact_id, status=status, reason=reason
-    )
+    enrollment = database.get_enrollment(connection, workflow_id, contact_id)
     if enrollment is None:
         return {
             "error": "not_found",
             "message": f"enrollment not found: {workflow_id}/{contact_id}",
         }
-    if status in ("completed", "failed"):
-        contact = database.get_contact(connection, contact_id)
-        database.create_activity(
-            connection,
-            contact_id=contact_id,
-            activity_type=f"workflow_{status}",
-            summary=reason or f"Workflow {status}",
-            detail={"workflow_id": workflow_id, "reason": reason},
-            company_id=contact.company_id if contact is not None else None,
-        )
-    return {"status": enrollment.status, "reason": enrollment.reason}
+    contact = database.get_contact(connection, contact_id)
+    database.create_activity(
+        connection,
+        contact_id=contact_id,
+        activity_type=f"enrollment_{outcome}",
+        summary=reason or f"Enrollment {outcome}",
+        detail={"reason": reason},
+        company_id=contact.company_id if contact is not None else None,
+        workflow_id=workflow_id,
+    )
+    return {"outcome": outcome, "reason": reason}
 
 
 def disable_contact(

--- a/src/mailpilot/agent/tools.py
+++ b/src/mailpilot/agent/tools.py
@@ -261,20 +261,24 @@ def list_enrollments(
     connection: psycopg.Connection[dict[str, Any]],
     workflow_id: str,
 ) -> list[dict[str, Any]]:
-    """List enrollments in a workflow with their outcome status.
+    """List enrollments in a workflow with their latest outcome.
 
     Lets the agent coordinate across contacts (e.g., skip person B if
-    person A at the same company already completed the objective).
+    person A at the same company already completed the objective). Each
+    row includes ``latest_outcome`` (``completed`` / ``failed`` / ``None``),
+    ``latest_outcome_reason``, and ``latest_outcome_at`` -- pulled from the
+    activity timeline since outcomes are timeline-only per ADR-08.
 
     Args:
         connection: Open database connection.
         workflow_id: Workflow ID.
 
     Returns:
-        List of enrollment records with status and reason.
+        List of enrollment records with operational status and the latest
+        outcome activity, if any.
     """
-    enrollments = database.list_enrollments(connection, workflow_id)
-    return [e.model_dump() for e in enrollments]
+    enrollments = database.list_enrollments_with_outcomes(connection, workflow_id)
+    return [e.model_dump(mode="json") for e in enrollments]
 
 
 def search_emails(

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -22,9 +22,11 @@ _ACTIVITY_TYPES = [
     "tag_added",
     "tag_removed",
     "status_changed",
-    "workflow_assigned",
-    "workflow_completed",
-    "workflow_failed",
+    "enrollment_added",
+    "enrollment_completed",
+    "enrollment_failed",
+    "enrollment_paused",
+    "enrollment_resumed",
 ]
 
 
@@ -965,7 +967,8 @@ def activity() -> None:
 
 
 @activity.command("create")
-@click.option("--contact-id", required=True, help="Contact ID.")
+@click.option("--contact-id", default=None, help="Contact ID.")
+@click.option("--company-id", default=None, help="Optional company ID.")
 @click.option(
     "--type",
     "activity_type",
@@ -975,15 +978,14 @@ def activity() -> None:
 )
 @click.option("--summary", required=True, help="One-line description.")
 @click.option("--detail", default=None, help="JSON detail payload.")
-@click.option("--company-id", default=None, help="Optional company ID.")
 def activity_create(
-    contact_id: str,
+    contact_id: str | None,
+    company_id: str | None,
     activity_type: str,
     summary: str,
     detail: str | None,
-    company_id: str | None,
 ) -> None:
-    """Create an activity event."""
+    """Create an activity event. At least one of --contact-id / --company-id."""
     from mailpilot.database import (
         create_activity,
         get_company,
@@ -993,20 +995,25 @@ def activity_create(
 
     if not summary.strip():
         output_error("summary cannot be empty", "validation_error")
+    if contact_id is None and company_id is None:
+        output_error(
+            "at least one of --contact-id or --company-id is required",
+            "validation_error",
+        )
     detail_dict: dict[str, object] = json.loads(detail) if detail else {}
     connection = initialize_database(_database_url())
     try:
-        if get_contact(connection, contact_id) is None:
+        if contact_id is not None and get_contact(connection, contact_id) is None:
             output_error(f"contact not found: {contact_id}", "not_found")
         if company_id is not None and get_company(connection, company_id) is None:
             output_error(f"company not found: {company_id}", "not_found")
         created = create_activity(
             connection,
             contact_id=contact_id,
+            company_id=company_id,
             activity_type=activity_type,
             summary=summary,
             detail=detail_dict,
-            company_id=company_id,
         )
         output(created.model_dump(mode="json"))
     finally:

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -1072,17 +1072,6 @@ def tag() -> None:
     """Manage tags on contacts and companies."""
 
 
-def _resolve_entity(contact_id: str | None, company_id: str | None) -> tuple[str, str]:
-    """Return (entity_type, entity_id) or call output_error."""
-    if contact_id and company_id:
-        output_error("specify only one of --contact-id or --company-id", "invalid_args")
-    if contact_id:
-        return ("contact", contact_id)
-    if company_id:
-        return ("company", company_id)
-    output_error("one of --contact-id or --company-id is required", "missing_filter")
-
-
 @tag.command("add")
 @click.option("--contact-id", default=None, help="Contact ID.")
 @click.option("--company-id", default=None, help="Company ID.")
@@ -1090,8 +1079,9 @@ def _resolve_entity(contact_id: str | None, company_id: str | None) -> tuple[str
 def tag_add(contact_id: str | None, company_id: str | None, name: str) -> None:
     """Add a tag to a contact or company."""
     from mailpilot.database import (
-        create_activity,
-        create_tag,
+        _normalize_tag_name,
+        add_company_tag,
+        add_contact_tag,
         get_company,
         get_contact,
         initialize_database,
@@ -1099,44 +1089,39 @@ def tag_add(contact_id: str | None, company_id: str | None, name: str) -> None:
 
     if not name.strip():
         output_error("tag name cannot be empty", "validation_error")
-    entity_type, entity_id = _resolve_entity(contact_id, company_id)
+    if (contact_id is None) == (company_id is None):
+        output_error(
+            "exactly one of --contact-id or --company-id is required",
+            "validation_error",
+        )
     connection = initialize_database(_database_url())
     try:
-        contact = None
-        if entity_type == "contact":
-            contact = get_contact(connection, entity_id)
-            if contact is None:
-                output_error(
-                    f"contact {entity_id} not found",
-                    "not_found",
+        if contact_id is not None:
+            if get_contact(connection, contact_id) is None:
+                output_error(f"contact {contact_id} not found", "not_found")
+            try:
+                created = add_contact_tag(
+                    connection, contact_id=contact_id, name=name
                 )
+            except ValueError as exc:
+                output_error(str(exc), "validation_error")
+            owner = ("contact", contact_id)
         else:
-            company = get_company(connection, entity_id)
-            if company is None:
-                output_error(
-                    f"company {entity_id} not found",
-                    "not_found",
+            assert company_id is not None
+            if get_company(connection, company_id) is None:
+                output_error(f"company {company_id} not found", "not_found")
+            try:
+                created = add_company_tag(
+                    connection, company_id=company_id, name=name
                 )
-        created = create_tag(
-            connection,
-            entity_type=entity_type,
-            entity_id=entity_id,
-            name=name,
-        )
+            except ValueError as exc:
+                output_error(str(exc), "validation_error")
+            owner = ("company", company_id)
         if created is None:
-            normalized = name.strip().lower()
+            normalized = _normalize_tag_name(name)
             output_error(
-                f"tag '{normalized}' already exists on {entity_type} {entity_id}",
+                f"tag '{normalized}' already exists on {owner[0]} {owner[1]}",
                 "already_exists",
-            )
-        if entity_type == "contact" and contact is not None:
-            create_activity(
-                connection,
-                contact_id=entity_id,
-                activity_type="tag_added",
-                summary=f"Tagged as {created.name}",
-                detail={"tag": created.name},
-                company_id=contact.company_id,
             )
         output(created.model_dump(mode="json"))
     finally:
@@ -1150,45 +1135,49 @@ def tag_add(contact_id: str | None, company_id: str | None, name: str) -> None:
 def tag_remove(contact_id: str | None, company_id: str | None, name: str) -> None:
     """Remove a tag from a contact or company."""
     from mailpilot.database import (
-        create_activity,
-        delete_tag,
+        _normalize_tag_name,
         get_company,
         get_contact,
         initialize_database,
+        remove_company_tag,
+        remove_contact_tag,
     )
 
-    entity_type, entity_id = _resolve_entity(contact_id, company_id)
+    if (contact_id is None) == (company_id is None):
+        output_error(
+            "exactly one of --contact-id or --company-id is required",
+            "validation_error",
+        )
     connection = initialize_database(_database_url())
     try:
-        contact = None
-        if entity_type == "contact":
-            contact = get_contact(connection, entity_id)
-            if contact is None:
-                output_error(f"contact {entity_id} not found", "not_found")
-        elif get_company(connection, entity_id) is None:
-            output_error(f"company {entity_id} not found", "not_found")
-        deleted = delete_tag(
-            connection,
-            entity_type=entity_type,
-            entity_id=entity_id,
-            name=name,
-        )
-        normalized = name.strip().lower()
+        if contact_id is not None:
+            if get_contact(connection, contact_id) is None:
+                output_error(f"contact {contact_id} not found", "not_found")
+            try:
+                deleted = remove_contact_tag(
+                    connection, contact_id=contact_id, name=name
+                )
+            except ValueError as exc:
+                output_error(str(exc), "validation_error")
+            owner = ("contact", contact_id)
+        else:
+            assert company_id is not None
+            if get_company(connection, company_id) is None:
+                output_error(f"company {company_id} not found", "not_found")
+            try:
+                deleted = remove_company_tag(
+                    connection, company_id=company_id, name=name
+                )
+            except ValueError as exc:
+                output_error(str(exc), "validation_error")
+            owner = ("company", company_id)
+        normalized = _normalize_tag_name(name)
         if not deleted:
             output_error(
-                f"tag '{normalized}' not found on {entity_type} {entity_id}",
+                f"tag '{normalized}' not found on {owner[0]} {owner[1]}",
                 "not_found",
             )
-        if entity_type == "contact" and contact is not None:
-            create_activity(
-                connection,
-                contact_id=entity_id,
-                activity_type="tag_removed",
-                summary=f"Removed tag {normalized}",
-                detail={"tag": normalized},
-                company_id=contact.company_id,
-            )
-        output({"removed": True, "tag": normalized, "entity_type": entity_type})
+        output({"removed": True, "tag": normalized, "owner_type": owner[0]})
     finally:
         connection.close()
 
@@ -1212,21 +1201,26 @@ def tag_list(
         list_tags,
     )
 
-    entity_type, entity_id = _resolve_entity(contact_id, company_id)
+    if (contact_id is None) == (company_id is None):
+        output_error(
+            "exactly one of --contact-id or --company-id is required",
+            "validation_error",
+        )
     connection = initialize_database(_database_url())
     try:
-        if entity_type == "contact":
-            if get_contact(connection, entity_id) is None:
-                output_error(f"contact {entity_id} not found", "not_found")
-        elif get_company(connection, entity_id) is None:
-            output_error(f"company {entity_id} not found", "not_found")
-        tags = list_tags(
-            connection,
-            entity_type=entity_type,
-            entity_id=entity_id,
-            limit=limit,
-            since=since,
-        )
+        if contact_id is not None:
+            if get_contact(connection, contact_id) is None:
+                output_error(f"contact {contact_id} not found", "not_found")
+            tags = list_tags(
+                connection, contact_id=contact_id, limit=limit, since=since
+            )
+        else:
+            assert company_id is not None
+            if get_company(connection, company_id) is None:
+                output_error(f"company {company_id} not found", "not_found")
+            tags = list_tags(
+                connection, company_id=company_id, limit=limit, since=since
+            )
         output({"tags": [t.model_dump(mode="json") for t in tags]})
     finally:
         connection.close()
@@ -1236,19 +1230,19 @@ def tag_list(
 @click.argument("name")
 @click.option(
     "--type",
-    "entity_type",
+    "owner",
     default=None,
     type=click.Choice(["contact", "company"]),
-    help="Filter by entity type.",
+    help="Filter by owner type.",
 )
 @click.option("--limit", default=100, help="Maximum results.")
-def tag_search(name: str, entity_type: str | None, limit: int) -> None:
+def tag_search(name: str, owner: str | None, limit: int) -> None:
     """Search tags by name."""
     from mailpilot.database import initialize_database, search_tags
 
     connection = initialize_database(_database_url())
     try:
-        tags = search_tags(connection, name=name, entity_type=entity_type, limit=limit)
+        tags = search_tags(connection, name=name, owner=owner, limit=limit)
         output({"tags": [t.model_dump(mode="json") for t in tags]})
     finally:
         connection.close()
@@ -1269,8 +1263,8 @@ def note() -> None:
 def note_add(contact_id: str | None, company_id: str | None, body: str) -> None:
     """Add a note to a contact or company."""
     from mailpilot.database import (
-        create_activity,
-        create_note,
+        add_company_note,
+        add_contact_note,
         get_company,
         get_contact,
         initialize_database,
@@ -1278,38 +1272,25 @@ def note_add(contact_id: str | None, company_id: str | None, body: str) -> None:
 
     if not body.strip():
         output_error("note body cannot be empty", "validation_error")
-    entity_type, entity_id = _resolve_entity(contact_id, company_id)
+    if (contact_id is None) == (company_id is None):
+        output_error(
+            "exactly one of --contact-id or --company-id is required",
+            "validation_error",
+        )
     connection = initialize_database(_database_url())
     try:
-        contact = None
-        if entity_type == "contact":
-            contact = get_contact(connection, entity_id)
-            if contact is None:
-                output_error(
-                    f"contact {entity_id} not found",
-                    "not_found",
-                )
+        if contact_id is not None:
+            if get_contact(connection, contact_id) is None:
+                output_error(f"contact {contact_id} not found", "not_found")
+            created = add_contact_note(
+                connection, contact_id=contact_id, body=body
+            )
         else:
-            company = get_company(connection, entity_id)
-            if company is None:
-                output_error(
-                    f"company {entity_id} not found",
-                    "not_found",
-                )
-        created = create_note(
-            connection,
-            entity_type=entity_type,
-            entity_id=entity_id,
-            body=body,
-        )
-        if entity_type == "contact" and contact is not None:
-            create_activity(
-                connection,
-                contact_id=entity_id,
-                activity_type="note_added",
-                summary="Note added",
-                detail={"note_id": created.id},
-                company_id=contact.company_id,
+            assert company_id is not None
+            if get_company(connection, company_id) is None:
+                output_error(f"company {company_id} not found", "not_found")
+            created = add_company_note(
+                connection, company_id=company_id, body=body
             )
         output(created.model_dump(mode="json"))
     finally:
@@ -1332,21 +1313,26 @@ def note_list(
         list_notes,
     )
 
-    entity_type, entity_id = _resolve_entity(contact_id, company_id)
+    if (contact_id is None) == (company_id is None):
+        output_error(
+            "exactly one of --contact-id or --company-id is required",
+            "validation_error",
+        )
     connection = initialize_database(_database_url())
     try:
-        if entity_type == "contact":
-            if get_contact(connection, entity_id) is None:
-                output_error(f"contact {entity_id} not found", "not_found")
-        elif get_company(connection, entity_id) is None:
-            output_error(f"company {entity_id} not found", "not_found")
-        notes = list_notes(
-            connection,
-            entity_type=entity_type,
-            entity_id=entity_id,
-            limit=limit,
-            since=since,
-        )
+        if contact_id is not None:
+            if get_contact(connection, contact_id) is None:
+                output_error(f"contact {contact_id} not found", "not_found")
+            notes = list_notes(
+                connection, contact_id=contact_id, limit=limit, since=since
+            )
+        else:
+            assert company_id is not None
+            if get_company(connection, company_id) is None:
+                output_error(f"company {company_id} not found", "not_found")
+            notes = list_notes(
+                connection, company_id=company_id, limit=limit, since=since
+            )
         output({"notes": [n.model_dump(mode="json") for n in notes]})
     finally:
         connection.close()

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -1086,7 +1086,7 @@ def tag() -> None:
 def tag_add(contact_id: str | None, company_id: str | None, name: str) -> None:
     """Add a tag to a contact or company."""
     from mailpilot.database import (
-        _normalize_tag_name,
+        _normalize_tag_name,  # pyright: ignore[reportPrivateUsage]
         add_company_tag,
         add_contact_tag,
         get_company,
@@ -1107,9 +1107,7 @@ def tag_add(contact_id: str | None, company_id: str | None, name: str) -> None:
             if get_contact(connection, contact_id) is None:
                 output_error(f"contact {contact_id} not found", "not_found")
             try:
-                created = add_contact_tag(
-                    connection, contact_id=contact_id, name=name
-                )
+                created = add_contact_tag(connection, contact_id=contact_id, name=name)
             except ValueError as exc:
                 output_error(str(exc), "validation_error")
             owner = ("contact", contact_id)
@@ -1118,9 +1116,7 @@ def tag_add(contact_id: str | None, company_id: str | None, name: str) -> None:
             if get_company(connection, company_id) is None:
                 output_error(f"company {company_id} not found", "not_found")
             try:
-                created = add_company_tag(
-                    connection, company_id=company_id, name=name
-                )
+                created = add_company_tag(connection, company_id=company_id, name=name)
             except ValueError as exc:
                 output_error(str(exc), "validation_error")
             owner = ("company", company_id)
@@ -1142,7 +1138,7 @@ def tag_add(contact_id: str | None, company_id: str | None, name: str) -> None:
 def tag_remove(contact_id: str | None, company_id: str | None, name: str) -> None:
     """Remove a tag from a contact or company."""
     from mailpilot.database import (
-        _normalize_tag_name,
+        _normalize_tag_name,  # pyright: ignore[reportPrivateUsage]
         get_company,
         get_contact,
         initialize_database,
@@ -1289,16 +1285,12 @@ def note_add(contact_id: str | None, company_id: str | None, body: str) -> None:
         if contact_id is not None:
             if get_contact(connection, contact_id) is None:
                 output_error(f"contact {contact_id} not found", "not_found")
-            created = add_contact_note(
-                connection, contact_id=contact_id, body=body
-            )
+            created = add_contact_note(connection, contact_id=contact_id, body=body)
         else:
             assert company_id is not None
             if get_company(connection, company_id) is None:
                 output_error(f"company {company_id} not found", "not_found")
-            created = add_company_note(
-                connection, company_id=company_id, body=body
-            )
+            created = add_company_note(connection, company_id=company_id, body=body)
         output(created.model_dump(mode="json"))
     finally:
         connection.close()
@@ -1702,13 +1694,11 @@ def enrollment_add(workflow_id: str, contact_id: str) -> None:
             create_activity(
                 connection,
                 contact_id=contact_id,
-                activity_type="workflow_assigned",
+                activity_type="enrollment_added",
                 summary=f"Assigned to {workflow.name}",
-                detail={
-                    "workflow_id": workflow_id,
-                    "workflow_name": workflow.name,
-                },
+                detail={"workflow_name": workflow.name},
                 company_id=contact.company_id,
+                workflow_id=workflow_id,
             )
             output(created.model_dump(mode="json"))
             return
@@ -1836,7 +1826,7 @@ def enrollment_view(workflow_id: str, contact_id: str) -> None:
 @click.option(
     "--status",
     default=None,
-    type=click.Choice(["pending", "active", "completed", "failed"]),
+    type=click.Choice(["active", "paused"]),
     help="Filter by enrollment status.",
 )
 @click.option("--limit", default=100, help="Maximum results.")
@@ -1881,38 +1871,50 @@ def enrollment_list(
 @click.option(
     "--status",
     required=True,
-    type=click.Choice(["pending", "active", "completed", "failed"]),
-    help="New enrollment status.",
+    type=click.Choice(["active", "paused"]),
+    help="New enrollment status (active or paused).",
 )
 @click.option("--reason", default=None, help="Status reason.")
 def enrollment_update(
     workflow_id: str, contact_id: str, status: str, reason: str | None
 ) -> None:
-    """Update enrollment status and reason."""
+    """Update enrollment operational status (active or paused).
+
+    Outcomes (completed, failed) are recorded as activity by the agent
+    via record_enrollment_outcome -- not via this command.
+    """
     from mailpilot.database import (
         create_activity,
         get_contact,
+        get_enrollment,
         initialize_database,
         update_enrollment,
     )
 
     connection = initialize_database(_database_url())
     try:
+        before = get_enrollment(connection, workflow_id, contact_id)
+        if before is None:
+            output_error("enrollment not found", "not_found")
         fields: dict[str, object] = {"status": status}
         if reason is not None:
             fields["reason"] = reason
         updated = update_enrollment(connection, workflow_id, contact_id, **fields)
         if updated is None:
             output_error("enrollment not found", "not_found")
-        if status in ("completed", "failed"):
+        if before.status != status:
             contact = get_contact(connection, contact_id)
+            activity_type = (
+                "enrollment_paused" if status == "paused" else "enrollment_resumed"
+            )
             create_activity(
                 connection,
                 contact_id=contact_id,
-                activity_type=f"workflow_{status}",
-                summary=reason or f"Workflow {status}",
-                detail={"workflow_id": workflow_id, "reason": reason or ""},
+                activity_type=activity_type,
+                summary=reason or f"Enrollment {status}",
+                detail={"reason": reason or ""},
                 company_id=contact.company_id if contact is not None else None,
+                workflow_id=workflow_id,
             )
         output(updated.model_dump(mode="json"))
     finally:

--- a/src/mailpilot/cli.py
+++ b/src/mailpilot/cli.py
@@ -1744,10 +1744,16 @@ def enrollment_run(workflow_id: str, contact_id: str) -> None:
         contact = get_contact(connection, contact_id)
         if contact is None:
             output_error(f"contact not found: {contact_id}", "not_found")
-        if get_enrollment(connection, workflow_id, contact.id) is None:
+        enrollment = get_enrollment(connection, workflow_id, contact.id)
+        if enrollment is None:
             output_error(
                 f"contact {contact_id} is not enrolled in workflow {workflow_id}",
                 "not_found",
+            )
+        if enrollment.status != "active":
+            output_error(
+                f"enrollment is not active (status={enrollment.status})",
+                "invalid_state",
             )
         email = None
         if wf.type == "inbound":

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -10,6 +10,7 @@ Convention:
     update_X(connection, id, ...) -> X
 """
 
+import re
 import uuid
 from collections.abc import Iterable
 from datetime import UTC, datetime
@@ -2103,39 +2104,58 @@ def list_activities(
 # -- Tag -----------------------------------------------------------------------
 
 
+_TAG_NAME_RE = re.compile(r"[a-z0-9][a-z0-9-]*")
+
+
+def _normalize_tag_name(name: str) -> str:
+    """Normalize a tag name to lowercase hyphenated form.
+
+    Strips whitespace, lowercases, replaces whitespace and underscores
+    with hyphens, collapses repeated hyphens, trims leading/trailing
+    hyphens, and validates against ``[a-z0-9][a-z0-9-]*``.
+
+    Raises:
+        ValueError: If the result is empty or contains disallowed
+        characters.
+    """
+    cleaned = name.strip().lower()
+    cleaned = re.sub(r"[\s_]+", "-", cleaned)
+    cleaned = re.sub(r"-+", "-", cleaned).strip("-")
+    if not _TAG_NAME_RE.fullmatch(cleaned):
+        raise ValueError(f"invalid tag name: {name!r} (normalized to {cleaned!r})")
+    return cleaned
+
+
 def create_tag(
     connection: psycopg.Connection[dict[str, Any]],
-    entity_type: str,
-    entity_id: str,
     name: str,
+    contact_id: str | None = None,
+    company_id: str | None = None,
 ) -> Tag | None:
     """Create a tag on a contact or company.
 
-    Normalizes the tag name to lowercase with leading/trailing whitespace
-    stripped. Uses ON CONFLICT DO NOTHING so duplicate tags are silently
-    ignored.
+    Exactly one of ``contact_id`` or ``company_id`` must be provided.
+    The name is normalized via ``_normalize_tag_name``. Uses ON CONFLICT
+    DO NOTHING -- returns None if the tag already exists.
 
-    Args:
-        connection: Open database connection.
-        entity_type: "contact" or "company".
-        entity_id: ID of the tagged entity.
-        name: Tag name (normalized to lowercase).
-
-    Returns:
-        Created tag, or None if the tag already exists.
+    Raises:
+        ValueError: If neither or both of contact_id/company_id are set,
+        or if the tag name fails normalization.
     """
-    normalized = name.strip().lower()
+    if (contact_id is None) == (company_id is None):
+        raise ValueError("exactly one of contact_id or company_id is required")
+    normalized = _normalize_tag_name(name)
     row = connection.execute(
         """\
-        INSERT INTO tag (id, entity_type, entity_id, name)
-        VALUES (%(id)s, %(entity_type)s, %(entity_id)s, %(name)s)
-        ON CONFLICT (entity_type, entity_id, name) DO NOTHING
+        INSERT INTO tag (id, contact_id, company_id, name)
+        VALUES (%(id)s, %(contact_id)s, %(company_id)s, %(name)s)
+        ON CONFLICT DO NOTHING
         RETURNING *
         """,
         {
             "id": _new_id(),
-            "entity_type": entity_type,
-            "entity_id": entity_id,
+            "contact_id": contact_id,
+            "company_id": company_id,
             "name": normalized,
         },
     ).fetchone()
@@ -2147,135 +2167,129 @@ def create_tag(
 
 def delete_tag(
     connection: psycopg.Connection[dict[str, Any]],
-    entity_type: str,
-    entity_id: str,
     name: str,
+    contact_id: str | None = None,
+    company_id: str | None = None,
 ) -> bool:
     """Remove a tag from a contact or company.
 
-    Args:
-        connection: Open database connection.
-        entity_type: "contact" or "company".
-        entity_id: ID of the tagged entity.
-        name: Tag name (normalized to lowercase for matching).
-
-    Returns:
-        True if the tag was deleted, False if it was not found.
+    Raises:
+        ValueError: If neither or both of contact_id/company_id are set.
     """
-    normalized = name.strip().lower()
-    cursor = connection.execute(
-        """\
-        DELETE FROM tag
-        WHERE entity_type = %(entity_type)s
-          AND entity_id = %(entity_id)s
-          AND name = %(name)s
-        """,
-        {
-            "entity_type": entity_type,
-            "entity_id": entity_id,
-            "name": normalized,
-        },
-    )
+    if (contact_id is None) == (company_id is None):
+        raise ValueError("exactly one of contact_id or company_id is required")
+    normalized = _normalize_tag_name(name)
+    if contact_id is not None:
+        cursor = connection.execute(
+            "DELETE FROM tag WHERE contact_id = %(contact_id)s AND name = %(name)s",
+            {"contact_id": contact_id, "name": normalized},
+        )
+    else:
+        cursor = connection.execute(
+            "DELETE FROM tag WHERE company_id = %(company_id)s AND name = %(name)s",
+            {"company_id": company_id, "name": normalized},
+        )
     connection.commit()
     return cursor.rowcount > 0
 
 
 def list_tags(
     connection: psycopg.Connection[dict[str, Any]],
-    entity_type: str,
-    entity_id: str,
+    contact_id: str | None = None,
+    company_id: str | None = None,
     limit: int = 100,
     since: str | None = None,
 ) -> list[Tag]:
-    """List all tags on a contact or company.
+    """List tags on a contact or company.
 
     Tag has no Summary projection -- the full row already matches the
-    summary contract (id, entity_type, entity_id, name, created_at).
+    summary contract.
 
-    Args:
-        connection: Open database connection.
-        entity_type: "contact" or "company".
-        entity_id: ID of the tagged entity.
-        limit: Maximum results.
-        since: ISO datetime lower bound on ``created_at``.
-
-    Returns:
-        Tags ordered by name.
+    Raises:
+        ValueError: If neither or both of contact_id/company_id are set.
     """
-    conditions: list[Composed | SQL] = [
-        SQL("entity_type = %(entity_type)s"),
-        SQL("entity_id = %(entity_id)s"),
-    ]
-    params: dict[str, object] = {
-        "entity_type": entity_type,
-        "entity_id": entity_id,
-        "limit": limit,
-    }
+    if (contact_id is None) == (company_id is None):
+        raise ValueError("exactly one of contact_id or company_id is required")
+    params: dict[str, object] = {"limit": limit}
+    where_parts: list[Composed | SQL] = []
+    if contact_id is not None:
+        where_parts.append(SQL("contact_id = %(contact_id)s"))
+        params["contact_id"] = contact_id
+    else:
+        where_parts.append(SQL("company_id = %(company_id)s"))
+        params["company_id"] = company_id
     if since is not None:
-        conditions.append(SQL("created_at >= %(since)s"))
+        where_parts.append(SQL("created_at >= %(since)s"))
         params["since"] = since
-    where = SQL("WHERE ") + SQL(" AND ").join(conditions)
+    where = SQL("WHERE ") + SQL(" AND ").join(where_parts)
     query = SQL("SELECT * FROM tag {} ORDER BY name LIMIT %(limit)s").format(where)
     rows = connection.execute(query, params).fetchall()
     return [Tag.model_validate(row) for row in rows]
 
 
-def list_entities_by_tag(
+def list_contacts_by_tag(
     connection: psycopg.Connection[dict[str, Any]],
-    entity_type: str,
     name: str,
     limit: int = 100,
 ) -> list[str]:
-    """Find all entities with a given tag.
-
-    Args:
-        connection: Open database connection.
-        entity_type: "contact" or "company".
-        name: Tag name to search for.
-        limit: Maximum number of entity IDs to return.
-
-    Returns:
-        Entity IDs matching the tag.
-    """
-    normalized = name.strip().lower()
+    """Return contact IDs with the given tag (normalized)."""
+    normalized = _normalize_tag_name(name)
     rows = connection.execute(
         """\
-        SELECT entity_id FROM tag
-        WHERE entity_type = %(entity_type)s AND name = %(name)s
+        SELECT contact_id FROM tag
+        WHERE contact_id IS NOT NULL AND name = %(name)s
         ORDER BY created_at
         LIMIT %(limit)s
         """,
-        {"entity_type": entity_type, "name": normalized, "limit": limit},
+        {"name": normalized, "limit": limit},
     ).fetchall()
-    return [row["entity_id"] for row in rows]
+    return [row["contact_id"] for row in rows]
+
+
+def list_companies_by_tag(
+    connection: psycopg.Connection[dict[str, Any]],
+    name: str,
+    limit: int = 100,
+) -> list[str]:
+    """Return company IDs with the given tag (normalized)."""
+    normalized = _normalize_tag_name(name)
+    rows = connection.execute(
+        """\
+        SELECT company_id FROM tag
+        WHERE company_id IS NOT NULL AND name = %(name)s
+        ORDER BY created_at
+        LIMIT %(limit)s
+        """,
+        {"name": normalized, "limit": limit},
+    ).fetchall()
+    return [row["company_id"] for row in rows]
 
 
 def search_tags(
     connection: psycopg.Connection[dict[str, Any]],
     name: str,
-    entity_type: str | None = None,
+    owner: str | None = None,
     limit: int = 100,
 ) -> list[Tag]:
-    """Search tags by name with optional entity type filter.
+    """Search tags by name pattern with optional owner filter.
 
     Args:
-        connection: Open database connection.
-        name: Tag name pattern (LIKE match).
-        entity_type: Optional filter by "contact" or "company".
-        limit: Maximum number of results.
-
-    Returns:
-        Matching tags ordered by name.
+        owner: ``"contact"`` to limit to contact tags, ``"company"`` to
+            limit to company tags, ``None`` for both.
     """
+    if owner not in (None, "contact", "company"):
+        raise ValueError("owner must be 'contact', 'company', or None")
     pattern = f"%{name.strip().lower()}%"
     params: dict[str, object] = {"pattern": pattern, "limit": limit}
-    type_filter = SQL("")
-    if entity_type is not None:
-        type_filter = SQL("AND entity_type = %(entity_type)s")
-        params["entity_type"] = entity_type
+    owner_filter = SQL("")
+    if owner == "contact":
+        owner_filter = SQL("AND contact_id IS NOT NULL")
+    elif owner == "company":
+        owner_filter = SQL("AND company_id IS NOT NULL")
     query = SQL(
-        "SELECT * FROM tag WHERE name LIKE %(pattern)s {} ORDER BY name LIMIT %(limit)s"
-    ).format(type_filter)
+        "SELECT * FROM tag WHERE name LIKE %(pattern)s {} "
+        "ORDER BY name LIMIT %(limit)s"
+    ).format(owner_filter)
     rows = connection.execute(query, params).fetchall()
     return [Tag.model_validate(row) for row in rows]
 

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -2299,31 +2299,27 @@ def search_tags(
 
 def create_note(
     connection: psycopg.Connection[dict[str, Any]],
-    entity_type: str,
-    entity_id: str,
     body: str,
+    contact_id: str | None = None,
+    company_id: str | None = None,
 ) -> Note:
-    """Create a freeform text note on a contact or company.
+    """Create a freeform note on a contact or company.
 
-    Args:
-        connection: Open database connection.
-        entity_type: "contact" or "company".
-        entity_id: ID of the annotated entity.
-        body: Note text.
-
-    Returns:
-        Created note.
+    Raises:
+        ValueError: If neither or both of contact_id/company_id are set.
     """
+    if (contact_id is None) == (company_id is None):
+        raise ValueError("exactly one of contact_id or company_id is required")
     row = connection.execute(
         """\
-        INSERT INTO note (id, entity_type, entity_id, body)
-        VALUES (%(id)s, %(entity_type)s, %(entity_id)s, %(body)s)
+        INSERT INTO note (id, contact_id, company_id, body)
+        VALUES (%(id)s, %(contact_id)s, %(company_id)s, %(body)s)
         RETURNING *
         """,
         {
             "id": _new_id(),
-            "entity_type": entity_type,
-            "entity_id": entity_id,
+            "contact_id": contact_id,
+            "company_id": company_id,
             "body": body,
         },
     ).fetchone()
@@ -2333,8 +2329,8 @@ def create_note(
 
 def list_notes(
     connection: psycopg.Connection[dict[str, Any]],
-    entity_type: str,
-    entity_id: str,
+    contact_id: str | None = None,
+    company_id: str | None = None,
     limit: int = 100,
     since: str | None = None,
 ) -> list[NoteSummary]:
@@ -2343,31 +2339,25 @@ def list_notes(
     The full body is replaced by ``body_preview`` -- the first 80 characters
     with a trailing ellipsis when the body is longer.
 
-    Args:
-        connection: Open database connection.
-        entity_type: "contact" or "company".
-        entity_id: ID of the annotated entity.
-        limit: Maximum results.
-        since: ISO datetime lower bound for created_at.
-
-    Returns:
-        Note summaries ordered by created_at descending.
+    Raises:
+        ValueError: If neither or both of contact_id/company_id are set.
     """
-    conditions: list[SQL] = [
-        SQL("entity_type = %(entity_type)s"),
-        SQL("entity_id = %(entity_id)s"),
-    ]
-    params: dict[str, object] = {
-        "entity_type": entity_type,
-        "entity_id": entity_id,
-        "limit": limit,
-    }
+    if (contact_id is None) == (company_id is None):
+        raise ValueError("exactly one of contact_id or company_id is required")
+    params: dict[str, object] = {"limit": limit}
+    where_parts: list[Composed | SQL] = []
+    if contact_id is not None:
+        where_parts.append(SQL("contact_id = %(contact_id)s"))
+        params["contact_id"] = contact_id
+    else:
+        where_parts.append(SQL("company_id = %(company_id)s"))
+        params["company_id"] = company_id
     if since is not None:
-        conditions.append(SQL("created_at >= %(since)s"))
+        where_parts.append(SQL("created_at >= %(since)s"))
         params["since"] = since
-    where = SQL("WHERE ") + SQL(" AND ").join(conditions)
+    where = SQL("WHERE ") + SQL(" AND ").join(where_parts)
     query = SQL(
-        "SELECT id, entity_type, entity_id, "
+        "SELECT id, contact_id, company_id, "
         "CASE WHEN LENGTH(body) > 80 THEN LEFT(body, 80) || '...' "
         "ELSE body END AS body_preview, "
         "created_at "

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -36,6 +36,7 @@ from mailpilot.models import (
     EmailSummary,
     Enrollment,
     EnrollmentSummary,
+    EnrollmentWithOutcome,
     Note,
     NoteSummary,
     SyncStatus,
@@ -1169,6 +1170,58 @@ def list_enrollments(
     ).format(status_filter)
     rows = connection.execute(query, params).fetchall()
     return [Enrollment.model_validate(row) for row in rows]
+
+
+def list_enrollments_with_outcomes(
+    connection: psycopg.Connection[dict[str, Any]],
+    workflow_id: str,
+) -> list[EnrollmentWithOutcome]:
+    """List enrollments in a workflow with their latest outcome activity.
+
+    Per ADR-08, outcomes (`completed` / `failed`) are timeline-only and do
+    not change `enrollment.status`. This helper LEFT JOINs the most recent
+    `enrollment_completed` / `enrollment_failed` activity per row so the
+    agent can answer "has this objective already been satisfied for any
+    contact in this workflow?" in a single query.
+
+    Args:
+        connection: Open database connection.
+        workflow_id: Workflow FK.
+
+    Returns:
+        List of `EnrollmentWithOutcome`, ordered by enrollment `created_at`.
+    """
+    rows = connection.execute(
+        """\
+        SELECT
+            e.workflow_id,
+            e.contact_id,
+            e.status,
+            e.reason,
+            e.created_at,
+            e.updated_at,
+            CASE a.type
+                WHEN 'enrollment_completed' THEN 'completed'
+                WHEN 'enrollment_failed' THEN 'failed'
+            END AS latest_outcome,
+            COALESCE(a.detail->>'reason', a.summary) AS latest_outcome_reason,
+            a.created_at AS latest_outcome_at
+        FROM enrollment e
+        LEFT JOIN LATERAL (
+            SELECT type, summary, detail, created_at
+            FROM activity
+            WHERE activity.contact_id = e.contact_id
+              AND activity.workflow_id = e.workflow_id
+              AND activity.type IN ('enrollment_completed', 'enrollment_failed')
+            ORDER BY created_at DESC
+            LIMIT 1
+        ) a ON TRUE
+        WHERE e.workflow_id = %(workflow_id)s
+        ORDER BY e.created_at
+        """,
+        {"workflow_id": workflow_id},
+    ).fetchall()
+    return [EnrollmentWithOutcome.model_validate(row) for row in rows]
 
 
 def delete_enrollment(

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -2011,36 +2011,47 @@ def create_tasks_for_routed_emails(
 
 def create_activity(
     connection: psycopg.Connection[dict[str, Any]],
-    contact_id: str,
     activity_type: str,
     summary: str = "",
     detail: dict[str, object] | None = None,
+    contact_id: str | None = None,
     company_id: str | None = None,
+    email_id: str | None = None,
+    workflow_id: str | None = None,
+    task_id: str | None = None,
 ) -> Activity:
-    """Create an activity event in a contact's timeline.
+    """Create an activity event.
 
-    Args:
-        connection: Open database connection.
-        contact_id: Contact FK (every activity relates to a contact).
-        activity_type: Activity type (email_sent, tag_added, etc.).
-        summary: One-line human-readable description.
-        detail: Type-specific JSON data (email_id, tag name, etc.).
-        company_id: Optional company FK for company-level views.
+    At least one of ``contact_id`` or ``company_id`` must be set.
+    Structured FK columns (``email_id``, ``workflow_id``, ``task_id``)
+    let reports join activity to source records without parsing
+    ``detail`` JSON.
 
-    Returns:
-        Created activity.
+    Raises:
+        ValueError: If neither contact_id nor company_id is provided.
     """
+    if contact_id is None and company_id is None:
+        raise ValueError("at least one of contact_id or company_id is required")
     row = connection.execute(
         """\
-        INSERT INTO activity (id, contact_id, company_id, type, summary, detail)
-        VALUES (%(id)s, %(contact_id)s, %(company_id)s, %(type)s,
-                %(summary)s, %(detail)s)
+        INSERT INTO activity (
+            id, contact_id, company_id, email_id, workflow_id, task_id,
+            type, summary, detail
+        )
+        VALUES (
+            %(id)s, %(contact_id)s, %(company_id)s, %(email_id)s,
+            %(workflow_id)s, %(task_id)s,
+            %(type)s, %(summary)s, %(detail)s
+        )
         RETURNING *
         """,
         {
             "id": _new_id(),
             "contact_id": contact_id,
             "company_id": company_id,
+            "email_id": email_id,
+            "workflow_id": workflow_id,
+            "task_id": task_id,
             "type": activity_type,
             "summary": summary,
             "detail": Json(detail or {}),

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -2285,8 +2285,11 @@ def search_tags(
     """Search tags by name pattern with optional owner filter.
 
     Args:
+        connection: Open database connection.
+        name: Pattern to LIKE-match against tag ``name``.
         owner: ``"contact"`` to limit to contact tags, ``"company"`` to
             limit to company tags, ``None`` for both.
+        limit: Maximum number of results.
     """
     if owner not in (None, "contact", "company"):
         raise ValueError("owner must be 'contact', 'company', or None")
@@ -2298,8 +2301,7 @@ def search_tags(
     elif owner == "company":
         owner_filter = SQL("AND company_id IS NOT NULL")
     query = SQL(
-        "SELECT * FROM tag WHERE name LIKE %(pattern)s {} "
-        "ORDER BY name LIMIT %(limit)s"
+        "SELECT * FROM tag WHERE name LIKE %(pattern)s {} ORDER BY name LIMIT %(limit)s"
     ).format(owner_filter)
     rows = connection.execute(query, params).fetchall()
     return [Tag.model_validate(row) for row in rows]

--- a/src/mailpilot/database.py
+++ b/src/mailpilot/database.py
@@ -2305,6 +2305,179 @@ def search_tags(
     return [Tag.model_validate(row) for row in rows]
 
 
+def add_contact_tag(
+    connection: psycopg.Connection[dict[str, Any]],
+    contact_id: str,
+    name: str,
+) -> Tag | None:
+    """Add a tag to a contact and emit a `tag_added` activity atomically.
+
+    The two writes share one transaction. Returns ``None`` if the tag
+    already exists -- in that case no activity is written.
+    """
+    normalized = _normalize_tag_name(name)
+    contact_row = connection.execute(
+        "SELECT company_id FROM contact WHERE id = %s", (contact_id,)
+    ).fetchone()
+    if contact_row is None:
+        raise ValueError(f"contact not found: {contact_id}")
+    tag_row = connection.execute(
+        """\
+        INSERT INTO tag (id, contact_id, company_id, name)
+        VALUES (%(id)s, %(contact_id)s, NULL, %(name)s)
+        ON CONFLICT DO NOTHING
+        RETURNING *
+        """,
+        {"id": _new_id(), "contact_id": contact_id, "name": normalized},
+    ).fetchone()
+    if tag_row is None:
+        connection.commit()
+        return None
+    connection.execute(
+        """\
+        INSERT INTO activity (
+            id, contact_id, company_id, type, summary, detail
+        )
+        VALUES (
+            %(id)s, %(contact_id)s, %(company_id)s,
+            'tag_added', %(summary)s, %(detail)s
+        )
+        """,
+        {
+            "id": _new_id(),
+            "contact_id": contact_id,
+            "company_id": contact_row["company_id"],
+            "summary": f"Tagged as {normalized}",
+            "detail": Json({"tag": normalized}),
+        },
+    )
+    connection.commit()
+    return Tag.model_validate(tag_row)
+
+
+def add_company_tag(
+    connection: psycopg.Connection[dict[str, Any]],
+    company_id: str,
+    name: str,
+) -> Tag | None:
+    """Add a tag to a company and emit a `tag_added` company activity atomically."""
+    normalized = _normalize_tag_name(name)
+    if (
+        connection.execute(
+            "SELECT 1 FROM company WHERE id = %s", (company_id,)
+        ).fetchone()
+        is None
+    ):
+        raise ValueError(f"company not found: {company_id}")
+    tag_row = connection.execute(
+        """\
+        INSERT INTO tag (id, contact_id, company_id, name)
+        VALUES (%(id)s, NULL, %(company_id)s, %(name)s)
+        ON CONFLICT DO NOTHING
+        RETURNING *
+        """,
+        {"id": _new_id(), "company_id": company_id, "name": normalized},
+    ).fetchone()
+    if tag_row is None:
+        connection.commit()
+        return None
+    connection.execute(
+        """\
+        INSERT INTO activity (
+            id, contact_id, company_id, type, summary, detail
+        )
+        VALUES (
+            %(id)s, NULL, %(company_id)s,
+            'tag_added', %(summary)s, %(detail)s
+        )
+        """,
+        {
+            "id": _new_id(),
+            "company_id": company_id,
+            "summary": f"Tagged as {normalized}",
+            "detail": Json({"tag": normalized}),
+        },
+    )
+    connection.commit()
+    return Tag.model_validate(tag_row)
+
+
+def remove_contact_tag(
+    connection: psycopg.Connection[dict[str, Any]],
+    contact_id: str,
+    name: str,
+) -> bool:
+    """Remove a tag from a contact and emit a `tag_removed` activity atomically."""
+    normalized = _normalize_tag_name(name)
+    contact_row = connection.execute(
+        "SELECT company_id FROM contact WHERE id = %s", (contact_id,)
+    ).fetchone()
+    if contact_row is None:
+        raise ValueError(f"contact not found: {contact_id}")
+    cursor = connection.execute(
+        "DELETE FROM tag WHERE contact_id = %s AND name = %s",
+        (contact_id, normalized),
+    )
+    if cursor.rowcount == 0:
+        connection.commit()
+        return False
+    connection.execute(
+        """\
+        INSERT INTO activity (
+            id, contact_id, company_id, type, summary, detail
+        )
+        VALUES (
+            %(id)s, %(contact_id)s, %(company_id)s,
+            'tag_removed', %(summary)s, %(detail)s
+        )
+        """,
+        {
+            "id": _new_id(),
+            "contact_id": contact_id,
+            "company_id": contact_row["company_id"],
+            "summary": f"Removed tag {normalized}",
+            "detail": Json({"tag": normalized}),
+        },
+    )
+    connection.commit()
+    return True
+
+
+def remove_company_tag(
+    connection: psycopg.Connection[dict[str, Any]],
+    company_id: str,
+    name: str,
+) -> bool:
+    """Remove a tag from a company and emit a `tag_removed` activity atomically."""
+    normalized = _normalize_tag_name(name)
+    cursor = connection.execute(
+        "DELETE FROM tag WHERE company_id = %s AND name = %s",
+        (company_id, normalized),
+    )
+    if cursor.rowcount == 0:
+        connection.commit()
+        return False
+    connection.execute(
+        """\
+        INSERT INTO activity (
+            id, contact_id, company_id, type, summary, detail
+        )
+        VALUES (
+            %(id)s, NULL, %(company_id)s,
+            'tag_removed', %(summary)s, %(detail)s
+        )
+        """,
+        {
+            "id": _new_id(),
+            "company_id": company_id,
+            "summary": f"Removed tag {normalized}",
+            "detail": Json({"tag": normalized}),
+        },
+    )
+    connection.commit()
+    return True
+
+
 # -- Note ----------------------------------------------------------------------
 
 
@@ -2398,6 +2571,91 @@ def get_note(
     if row is None:
         return None
     return Note.model_validate(row)
+
+
+def add_contact_note(
+    connection: psycopg.Connection[dict[str, Any]],
+    contact_id: str,
+    body: str,
+) -> Note:
+    """Add a note to a contact and emit a `note_added` activity atomically."""
+    contact_row = connection.execute(
+        "SELECT company_id FROM contact WHERE id = %s", (contact_id,)
+    ).fetchone()
+    if contact_row is None:
+        raise ValueError(f"contact not found: {contact_id}")
+    note_row = connection.execute(
+        """\
+        INSERT INTO note (id, contact_id, company_id, body)
+        VALUES (%(id)s, %(contact_id)s, NULL, %(body)s)
+        RETURNING *
+        """,
+        {"id": _new_id(), "contact_id": contact_id, "body": body},
+    ).fetchone()
+    note = Note.model_validate(note_row)
+    connection.execute(
+        """\
+        INSERT INTO activity (
+            id, contact_id, company_id, type, summary, detail
+        )
+        VALUES (
+            %(id)s, %(contact_id)s, %(company_id)s,
+            'note_added', %(summary)s, %(detail)s
+        )
+        """,
+        {
+            "id": _new_id(),
+            "contact_id": contact_id,
+            "company_id": contact_row["company_id"],
+            "summary": "Note added",
+            "detail": Json({"note_id": note.id}),
+        },
+    )
+    connection.commit()
+    return note
+
+
+def add_company_note(
+    connection: psycopg.Connection[dict[str, Any]],
+    company_id: str,
+    body: str,
+) -> Note:
+    """Add a note to a company and emit a `note_added` company activity atomically."""
+    if (
+        connection.execute(
+            "SELECT 1 FROM company WHERE id = %s", (company_id,)
+        ).fetchone()
+        is None
+    ):
+        raise ValueError(f"company not found: {company_id}")
+    note_row = connection.execute(
+        """\
+        INSERT INTO note (id, contact_id, company_id, body)
+        VALUES (%(id)s, NULL, %(company_id)s, %(body)s)
+        RETURNING *
+        """,
+        {"id": _new_id(), "company_id": company_id, "body": body},
+    ).fetchone()
+    note = Note.model_validate(note_row)
+    connection.execute(
+        """\
+        INSERT INTO activity (
+            id, contact_id, company_id, type, summary, detail
+        )
+        VALUES (
+            %(id)s, NULL, %(company_id)s,
+            'note_added', %(summary)s, %(detail)s
+        )
+        """,
+        {
+            "id": _new_id(),
+            "company_id": company_id,
+            "summary": "Note added",
+            "detail": Json({"note_id": note.id}),
+        },
+    )
+    connection.commit()
+    return note
 
 
 # -- Sync Status ---------------------------------------------------------------

--- a/src/mailpilot/email_ops.py
+++ b/src/mailpilot/email_ops.py
@@ -73,22 +73,6 @@ class ContactMissingError(EmailOpsError):
     code = "not_found"
 
 
-def _activate_enrollment_if_pending(
-    connection: psycopg.Connection[dict[str, Any]],
-    workflow_id: str,
-    contact_id: str,
-) -> None:
-    enrollment = database.get_enrollment(connection, workflow_id, contact_id)
-    if enrollment is not None and enrollment.status == "pending":
-        database.update_enrollment(
-            connection,
-            workflow_id,
-            contact_id,
-            status="active",
-            reason="email sent",
-        )
-
-
 def _emit_email_sent_activity(
     connection: psycopg.Connection[dict[str, Any]],
     contact: Contact,
@@ -100,12 +84,10 @@ def _emit_email_sent_activity(
         contact_id=contact.id,
         activity_type="email_sent",
         summary=email.subject,
-        detail={
-            "email_id": email.id,
-            "subject": email.subject,
-            "workflow_id": workflow_id,
-        },
+        detail={"subject": email.subject},
         company_id=contact.company_id,
+        email_id=email.id,
+        workflow_id=workflow_id,
     )
 
 
@@ -128,8 +110,6 @@ def send_email(  # noqa: PLR0913
     contact-status and 30-day cold-outbound cooldown guards. The cooldown
     query is workflow-scoped, so it runs only when ``workflow_id`` is set
     (ad-hoc CLI sends without a workflow have no cooldown context).
-    Activates a pending enrollment when both ``workflow_id`` and a
-    resolved contact are present.
 
     Raises:
         ContactDisabledError: contact is bounced/unsubscribed.
@@ -172,9 +152,6 @@ def send_email(  # noqa: PLR0913
     if contact is not None:
         _emit_email_sent_activity(connection, contact, email, workflow_id)
 
-    if workflow_id is not None and contact_id is not None:
-        _activate_enrollment_if_pending(connection, workflow_id, contact_id)
-
     return email
 
 
@@ -194,8 +171,7 @@ def reply_email(  # noqa: PLR0913
 
     Auto-derives recipient (contact.email), subject ("Re: " prefixed
     unless already prefixed), thread_id, and In-Reply-To from the
-    original. No cooldown -- replies are always allowed. Activates a
-    matching pending enrollment when ``workflow_id`` is set.
+    original. No cooldown -- replies are always allowed.
 
     Raises:
         OriginalNotFoundError: ``email_id`` does not exist.
@@ -241,8 +217,5 @@ def reply_email(  # noqa: PLR0913
     )
 
     _emit_email_sent_activity(connection, contact, email, workflow_id)
-
-    if workflow_id is not None:
-        _activate_enrollment_if_pending(connection, workflow_id, contact.id)
 
     return email

--- a/src/mailpilot/models.py
+++ b/src/mailpilot/models.py
@@ -157,6 +157,29 @@ class EnrollmentSummary(BaseModel):
     updated_at: datetime
 
 
+EnrollmentOutcome = Literal["completed", "failed"]
+
+
+class EnrollmentWithOutcome(BaseModel):
+    """Enrollment plus the latest outcome activity, if any.
+
+    Outcomes (`completed` / `failed`) are timeline-only per ADR-08 -- they do
+    not live on the enrollment row. This composite carries the most recent
+    `enrollment_completed` / `enrollment_failed` activity so the agent can
+    coordinate across contacts in a single read.
+    """
+
+    workflow_id: str
+    contact_id: str
+    status: EnrollmentStatus
+    reason: str
+    created_at: datetime
+    updated_at: datetime
+    latest_outcome: EnrollmentOutcome | None = None
+    latest_outcome_reason: str | None = None
+    latest_outcome_at: datetime | None = None
+
+
 EmailDirection = Literal["inbound", "outbound"]
 
 

--- a/src/mailpilot/models.py
+++ b/src/mailpilot/models.py
@@ -126,15 +126,21 @@ class WorkflowSummary(BaseModel):
     created_at: datetime
 
 
-EnrollmentStatus = Literal["pending", "active", "completed", "failed"]
+EnrollmentStatus = Literal["active", "paused"]
 
 
 class Enrollment(BaseModel):
-    """A contact's participation in a workflow with lifecycle outcome."""
+    """A contact's binding to a workflow.
+
+    Status is operational state only -- ``active`` (agent considers this
+    contact when the workflow runs) or ``paused`` (operator/agent has
+    suspended). Outcomes (completed/failed) live in the activity timeline,
+    not in this row.
+    """
 
     workflow_id: str
     contact_id: str
-    status: EnrollmentStatus = "pending"
+    status: EnrollmentStatus = "active"
     reason: str = ""
     created_at: datetime
     updated_at: datetime
@@ -232,18 +238,30 @@ ActivityType = Literal[
     "tag_added",
     "tag_removed",
     "status_changed",
-    "workflow_assigned",
-    "workflow_completed",
-    "workflow_failed",
+    "enrollment_added",
+    "enrollment_completed",
+    "enrollment_failed",
+    "enrollment_paused",
+    "enrollment_resumed",
 ]
 
 
 class Activity(BaseModel):
-    """Chronological event in a contact's relationship timeline."""
+    """Chronological event in a contact or company timeline.
+
+    Either ``contact_id`` or ``company_id`` must be set (or both, for
+    contact events that should also surface in the company timeline).
+    Structured FK columns (``email_id``, ``workflow_id``, ``task_id``)
+    let reports join activity to source records without parsing
+    ``detail`` JSON.
+    """
 
     id: str
-    contact_id: str
+    contact_id: str | None = None
     company_id: str | None = None
+    email_id: str | None = None
+    workflow_id: str | None = None
+    task_id: str | None = None
     type: ActivityType
     summary: str = ""
     detail: dict[str, object] = {}
@@ -254,32 +272,37 @@ class ActivitySummary(BaseModel):
     """List-view projection of `Activity`."""
 
     id: str
-    contact_id: str
+    contact_id: str | None
     company_id: str | None
     type: ActivityType
     summary: str
     created_at: datetime
 
 
-EntityType = Literal["contact", "company"]
-
-
 class Tag(BaseModel):
-    """Flexible label on a contact or company for segmentation."""
+    """Flexible label on a contact or company for segmentation.
+
+    Exactly one of ``contact_id`` or ``company_id`` is set (XOR enforced
+    at the schema level).
+    """
 
     id: str
-    entity_type: EntityType
-    entity_id: str
+    contact_id: str | None = None
+    company_id: str | None = None
     name: str
     created_at: datetime
 
 
 class Note(BaseModel):
-    """Freeform text annotation on a contact or company."""
+    """Freeform text annotation on a contact or company.
+
+    Exactly one of ``contact_id`` or ``company_id`` is set (XOR enforced
+    at the schema level).
+    """
 
     id: str
-    entity_type: EntityType
-    entity_id: str
+    contact_id: str | None = None
+    company_id: str | None = None
     body: str
     created_at: datetime
 
@@ -288,8 +311,8 @@ class NoteSummary(BaseModel):
     """List-view projection of `Note` with truncated body preview."""
 
     id: str
-    entity_type: EntityType
-    entity_id: str
+    contact_id: str | None
+    company_id: str | None
     body_preview: str
     created_at: datetime
 

--- a/src/mailpilot/routing.py
+++ b/src/mailpilot/routing.py
@@ -320,9 +320,9 @@ def _ensure_enrollment(
 ) -> None:
     """Create an enrollment entry if not already present.
 
-    Emits a ``workflow_assigned`` activity only on the initial insert --
-    ``create_enrollment`` returns ``None`` on ON CONFLICT so re-routes in
-    the same thread do not duplicate the timeline entry.
+    Emits an ``enrollment_added`` activity only on the initial insert --
+    ``create_enrollment`` returns ``None`` on ON CONFLICT so re-routes
+    in the same thread do not duplicate the timeline entry.
     """
     enrollment = create_enrollment(connection, workflow_id, contact_id)
     if enrollment is None:
@@ -333,8 +333,9 @@ def _ensure_enrollment(
     create_activity(
         connection,
         contact_id=contact_id,
-        activity_type="workflow_assigned",
+        activity_type="enrollment_added",
         summary=f"Assigned to {workflow_name or 'workflow'}",
-        detail={"workflow_id": workflow_id, "workflow_name": workflow_name},
+        detail={"workflow_name": workflow_name},
         company_id=contact.company_id if contact is not None else None,
+        workflow_id=workflow_id,
     )

--- a/src/mailpilot/run.py
+++ b/src/mailpilot/run.py
@@ -20,6 +20,7 @@ from mailpilot.database import (
     get_account,
     get_contact,
     get_email,
+    get_enrollment,
     get_workflow,
     list_accounts,
     list_pending_tasks,
@@ -76,6 +77,37 @@ def execute_task(
                 task.id,
                 status="cancelled",
                 result={"reason": "contact disabled or not found"},
+            )
+            return
+
+        enrollment = get_enrollment(connection, task.workflow_id, task.contact_id)
+        if enrollment is None:
+            logfire.info(
+                "run.task.skip_missing_enrollment",
+                task_id=task.id,
+                workflow_id=task.workflow_id,
+                contact_id=task.contact_id,
+            )
+            complete_task(
+                connection,
+                task.id,
+                status="cancelled",
+                result={"reason": "enrollment not found"},
+            )
+            return
+        if enrollment.status != "active":
+            logfire.info(
+                "run.task.skip_paused_enrollment",
+                task_id=task.id,
+                workflow_id=task.workflow_id,
+                contact_id=task.contact_id,
+                enrollment_status=enrollment.status,
+            )
+            complete_task(
+                connection,
+                task.id,
+                status="cancelled",
+                result={"reason": "enrollment paused"},
             )
             return
 

--- a/src/mailpilot/schema.sql
+++ b/src/mailpilot/schema.sql
@@ -73,8 +73,8 @@ CREATE INDEX IF NOT EXISTS idx_workflow_account_id ON workflow(account_id);
 CREATE TABLE IF NOT EXISTS enrollment (
     workflow_id   TEXT NOT NULL REFERENCES workflow(id),
     contact_id    TEXT NOT NULL REFERENCES contact(id),
-    status        TEXT NOT NULL DEFAULT 'pending'
-                  CHECK (status IN ('pending', 'active', 'completed', 'failed')),
+    status        TEXT NOT NULL DEFAULT 'active'
+                  CHECK (status IN ('active', 'paused')),
     reason        TEXT NOT NULL DEFAULT '',
     created_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -149,48 +149,66 @@ CREATE TRIGGER task_pending_trigger
 
 CREATE TABLE IF NOT EXISTS activity (
     id              TEXT PRIMARY KEY,
-    contact_id      TEXT NOT NULL REFERENCES contact(id),
+    contact_id      TEXT REFERENCES contact(id),
     company_id      TEXT REFERENCES company(id),
+    email_id        TEXT REFERENCES email(id),
+    workflow_id     TEXT REFERENCES workflow(id),
+    task_id         TEXT REFERENCES task(id),
     type            TEXT NOT NULL
                     CHECK (type IN (
                         'email_sent', 'email_received',
                         'note_added', 'tag_added', 'tag_removed',
-                        'status_changed', 'workflow_assigned',
-                        'workflow_completed', 'workflow_failed'
+                        'status_changed',
+                        'enrollment_added',
+                        'enrollment_completed', 'enrollment_failed',
+                        'enrollment_paused', 'enrollment_resumed'
                     )),
     summary         TEXT NOT NULL DEFAULT '',
     detail          JSONB NOT NULL DEFAULT '{}',
-    created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (contact_id IS NOT NULL OR company_id IS NOT NULL)
 );
 
-CREATE INDEX IF NOT EXISTS idx_activity_contact_id ON activity(contact_id);
-CREATE INDEX IF NOT EXISTS idx_activity_company_id ON activity(company_id);
+CREATE INDEX IF NOT EXISTS idx_activity_contact_timeline
+    ON activity(contact_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_activity_company_timeline
+    ON activity(company_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_activity_type ON activity(type);
-CREATE INDEX IF NOT EXISTS idx_activity_created_at ON activity(created_at);
 
 CREATE TABLE IF NOT EXISTS tag (
     id              TEXT PRIMARY KEY,
-    entity_type     TEXT NOT NULL
-                    CHECK (entity_type IN ('contact', 'company')),
-    entity_id       TEXT NOT NULL,
+    contact_id      TEXT REFERENCES contact(id),
+    company_id      TEXT REFERENCES company(id),
     name            TEXT NOT NULL,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE (entity_type, entity_id, name)
+    CHECK (
+        (contact_id IS NOT NULL AND company_id IS NULL)
+        OR
+        (contact_id IS NULL AND company_id IS NOT NULL)
+    )
 );
 
-CREATE INDEX IF NOT EXISTS idx_tag_entity ON tag(entity_type, entity_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tag_contact_unique
+    ON tag(contact_id, name) WHERE contact_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tag_company_unique
+    ON tag(company_id, name) WHERE company_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_tag_name ON tag(name);
 
 CREATE TABLE IF NOT EXISTS note (
     id              TEXT PRIMARY KEY,
-    entity_type     TEXT NOT NULL
-                    CHECK (entity_type IN ('contact', 'company')),
-    entity_id       TEXT NOT NULL,
+    contact_id      TEXT REFERENCES contact(id),
+    company_id      TEXT REFERENCES company(id),
     body            TEXT NOT NULL,
-    created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (
+        (contact_id IS NOT NULL AND company_id IS NULL)
+        OR
+        (contact_id IS NULL AND company_id IS NOT NULL)
+    )
 );
 
-CREATE INDEX IF NOT EXISTS idx_note_entity ON note(entity_type, entity_id);
+CREATE INDEX IF NOT EXISTS idx_note_contact_id ON note(contact_id) WHERE contact_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_note_company_id ON note(company_id) WHERE company_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS sync_status (
     id            TEXT PRIMARY KEY DEFAULT 'singleton',

--- a/src/mailpilot/sync.py
+++ b/src/mailpilot/sync.py
@@ -779,8 +779,9 @@ def _store_inbound_message(  # noqa: PLR0913
         contact_id=contact.id,
         activity_type="email_received",
         summary=email.subject,
-        detail={"email_id": email.id, "subject": email.subject},
+        detail={"subject": email.subject},
         company_id=contact.company_id,
+        email_id=email.id,
     )
     sync_messages_stored.add(
         1,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,16 +147,16 @@ def make_test_activity(
 
 def make_test_tag(
     connection: psycopg.Connection[dict[str, Any]],
-    entity_type: str = "contact",
-    entity_id: str = "",
+    contact_id: str | None = None,
+    company_id: str | None = None,
     name: str = "prospect",
 ) -> Tag:
     """Create a test tag in the database."""
     tag = create_tag(
         connection,
-        entity_type=entity_type,
-        entity_id=entity_id,
         name=name,
+        contact_id=contact_id,
+        company_id=company_id,
     )
     assert tag is not None, f"tag '{name}' already exists"
     return tag
@@ -164,14 +164,14 @@ def make_test_tag(
 
 def make_test_note(
     connection: psycopg.Connection[dict[str, Any]],
-    entity_type: str = "contact",
-    entity_id: str = "",
+    contact_id: str | None = None,
+    company_id: str | None = None,
     body: str = "Test note body",
 ) -> Note:
     """Create a test note in the database."""
     return create_note(
         connection,
-        entity_type=entity_type,
-        entity_id=entity_id,
         body=body,
+        contact_id=contact_id,
+        company_id=company_id,
     )

--- a/tests/test_agent_invoke.py
+++ b/tests/test_agent_invoke.py
@@ -29,7 +29,7 @@ from mailpilot.agent.invoke import (
     _build_agent,  # pyright: ignore[reportPrivateUsage]
     _wrap_create_task,  # pyright: ignore[reportPrivateUsage]
     _wrap_disable_contact,  # pyright: ignore[reportPrivateUsage]
-    _wrap_update_enrollment_status,  # pyright: ignore[reportPrivateUsage]
+    _wrap_record_enrollment_outcome,  # pyright: ignore[reportPrivateUsage]
     invoke_workflow_agent,
 )
 from mailpilot.database import (
@@ -654,8 +654,8 @@ def test_agent_calls_reply_email(
 
 
 def test_system_prefix_guides_contact_status_update() -> None:
-    """System prefix must instruct agents to update contact status."""
-    assert "update_enrollment_status" in _SYSTEM_PREFIX
+    """System prefix must instruct agents to record enrollment outcome."""
+    assert "record_enrollment_outcome" in _SYSTEM_PREFIX
 
 
 def test_system_prefix_allows_markdown_in_emails() -> None:
@@ -704,7 +704,7 @@ def test_wrappers_do_not_take_contact_id_from_llm() -> None:
     the contact's email as contact_id and the tool returned not_found.
     """
     for wrapper in (
-        _wrap_update_enrollment_status,
+        _wrap_record_enrollment_outcome,
         _wrap_disable_contact,
         _wrap_create_task,
     ):
@@ -744,7 +744,7 @@ def test_invoke_surfaces_tool_errors_in_result(
 ) -> None:
     """When a tool returns {error: ...}, the result must surface it.
 
-    Regression for the 2026-04-26 smoke test defect where update_enrollment_status
+    Regression for the 2026-04-26 smoke test defect where record_enrollment_outcome
     returned not_found and the orchestration still reported success.
     """
     _account, contact, workflow = _setup(database_connection)

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -546,6 +546,89 @@ def test_list_enrollments_empty(
     assert result == []
 
 
+def test_list_enrollments_includes_latest_outcome(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Each enrollment row carries the latest enrollment_completed/failed
+    outcome so the agent can coordinate across contacts (skip person B if
+    person A at the same company already finished the objective)."""
+    account = make_test_account(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+
+    completed_contact = make_test_contact(database_connection, email="done@example.com")
+    failed_contact = make_test_contact(database_connection, email="failed@example.com")
+    pending_contact = make_test_contact(database_connection, email="open@example.com")
+    create_enrollment(database_connection, workflow.id, completed_contact.id)
+    create_enrollment(database_connection, workflow.id, failed_contact.id)
+    create_enrollment(database_connection, workflow.id, pending_contact.id)
+
+    record_enrollment_outcome(
+        connection=database_connection,
+        workflow_id=workflow.id,
+        contact_id=completed_contact.id,
+        outcome="completed",
+        reason="meeting booked",
+    )
+    record_enrollment_outcome(
+        connection=database_connection,
+        workflow_id=workflow.id,
+        contact_id=failed_contact.id,
+        outcome="failed",
+        reason="hard bounce",
+    )
+
+    rows = list_enrollments(connection=database_connection, workflow_id=workflow.id)
+    by_contact = {row["contact_id"]: row for row in rows}
+
+    completed_row = by_contact[completed_contact.id]
+    assert completed_row["latest_outcome"] == "completed"
+    assert completed_row["latest_outcome_reason"] == "meeting booked"
+    assert completed_row["latest_outcome_at"] is not None
+
+    failed_row = by_contact[failed_contact.id]
+    assert failed_row["latest_outcome"] == "failed"
+    assert failed_row["latest_outcome_reason"] == "hard bounce"
+    assert failed_row["latest_outcome_at"] is not None
+
+    pending_row = by_contact[pending_contact.id]
+    assert pending_row["latest_outcome"] is None
+    assert pending_row["latest_outcome_reason"] is None
+    assert pending_row["latest_outcome_at"] is None
+
+
+def test_list_enrollments_uses_most_recent_outcome(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """If multiple outcomes were recorded, only the latest is surfaced."""
+    account = make_test_account(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    _activate(database_connection, workflow.id)
+
+    contact = make_test_contact(database_connection, email="flip@example.com")
+    create_enrollment(database_connection, workflow.id, contact.id)
+
+    record_enrollment_outcome(
+        connection=database_connection,
+        workflow_id=workflow.id,
+        contact_id=contact.id,
+        outcome="failed",
+        reason="initial soft fail",
+    )
+    record_enrollment_outcome(
+        connection=database_connection,
+        workflow_id=workflow.id,
+        contact_id=contact.id,
+        outcome="completed",
+        reason="recovered after re-engagement",
+    )
+
+    rows = list_enrollments(connection=database_connection, workflow_id=workflow.id)
+    assert len(rows) == 1
+    assert rows[0]["latest_outcome"] == "completed"
+    assert rows[0]["latest_outcome_reason"] == "recovered after re-engagement"
+
+
 # -- search_emails -------------------------------------------------------------
 
 

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -25,10 +25,10 @@ from mailpilot.agent.tools import (
     read_company,
     read_contact,
     read_email,
+    record_enrollment_outcome,
     reply_email,
     search_emails,
     send_email,
-    record_enrollment_outcome,
 )
 from mailpilot.database import (
     activate_workflow,

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -28,7 +28,7 @@ from mailpilot.agent.tools import (
     reply_email,
     search_emails,
     send_email,
-    update_enrollment_status,
+    record_enrollment_outcome,
 )
 from mailpilot.database import (
     activate_workflow,
@@ -374,51 +374,13 @@ def test_cancel_task_not_found(
     assert result["error"] == "not_found"
 
 
-# -- update_enrollment_status -----------------------------------------------------
+# -- record_enrollment_outcome -----------------------------------------------------
 
 
-def test_update_enrollment_status_success(
+def test_record_enrollment_outcome_completed_writes_activity_only(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
-    account = make_test_account(database_connection)
-    contact = make_test_contact(database_connection)
-    workflow = make_test_workflow(database_connection, account_id=account.id)
-    create_enrollment(database_connection, workflow.id, contact.id)
-
-    result = update_enrollment_status(
-        connection=database_connection,
-        workflow_id=workflow.id,
-        contact_id=contact.id,
-        status="completed",
-        reason="meeting booked",
-    )
-
-    assert result["status"] == "completed"
-    wc = get_enrollment(database_connection, workflow.id, contact.id)
-    assert wc is not None
-    assert wc.status == "completed"
-    assert wc.reason == "meeting booked"
-
-
-def test_update_enrollment_status_not_found(
-    database_connection: psycopg.Connection[dict[str, Any]],
-):
-    result = update_enrollment_status(
-        connection=database_connection,
-        workflow_id="nonexistent",
-        contact_id="nonexistent",
-        status="completed",
-        reason="done",
-    )
-
-    assert result["error"] == "not_found"
-
-
-def test_update_enrollment_status_emits_workflow_completed_activity(
-    database_connection: psycopg.Connection[dict[str, Any]],
-):
-    """Transitioning to ``completed`` must emit a workflow_completed
-    activity with the agent's reason as summary."""
+    """outcome='completed' emits enrollment_completed activity, no status change."""
     from mailpilot.database import list_activities
 
     account = make_test_account(database_connection)
@@ -426,24 +388,28 @@ def test_update_enrollment_status_emits_workflow_completed_activity(
     workflow = make_test_workflow(database_connection, account_id=account.id)
     create_enrollment(database_connection, workflow.id, contact.id)
 
-    update_enrollment_status(
+    result = record_enrollment_outcome(
         connection=database_connection,
         workflow_id=workflow.id,
         contact_id=contact.id,
-        status="completed",
+        outcome="completed",
         reason="meeting booked",
     )
+    assert result == {"outcome": "completed", "reason": "meeting booked"}
 
-    activities = list_activities(
-        database_connection, contact_id=contact.id, activity_type="workflow_completed"
-    )
-    assert len(activities) == 1
-    assert activities[0].summary == "meeting booked"
+    enrollment = get_enrollment(database_connection, workflow.id, contact.id)
+    assert enrollment is not None
+    assert enrollment.status == "active"  # unchanged
+
+    activities = list_activities(database_connection, contact_id=contact.id)
+    types = [a.type for a in activities]
+    assert "enrollment_completed" in types
 
 
-def test_update_enrollment_status_emits_workflow_failed_activity(
+def test_record_enrollment_outcome_failed(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
+    """outcome='failed' emits enrollment_failed activity."""
     from mailpilot.database import list_activities
 
     account = make_test_account(database_connection)
@@ -451,41 +417,43 @@ def test_update_enrollment_status_emits_workflow_failed_activity(
     workflow = make_test_workflow(database_connection, account_id=account.id)
     create_enrollment(database_connection, workflow.id, contact.id)
 
-    update_enrollment_status(
+    record_enrollment_outcome(
         connection=database_connection,
         workflow_id=workflow.id,
         contact_id=contact.id,
-        status="failed",
+        outcome="failed",
         reason="no response",
     )
-
-    activities = list_activities(
-        database_connection, contact_id=contact.id, activity_type="workflow_failed"
-    )
-    assert len(activities) == 1
-    assert activities[0].summary == "no response"
+    types = [
+        a.type for a in list_activities(database_connection, contact_id=contact.id)
+    ]
+    assert "enrollment_failed" in types
 
 
-def test_update_enrollment_status_active_does_not_emit_activity(
+def test_record_enrollment_outcome_rejects_invalid_outcome(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
-    """Only completed/failed transitions emit; active transitions do not."""
-    from mailpilot.database import list_activities
-
-    account = make_test_account(database_connection)
-    contact = make_test_contact(database_connection)
-    workflow = make_test_workflow(database_connection, account_id=account.id)
-    create_enrollment(database_connection, workflow.id, contact.id)
-
-    update_enrollment_status(
+    result = record_enrollment_outcome(
         connection=database_connection,
-        workflow_id=workflow.id,
-        contact_id=contact.id,
-        status="active",
-        reason="started",
+        workflow_id="wf1",
+        contact_id="c1",
+        outcome="cancelled",
+        reason="x",
     )
+    assert result.get("error") == "invalid_outcome"
 
-    assert list_activities(database_connection, contact_id=contact.id) == []
+
+def test_record_enrollment_outcome_missing_enrollment(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    result = record_enrollment_outcome(
+        connection=database_connection,
+        workflow_id="wf-nonexistent",
+        contact_id="c-nonexistent",
+        outcome="completed",
+        reason="x",
+    )
+    assert result.get("error") == "not_found"
 
 
 # -- disable_contact -----------------------------------------------------------
@@ -564,7 +532,7 @@ def test_list_enrollments_success(
 
     assert len(result) == 1
     assert result[0]["contact_id"] == contact.id
-    assert result[0]["status"] == "pending"
+    assert result[0]["status"] == "active"
 
 
 def test_list_enrollments_empty(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3945,9 +3945,7 @@ def test_note_add(runner: CliRunner, mock_connection: MagicMock) -> None:
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
-        patch(
-            "mailpilot.database.add_contact_note", return_value=note
-        ) as mock_create,
+        patch("mailpilot.database.add_contact_note", return_value=note) as mock_create,
         patch("mailpilot.database.get_contact", return_value=contact),
     ):
         result = runner.invoke(
@@ -4237,7 +4235,7 @@ def _make_enrollment(**overrides: Any) -> Enrollment:
     defaults: dict[str, Any] = {
         "workflow_id": _WORKFLOW_ID,
         "contact_id": _CONTACT_ID,
-        "status": "pending",
+        "status": "active",
         "reason": "",
         "created_at": _NOW,
         "updated_at": _NOW,
@@ -4251,7 +4249,7 @@ def _make_enrollment_summary(**overrides: Any) -> EnrollmentSummary:
         "contact_id": _CONTACT_ID,
         "contact_email": "alice@example.com",
         "contact_name": "Alice Smith",
-        "status": "pending",
+        "status": "active",
         "updated_at": _NOW,
     }
     return EnrollmentSummary(**{**defaults, **overrides})
@@ -4287,14 +4285,14 @@ def test_enrollment_add(runner: CliRunner, mock_connection: MagicMock) -> None:
     assert result.exit_code == 0
     mock_create.assert_called_once_with(mock_connection, _WORKFLOW_ID, _CONTACT_ID)
     activity_kwargs = mock_activity.call_args.kwargs
-    assert activity_kwargs["activity_type"] == "workflow_assigned"
+    assert activity_kwargs["activity_type"] == "enrollment_added"
     assert activity_kwargs["contact_id"] == _CONTACT_ID
-    assert activity_kwargs["detail"]["workflow_id"] == _WORKFLOW_ID
+    assert activity_kwargs["workflow_id"] == _WORKFLOW_ID
     data = json.loads(result.output)
     assert data["ok"] is True
     assert data["workflow_id"] == _WORKFLOW_ID
     assert data["contact_id"] == _CONTACT_ID
-    assert data["status"] == "pending"
+    assert data["status"] == "active"
 
 
 def test_enrollment_add_idempotent(
@@ -4549,7 +4547,7 @@ def test_enrollment_list_with_status(
                 "--workflow-id",
                 _WORKFLOW_ID,
                 "--status",
-                "completed",
+                "paused",
             ],
         )
 
@@ -4558,7 +4556,7 @@ def test_enrollment_list_with_status(
         mock_connection,
         workflow_id=_WORKFLOW_ID,
         contact_id=None,
-        status="completed",
+        status="paused",
         limit=100,
         since=None,
     )
@@ -4647,11 +4645,15 @@ def test_enrollment_list_workflow_not_found(
 # -- enrollment update ---------------------------------------------------------
 
 
-def test_enrollment_update(runner: CliRunner, mock_connection: MagicMock) -> None:
-    updated = _make_enrollment(status="completed", reason="Demo booked")
+def test_enrollment_update_paused_emits_activity(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    before = _make_enrollment(status="active")
+    updated = _make_enrollment(status="paused", reason="vacation")
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_enrollment", return_value=before),
         patch(
             "mailpilot.database.update_enrollment", return_value=updated
         ) as mock_update,
@@ -4668,9 +4670,9 @@ def test_enrollment_update(runner: CliRunner, mock_connection: MagicMock) -> Non
                 "--contact-id",
                 _CONTACT_ID,
                 "--status",
-                "completed",
+                "paused",
                 "--reason",
-                "Demo booked",
+                "vacation",
             ],
         )
 
@@ -4679,63 +4681,57 @@ def test_enrollment_update(runner: CliRunner, mock_connection: MagicMock) -> Non
         mock_connection,
         _WORKFLOW_ID,
         _CONTACT_ID,
-        status="completed",
-        reason="Demo booked",
+        status="paused",
+        reason="vacation",
     )
     activity_kwargs = mock_activity.call_args.kwargs
-    assert activity_kwargs["activity_type"] == "workflow_completed"
-    assert activity_kwargs["summary"] == "Demo booked"
-    data = json.loads(result.output)
-    assert data["ok"] is True
-    assert data["status"] == "completed"
-    assert data["reason"] == "Demo booked"
+    assert activity_kwargs["activity_type"] == "enrollment_paused"
+    assert activity_kwargs["summary"] == "vacation"
+    assert activity_kwargs["workflow_id"] == _WORKFLOW_ID
 
 
-def test_enrollment_update_without_reason(
+def test_enrollment_update_active_emits_resumed_activity(
     runner: CliRunner, mock_connection: MagicMock
 ) -> None:
-    updated = _make_enrollment(status="failed")
-    with (
-        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
-        patch("mailpilot.database.initialize_database", return_value=mock_connection),
-        patch(
-            "mailpilot.database.update_enrollment", return_value=updated
-        ) as mock_update,
-        patch("mailpilot.database.get_contact", return_value=_make_contact()),
-        patch("mailpilot.database.create_activity") as mock_activity,
-    ):
-        result = runner.invoke(
-            main,
-            [
-                "enrollment",
-                "update",
-                "--workflow-id",
-                _WORKFLOW_ID,
-                "--contact-id",
-                _CONTACT_ID,
-                "--status",
-                "failed",
-            ],
-        )
-
-    assert result.exit_code == 0
-    mock_update.assert_called_once_with(
-        mock_connection,
-        _WORKFLOW_ID,
-        _CONTACT_ID,
-        status="failed",
-    )
-    assert mock_activity.call_args.kwargs["activity_type"] == "workflow_failed"
-
-
-def test_enrollment_update_active_does_not_emit_activity(
-    runner: CliRunner, mock_connection: MagicMock
-) -> None:
-    """Transitions to active or pending must not emit a workflow activity."""
+    """paused -> active transition emits enrollment_resumed."""
+    before = _make_enrollment(status="paused")
     updated = _make_enrollment(status="active")
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_enrollment", return_value=before),
+        patch("mailpilot.database.update_enrollment", return_value=updated),
+        patch("mailpilot.database.get_contact", return_value=_make_contact()),
+        patch("mailpilot.database.create_activity") as mock_activity,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "enrollment",
+                "update",
+                "--workflow-id",
+                _WORKFLOW_ID,
+                "--contact-id",
+                _CONTACT_ID,
+                "--status",
+                "active",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert mock_activity.call_args.kwargs["activity_type"] == "enrollment_resumed"
+
+
+def test_enrollment_update_unchanged_status_does_not_emit_activity(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    """No status change -- no activity."""
+    before = _make_enrollment(status="active")
+    updated = _make_enrollment(status="active")
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_enrollment", return_value=before),
         patch("mailpilot.database.update_enrollment", return_value=updated),
         patch("mailpilot.database.create_activity") as mock_activity,
     ):
@@ -4757,13 +4753,13 @@ def test_enrollment_update_active_does_not_emit_activity(
     mock_activity.assert_not_called()
 
 
-def test_enrollment_update_not_found(
+def test_enrollment_update_rejects_legacy_status(
     runner: CliRunner, mock_connection: MagicMock
 ) -> None:
+    """`completed`/`failed`/`pending` are no longer valid CLI statuses."""
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
-        patch("mailpilot.database.update_enrollment", return_value=None),
     ):
         result = runner.invoke(
             main,
@@ -4776,6 +4772,31 @@ def test_enrollment_update_not_found(
                 _CONTACT_ID,
                 "--status",
                 "completed",
+            ],
+        )
+
+    assert result.exit_code != 0
+
+
+def test_enrollment_update_not_found(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_enrollment", return_value=None),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "enrollment",
+                "update",
+                "--workflow-id",
+                _WORKFLOW_ID,
+                "--contact-id",
+                _CONTACT_ID,
+                "--status",
+                "active",
             ],
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3507,8 +3507,8 @@ def test_activity_list_company_not_found(
 def _make_tag(**overrides: Any) -> Tag:
     defaults: dict[str, Any] = {
         "id": "01234567-0000-7000-0000-000000000011",
-        "entity_type": "contact",
-        "entity_id": "01234567-0000-7000-0000-000000000003",
+        "contact_id": "01234567-0000-7000-0000-000000000003",
+        "company_id": None,
         "name": "prospect",
         "created_at": _NOW,
     }
@@ -3524,9 +3524,8 @@ def test_tag_add(runner: CliRunner, mock_connection: MagicMock) -> None:
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
-        patch("mailpilot.database.create_tag", return_value=tag) as mock_create,
+        patch("mailpilot.database.add_contact_tag", return_value=tag) as mock_add,
         patch("mailpilot.database.get_contact", return_value=contact),
-        patch("mailpilot.database.create_activity"),
     ):
         result = runner.invoke(
             main,
@@ -3534,10 +3533,9 @@ def test_tag_add(runner: CliRunner, mock_connection: MagicMock) -> None:
         )
 
     assert result.exit_code == 0
-    mock_create.assert_called_once_with(
+    mock_add.assert_called_once_with(
         mock_connection,
-        entity_type="contact",
-        entity_id="cid-1",
+        contact_id="cid-1",
         name="prospect",
     )
     data = json.loads(result.output)
@@ -3545,30 +3543,25 @@ def test_tag_add(runner: CliRunner, mock_connection: MagicMock) -> None:
     assert data["name"] == "prospect"
 
 
-def test_tag_add_creates_activity(
-    runner: CliRunner, mock_connection: MagicMock
-) -> None:
-    tag = _make_tag()
-    contact = _make_contact()
+def test_tag_add_on_company(runner: CliRunner, mock_connection: MagicMock) -> None:
+    tag = _make_tag(contact_id=None, company_id="comp-1", name="enterprise")
+    company = _make_company(id="comp-1")
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
-        patch("mailpilot.database.create_tag", return_value=tag),
-        patch("mailpilot.database.get_contact", return_value=contact),
-        patch("mailpilot.database.create_activity") as mock_activity,
+        patch("mailpilot.database.add_company_tag", return_value=tag) as mock_add,
+        patch("mailpilot.database.get_company", return_value=company),
     ):
-        runner.invoke(
+        result = runner.invoke(
             main,
-            ["tag", "add", "--contact-id", "cid-1", "prospect"],
+            ["tag", "add", "--company-id", "comp-1", "enterprise"],
         )
 
-    mock_activity.assert_called_once_with(
+    assert result.exit_code == 0
+    mock_add.assert_called_once_with(
         mock_connection,
-        contact_id="cid-1",
-        activity_type="tag_added",
-        summary="Tagged as prospect",
-        detail={"tag": "prospect"},
-        company_id=None,
+        company_id="comp-1",
+        name="enterprise",
     )
 
 
@@ -3578,7 +3571,7 @@ def test_tag_add_already_exists(runner: CliRunner, mock_connection: MagicMock) -
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
         patch("mailpilot.database.get_contact", return_value=contact),
-        patch("mailpilot.database.create_tag", return_value=None),
+        patch("mailpilot.database.add_contact_tag", return_value=None),
     ):
         result = runner.invoke(
             main,
@@ -3638,7 +3631,7 @@ def test_tag_add_no_entity(runner: CliRunner, mock_connection: MagicMock) -> Non
 
     assert result.exit_code == 1
     data = json.loads(result.output)
-    assert data["error"] == "missing_filter"
+    assert data["error"] == "validation_error"
 
 
 def test_tag_add_empty_name(runner: CliRunner, mock_connection: MagicMock) -> None:
@@ -3654,6 +3647,25 @@ def test_tag_add_empty_name(runner: CliRunner, mock_connection: MagicMock) -> No
     assert "name" in data["message"]
 
 
+def test_tag_add_rejects_invalid_name(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    contact = _make_contact()
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_contact", return_value=contact),
+    ):
+        result = runner.invoke(
+            main, ["tag", "add", "--contact-id", "cid-1", "hot/lead"]
+        )
+
+    assert result.exit_code != 0
+    data = json.loads(result.output)
+    assert data["error"] == "validation_error"
+    assert "invalid tag" in data["message"].lower()
+
+
 # -- tag remove ----------------------------------------------------------------
 
 
@@ -3662,9 +3674,10 @@ def test_tag_remove(runner: CliRunner, mock_connection: MagicMock) -> None:
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
-        patch("mailpilot.database.delete_tag", return_value=True) as mock_delete,
+        patch(
+            "mailpilot.database.remove_contact_tag", return_value=True
+        ) as mock_delete,
         patch("mailpilot.database.get_contact", return_value=contact),
-        patch("mailpilot.database.create_activity"),
     ):
         result = runner.invoke(
             main,
@@ -3674,39 +3687,12 @@ def test_tag_remove(runner: CliRunner, mock_connection: MagicMock) -> None:
     assert result.exit_code == 0
     mock_delete.assert_called_once_with(
         mock_connection,
-        entity_type="contact",
-        entity_id="cid-1",
+        contact_id="cid-1",
         name="prospect",
     )
     data = json.loads(result.output)
     assert data["ok"] is True
     assert data["removed"] is True
-
-
-def test_tag_remove_creates_activity(
-    runner: CliRunner, mock_connection: MagicMock
-) -> None:
-    contact = _make_contact()
-    with (
-        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
-        patch("mailpilot.database.initialize_database", return_value=mock_connection),
-        patch("mailpilot.database.delete_tag", return_value=True),
-        patch("mailpilot.database.get_contact", return_value=contact),
-        patch("mailpilot.database.create_activity") as mock_activity,
-    ):
-        runner.invoke(
-            main,
-            ["tag", "remove", "--contact-id", "cid-1", "prospect"],
-        )
-
-    mock_activity.assert_called_once_with(
-        mock_connection,
-        contact_id="cid-1",
-        activity_type="tag_removed",
-        summary="Removed tag prospect",
-        detail={"tag": "prospect"},
-        company_id=None,
-    )
 
 
 def test_tag_remove_not_found(runner: CliRunner, mock_connection: MagicMock) -> None:
@@ -3715,7 +3701,7 @@ def test_tag_remove_not_found(runner: CliRunner, mock_connection: MagicMock) -> 
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
         patch("mailpilot.database.get_contact", return_value=contact),
-        patch("mailpilot.database.delete_tag", return_value=False),
+        patch("mailpilot.database.remove_contact_tag", return_value=False),
     ):
         result = runner.invoke(
             main,
@@ -3783,8 +3769,7 @@ def test_tag_list(runner: CliRunner, mock_connection: MagicMock) -> None:
     assert result.exit_code == 0
     mock_list.assert_called_once_with(
         mock_connection,
-        entity_type="contact",
-        entity_id="cid-1",
+        contact_id="cid-1",
         limit=100,
         since=None,
     )
@@ -3820,8 +3805,7 @@ def test_tag_list_limit_and_since(
     assert result.exit_code == 0
     mock_list.assert_called_once_with(
         mock_connection,
-        entity_type="contact",
-        entity_id="cid-1",
+        contact_id="cid-1",
         limit=5,
         since="2024-01-01T00:00:00",
     )
@@ -3837,7 +3821,7 @@ def test_tag_list_no_entity(runner: CliRunner, mock_connection: MagicMock) -> No
 
     assert result.exit_code == 1
     data = json.loads(result.output)
-    assert data["error"] == "missing_filter"
+    assert data["error"] == "validation_error"
 
 
 def test_tag_list_contact_not_found(
@@ -3886,7 +3870,7 @@ def test_tag_search(runner: CliRunner, mock_connection: MagicMock) -> None:
 
     assert result.exit_code == 0
     mock_search.assert_called_once_with(
-        mock_connection, name="prospect", entity_type=None, limit=100
+        mock_connection, name="prospect", owner=None, limit=100
     )
     data = json.loads(result.output)
     assert data["ok"] is True
@@ -3905,7 +3889,7 @@ def test_tag_search_with_type(runner: CliRunner, mock_connection: MagicMock) -> 
 
     assert result.exit_code == 0
     mock_search.assert_called_once_with(
-        mock_connection, name="prospect", entity_type="contact", limit=5
+        mock_connection, name="prospect", owner="contact", limit=5
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3899,8 +3899,8 @@ def test_tag_search_with_type(runner: CliRunner, mock_connection: MagicMock) -> 
 def _make_note(**overrides: Any) -> Note:
     defaults: dict[str, Any] = {
         "id": "01234567-0000-7000-0000-000000000012",
-        "entity_type": "contact",
-        "entity_id": "01234567-0000-7000-0000-000000000003",
+        "contact_id": "01234567-0000-7000-0000-000000000003",
+        "company_id": None,
         "body": "Test note body",
         "created_at": _NOW,
     }
@@ -3916,9 +3916,10 @@ def test_note_add(runner: CliRunner, mock_connection: MagicMock) -> None:
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
-        patch("mailpilot.database.create_note", return_value=note) as mock_create,
+        patch(
+            "mailpilot.database.add_contact_note", return_value=note
+        ) as mock_create,
         patch("mailpilot.database.get_contact", return_value=contact),
-        patch("mailpilot.database.create_activity"),
     ):
         result = runner.invoke(
             main,
@@ -3928,8 +3929,7 @@ def test_note_add(runner: CliRunner, mock_connection: MagicMock) -> None:
     assert result.exit_code == 0
     mock_create.assert_called_once_with(
         mock_connection,
-        entity_type="contact",
-        entity_id="cid-1",
+        contact_id="cid-1",
         body="Test note body",
     )
     data = json.loads(result.output)
@@ -3938,12 +3938,12 @@ def test_note_add(runner: CliRunner, mock_connection: MagicMock) -> None:
 
 
 def test_note_add_on_company(runner: CliRunner, mock_connection: MagicMock) -> None:
-    note = _make_note(entity_type="company", entity_id="comp-1")
+    note = _make_note(contact_id=None, company_id="comp-1")
     company = _make_company(id="comp-1")
     with (
         patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
         patch("mailpilot.database.initialize_database", return_value=mock_connection),
-        patch("mailpilot.database.create_note", return_value=note),
+        patch("mailpilot.database.add_company_note", return_value=note) as mock_add,
         patch("mailpilot.database.get_company", return_value=company),
     ):
         result = runner.invoke(
@@ -3952,35 +3952,13 @@ def test_note_add_on_company(runner: CliRunner, mock_connection: MagicMock) -> N
         )
 
     assert result.exit_code == 0
+    mock_add.assert_called_once_with(
+        mock_connection,
+        company_id="comp-1",
+        body="Company note",
+    )
     data = json.loads(result.output)
     assert data["ok"] is True
-
-
-def test_note_add_creates_activity(
-    runner: CliRunner, mock_connection: MagicMock
-) -> None:
-    note = _make_note()
-    contact = _make_contact()
-    with (
-        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
-        patch("mailpilot.database.initialize_database", return_value=mock_connection),
-        patch("mailpilot.database.create_note", return_value=note),
-        patch("mailpilot.database.get_contact", return_value=contact),
-        patch("mailpilot.database.create_activity") as mock_activity,
-    ):
-        runner.invoke(
-            main,
-            ["note", "add", "--contact-id", "cid-1", "--body", "Test note body"],
-        )
-
-    mock_activity.assert_called_once_with(
-        mock_connection,
-        contact_id="cid-1",
-        activity_type="note_added",
-        summary="Note added",
-        detail={"note_id": note.id},
-        company_id=None,
-    )
 
 
 def test_note_add_contact_not_found(
@@ -4031,7 +4009,7 @@ def test_note_add_no_entity(runner: CliRunner, mock_connection: MagicMock) -> No
 
     assert result.exit_code == 1
     data = json.loads(result.output)
-    assert data["error"] == "missing_filter"
+    assert data["error"] == "validation_error"
 
 
 def test_note_add_empty_body(runner: CliRunner, mock_connection: MagicMock) -> None:
@@ -4111,7 +4089,7 @@ def test_note_list_with_limit(runner: CliRunner, mock_connection: MagicMock) -> 
 
     assert result.exit_code == 0
     mock_list.assert_called_once_with(
-        mock_connection, entity_type="contact", entity_id="cid-1", limit=5, since=None
+        mock_connection, contact_id="cid-1", limit=5, since=None
     )
 
 
@@ -4138,8 +4116,7 @@ def test_note_list_with_since(runner: CliRunner, mock_connection: MagicMock) -> 
     assert result.exit_code == 0
     mock_list.assert_called_once_with(
         mock_connection,
-        entity_type="contact",
-        entity_id="cid-1",
+        contact_id="cid-1",
         limit=100,
         since="2024-01-01T00:00:00Z",
     )
@@ -4155,7 +4132,7 @@ def test_note_list_no_entity(runner: CliRunner, mock_connection: MagicMock) -> N
 
     assert result.exit_code == 1
     data = json.loads(result.output)
-    assert data["error"] == "missing_filter"
+    assert data["error"] == "validation_error"
 
 
 # -- note view -----------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3147,6 +3147,52 @@ def test_enrollment_run_contact_not_enrolled(
     assert "not enrolled" in data["message"]
 
 
+def test_enrollment_run_paused_enrollment(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    """Manual run is rejected when the enrollment is paused."""
+    workflow = _make_workflow(status="active")
+    contact = Contact(
+        id=_CONTACT_ID,
+        email="lead@acme.com",
+        domain="acme.com",
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    paused = Enrollment(
+        workflow_id=_WORKFLOW_ID,
+        contact_id=_CONTACT_ID,
+        status="paused",
+        reason="operator hold",
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_workflow", return_value=workflow),
+        patch("mailpilot.database.get_contact", return_value=contact),
+        patch("mailpilot.database.get_enrollment", return_value=paused),
+        patch("mailpilot.agent.invoke_workflow_agent") as mock_invoke,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "enrollment",
+                "run",
+                "--workflow-id",
+                _WORKFLOW_ID,
+                "--contact-id",
+                _CONTACT_ID,
+            ],
+        )
+    assert result.exit_code == 1, result.output
+    mock_invoke.assert_not_called()
+    data = json.loads(result.output)
+    assert data["error"] == "invalid_state"
+    assert "paused" in data["message"]
+
+
 def test_enrollment_run_agent_failed(
     runner: CliRunner, mock_connection: MagicMock
 ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3240,14 +3240,43 @@ def test_activity_create(runner: CliRunner, mock_connection: MagicMock) -> None:
     mock_create.assert_called_once_with(
         mock_connection,
         contact_id="cid-1",
+        company_id=None,
         activity_type="email_sent",
         summary="Sent intro",
         detail={},
-        company_id=None,
     )
     data = json.loads(result.output)
     assert data["ok"] is True
     assert data["type"] == "email_sent"
+
+
+def test_activity_create_company_only(
+    runner: CliRunner, mock_connection: MagicMock
+) -> None:
+    """Company-only activity rows are allowed (#102 sugg 2)."""
+    activity = _make_activity(contact_id=None, company_id="comp-1", type="note_added")
+    company = _make_company(id="comp-1")
+    with (
+        patch("mailpilot.settings.get_settings", return_value=make_test_settings()),
+        patch("mailpilot.database.initialize_database", return_value=mock_connection),
+        patch("mailpilot.database.get_company", return_value=company),
+        patch("mailpilot.database.create_activity", return_value=activity),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "activity",
+                "create",
+                "--company-id",
+                "comp-1",
+                "--type",
+                "note_added",
+                "--summary",
+                "Company note",
+            ],
+        )
+
+    assert result.exit_code == 0
 
 
 def test_activity_create_with_detail(
@@ -3283,10 +3312,10 @@ def test_activity_create_with_detail(
     mock_create.assert_called_once_with(
         mock_connection,
         contact_id="cid-1",
+        company_id=None,
         activity_type="email_sent",
         summary="Sent intro",
         detail={"email_id": "e-1"},
-        company_id=None,
     )
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1660,6 +1660,62 @@ def test_list_activities_requires_filter(
         list_activities(database_connection)
 
 
+def test_create_activity_with_structured_fks(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """email_id, workflow_id, task_id are first-class FK columns (#102 sugg 5)."""
+    account = make_test_account(database_connection)
+    contact = make_test_contact(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    email = create_email(
+        database_connection,
+        account_id=account.id,
+        contact_id=contact.id,
+        direction="outbound",
+        subject="Hi",
+        body_text="hi",
+    )
+    assert email is not None
+
+    activity = create_activity(
+        database_connection,
+        contact_id=contact.id,
+        activity_type="email_sent",
+        summary="Hi",
+        email_id=email.id,
+        workflow_id=workflow.id,
+    )
+    assert activity.email_id == email.id
+    assert activity.workflow_id == workflow.id
+    assert activity.task_id is None
+
+
+def test_create_activity_company_only(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """contact_id is nullable when company_id is provided (#102 sugg 2)."""
+    company = make_test_company(database_connection)
+    activity = create_activity(
+        database_connection,
+        company_id=company.id,
+        activity_type="note_added",
+        summary="Company note",
+    )
+    assert activity.contact_id is None
+    assert activity.company_id == company.id
+
+
+def test_create_activity_requires_contact_or_company(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    with pytest.raises(ValueError, match="contact_id or company_id"):
+        create_activity(
+            database_connection,
+            activity_type="note_added",
+            summary="orphan",
+        )
+
+
 def test_status_counts_includes_activities(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -55,7 +55,6 @@ from mailpilot.database import (
     list_contacts,
     list_emails,
     list_enrollments_detailed,
-    list_entities_by_tag,
     list_notes,
     list_tags,
     list_tasks,
@@ -1673,210 +1672,173 @@ def test_status_counts_includes_activities(
 # -- Tag -----------------------------------------------------------------------
 
 
-def test_create_tag(
+def test_normalize_tag_name_accepts_valid_inputs() -> None:
+    """Lowercase, hyphenated, alphanumeric tags pass through unchanged."""
+    from mailpilot.database import _normalize_tag_name
+
+    assert _normalize_tag_name("prospect") == "prospect"
+    assert _normalize_tag_name("hot-lead") == "hot-lead"
+    assert _normalize_tag_name("q4-2025") == "q4-2025"
+
+
+def test_normalize_tag_name_collapses_separators_and_case() -> None:
+    """Whitespace, underscores, and uppercase are normalized; hyphens collapse."""
+    from mailpilot.database import _normalize_tag_name
+
+    assert _normalize_tag_name("Hot Lead") == "hot-lead"
+    assert _normalize_tag_name("hot_lead") == "hot-lead"
+    assert _normalize_tag_name("HOT--LEAD") == "hot-lead"
+    assert _normalize_tag_name("  spaced  ") == "spaced"
+    assert _normalize_tag_name("-leading-trailing-") == "leading-trailing"
+
+
+def test_normalize_tag_name_rejects_invalid() -> None:
+    """Names that cannot be normalized to [a-z0-9][a-z0-9-]* raise ValueError."""
+    from mailpilot.database import _normalize_tag_name
+
+    with pytest.raises(ValueError):
+        _normalize_tag_name("")
+    with pytest.raises(ValueError):
+        _normalize_tag_name("---")
+    with pytest.raises(ValueError):
+        _normalize_tag_name("hot/lead")
+    with pytest.raises(ValueError):
+        _normalize_tag_name("hot.lead")
+
+
+def test_create_contact_tag_and_company_tag(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
+    """create_tag accepts contact_id XOR company_id."""
+    company = make_test_company(database_connection)
     contact = make_test_contact(database_connection)
-    tag = make_test_tag(
-        database_connection, entity_type="contact", entity_id=contact.id
-    )
-    assert tag.entity_type == "contact"
-    assert tag.entity_id == contact.id
-    assert tag.name == "prospect"
-    assert tag.id
+
+    contact_tag = create_tag(database_connection, contact_id=contact.id, name="prospect")
+    assert contact_tag is not None
+    assert contact_tag.contact_id == contact.id
+    assert contact_tag.company_id is None
+    assert contact_tag.name == "prospect"
+
+    company_tag = create_tag(database_connection, company_id=company.id, name="enterprise")
+    assert company_tag is not None
+    assert company_tag.company_id == company.id
+    assert company_tag.contact_id is None
+
+
+def test_create_tag_requires_exactly_one_owner(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """contact_id XOR company_id; passing both or neither raises."""
+    with pytest.raises(ValueError, match="exactly one"):
+        create_tag(database_connection, name="x")
+    with pytest.raises(ValueError, match="exactly one"):
+        create_tag(database_connection, contact_id="c1", company_id="co1", name="x")
 
 
 def test_create_tag_normalizes_name(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
+    """create_tag applies _normalize_tag_name."""
     contact = make_test_contact(database_connection)
-    tag = make_test_tag(
-        database_connection,
-        entity_type="contact",
-        entity_id=contact.id,
-        name="  PROSPECT  ",
-    )
-    assert tag.name == "prospect"
+    tag = create_tag(database_connection, contact_id=contact.id, name="Hot Lead")
+    assert tag is not None
+    assert tag.name == "hot-lead"
 
 
-def test_create_tag_idempotent(
+def test_create_tag_idempotent_on_duplicate(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
+    """Duplicate insert returns None thanks to ON CONFLICT DO NOTHING."""
     contact = make_test_contact(database_connection)
-    first = create_tag(
-        database_connection,
-        entity_type="contact",
-        entity_id=contact.id,
-        name="prospect",
-    )
+    first = create_tag(database_connection, contact_id=contact.id, name="prospect")
+    second = create_tag(database_connection, contact_id=contact.id, name="prospect")
     assert first is not None
-    second = create_tag(
-        database_connection,
-        entity_type="contact",
-        entity_id=contact.id,
-        name="prospect",
-    )
     assert second is None
 
 
-def test_create_tag_on_company(
-    database_connection: psycopg.Connection[dict[str, Any]],
-):
-    company = make_test_company(database_connection)
-    tag = make_test_tag(
-        database_connection,
-        entity_type="company",
-        entity_id=company.id,
-        name="logistics",
-    )
-    assert tag.entity_type == "company"
-    assert tag.name == "logistics"
-
-
-def test_delete_tag(
+def test_delete_tag_by_contact(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
     contact = make_test_contact(database_connection)
-    make_test_tag(database_connection, entity_type="contact", entity_id=contact.id)
-    deleted = delete_tag(
-        database_connection,
-        entity_type="contact",
-        entity_id=contact.id,
-        name="prospect",
-    )
-    assert deleted is True
+    create_tag(database_connection, contact_id=contact.id, name="cold")
+    assert delete_tag(database_connection, contact_id=contact.id, name="cold") is True
+    assert delete_tag(database_connection, contact_id=contact.id, name="cold") is False
 
 
-def test_delete_tag_not_found(
+def test_list_tags_by_contact(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
     contact = make_test_contact(database_connection)
-    deleted = delete_tag(
-        database_connection,
-        entity_type="contact",
-        entity_id=contact.id,
-        name="nonexistent",
-    )
-    assert deleted is False
-
-
-def test_list_tags(
-    database_connection: psycopg.Connection[dict[str, Any]],
-):
-    contact = make_test_contact(database_connection)
-    make_test_tag(
-        database_connection, entity_type="contact", entity_id=contact.id, name="cold"
-    )
-    make_test_tag(
-        database_connection,
-        entity_type="contact",
-        entity_id=contact.id,
-        name="prospect",
-    )
-    tags = list_tags(database_connection, entity_type="contact", entity_id=contact.id)
-    assert len(tags) == 2
-    # Ordered by name
-    assert tags[0].name == "cold"
-    assert tags[1].name == "prospect"
+    create_tag(database_connection, contact_id=contact.id, name="prospect")
+    create_tag(database_connection, contact_id=contact.id, name="cold")
+    tags = list_tags(database_connection, contact_id=contact.id)
+    assert {t.name for t in tags} == {"prospect", "cold"}
 
 
 def test_list_tags_empty(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
     contact = make_test_contact(database_connection)
-    tags = list_tags(database_connection, entity_type="contact", entity_id=contact.id)
+    tags = list_tags(database_connection, contact_id=contact.id)
     assert tags == []
 
 
-def test_list_entities_by_tag(
+def test_list_contacts_by_tag_name(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
-    c1 = make_test_contact(database_connection, email="a@test.com", domain="test.com")
-    c2 = make_test_contact(database_connection, email="b@test.com", domain="test.com")
-    c3 = make_test_contact(database_connection, email="c@test.com", domain="test.com")
-    make_test_tag(
-        database_connection, entity_type="contact", entity_id=c1.id, name="prospect"
-    )
-    make_test_tag(
-        database_connection, entity_type="contact", entity_id=c2.id, name="prospect"
-    )
-    make_test_tag(
-        database_connection, entity_type="contact", entity_id=c3.id, name="client"
-    )
+    from mailpilot.database import list_contacts_by_tag
 
-    ids = list_entities_by_tag(
-        database_connection, entity_type="contact", name="prospect"
-    )
-    assert len(ids) == 2
-    assert c1.id in ids
-    assert c2.id in ids
+    a = make_test_contact(database_connection, email="x1@acme.test", domain="acme.test")
+    b = make_test_contact(database_connection, email="x2@acme.test", domain="acme.test")
+    create_tag(database_connection, contact_id=a.id, name="hot")
+    create_tag(database_connection, contact_id=b.id, name="hot")
+    ids = list_contacts_by_tag(database_connection, name="hot")
+    assert set(ids) == {a.id, b.id}
 
 
-def test_list_entities_by_tag_with_limit(
+def test_list_companies_by_tag_name(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
-    c1 = make_test_contact(database_connection, email="a@test.com", domain="test.com")
-    c2 = make_test_contact(database_connection, email="b@test.com", domain="test.com")
-    make_test_tag(
-        database_connection, entity_type="contact", entity_id=c1.id, name="prospect"
-    )
-    make_test_tag(
-        database_connection, entity_type="contact", entity_id=c2.id, name="prospect"
-    )
+    from mailpilot.database import list_companies_by_tag
 
-    ids = list_entities_by_tag(
-        database_connection, entity_type="contact", name="prospect", limit=1
-    )
-    assert len(ids) == 1
+    a = make_test_company(database_connection, name="A", domain="a.test")
+    b = make_test_company(database_connection, name="B", domain="b.test")
+    create_tag(database_connection, company_id=a.id, name="enterprise")
+    create_tag(database_connection, company_id=b.id, name="enterprise")
+    ids = list_companies_by_tag(database_connection, name="enterprise")
+    assert set(ids) == {a.id, b.id}
 
 
 def test_search_tags(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
     contact = make_test_contact(database_connection)
-    make_test_tag(
-        database_connection,
-        entity_type="contact",
-        entity_id=contact.id,
-        name="prospect",
-    )
-    make_test_tag(
-        database_connection, entity_type="contact", entity_id=contact.id, name="cold"
-    )
+    create_tag(database_connection, contact_id=contact.id, name="prospect")
+    create_tag(database_connection, contact_id=contact.id, name="cold")
 
     results = search_tags(database_connection, name="pro")
     assert len(results) == 1
     assert results[0].name == "prospect"
 
 
-def test_search_tags_with_entity_type(
+def test_search_tags_with_owner(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
     contact = make_test_contact(database_connection)
     company = make_test_company(database_connection)
-    make_test_tag(
-        database_connection,
-        entity_type="contact",
-        entity_id=contact.id,
-        name="prospect",
-    )
-    make_test_tag(
-        database_connection,
-        entity_type="company",
-        entity_id=company.id,
-        name="prospect",
-    )
+    create_tag(database_connection, contact_id=contact.id, name="prospect")
+    create_tag(database_connection, company_id=company.id, name="prospect")
 
-    results = search_tags(database_connection, name="prospect", entity_type="contact")
+    results = search_tags(database_connection, name="prospect", owner="contact")
     assert len(results) == 1
-    assert results[0].entity_type == "contact"
+    assert results[0].contact_id == contact.id
 
 
 def test_status_counts_includes_tags(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
     contact = make_test_contact(database_connection)
-    make_test_tag(database_connection, entity_type="contact", entity_id=contact.id)
+    make_test_tag(database_connection, contact_id=contact.id)
     counts = get_status_counts(database_connection)
     assert counts["tags"] == 1
 
@@ -2767,29 +2729,16 @@ def test_list_tags_limit_and_since(
     database_connection: psycopg.Connection[dict[str, Any]],
 ) -> None:
     contact = make_test_contact(database_connection)
-    make_test_tag(
-        database_connection, entity_type="contact", entity_id=contact.id, name="a"
-    )
-    make_test_tag(
-        database_connection, entity_type="contact", entity_id=contact.id, name="b"
+    make_test_tag(database_connection, contact_id=contact.id, name="a")
+    make_test_tag(database_connection, contact_id=contact.id, name="b")
+    assert (
+        len(list_tags(database_connection, contact_id=contact.id, limit=1)) == 1
     )
     assert (
         len(
             list_tags(
                 database_connection,
-                entity_type="contact",
-                entity_id=contact.id,
-                limit=1,
-            )
-        )
-        == 1
-    )
-    assert (
-        len(
-            list_tags(
-                database_connection,
-                entity_type="contact",
-                entity_id=contact.id,
+                contact_id=contact.id,
                 since="9999-01-01T00:00:00",
             )
         )

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -2164,7 +2164,7 @@ def test_list_enrollments_detailed(
     detail = results[0]
     assert detail.contact_email == "alice@example.com"
     assert detail.contact_name == "Alice Smith"
-    assert detail.status == "pending"
+    assert detail.status == "active"
     assert detail.workflow_id == workflow.id
     assert detail.contact_id == contact.id
 
@@ -2180,12 +2180,50 @@ def test_list_enrollments_detailed_status_filter(
     c2 = make_test_contact(database_connection, email="b@example.com")
     create_enrollment(database_connection, workflow.id, c1.id)
     create_enrollment(database_connection, workflow.id, c2.id)
-    update_enrollment(database_connection, workflow.id, c1.id, status="completed")
+    update_enrollment(database_connection, workflow.id, c1.id, status="paused")
     results = list_enrollments_detailed(
-        database_connection, workflow_id=workflow.id, status="completed"
+        database_connection, workflow_id=workflow.id, status="paused"
     )
     assert len(results) == 1
     assert results[0].contact_id == c1.id
+
+
+def test_create_enrollment_defaults_to_active(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """Enrollment defaults to 'active' (status collapse, comment #4334976677)."""
+    account = make_test_account(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    contact = make_test_contact(database_connection)
+
+    enrollment = create_enrollment(
+        database_connection, workflow_id=workflow.id, contact_id=contact.id
+    )
+    assert enrollment is not None
+    assert enrollment.status == "active"
+
+
+def test_update_enrollment_rejects_legacy_statuses(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """`completed`/`failed`/`pending` are no longer valid enrollment statuses."""
+    from mailpilot.database import update_enrollment
+
+    account = make_test_account(database_connection)
+    workflow = make_test_workflow(database_connection, account_id=account.id)
+    contact = make_test_contact(database_connection)
+    create_enrollment(
+        database_connection, workflow_id=workflow.id, contact_id=contact.id
+    )
+    for bad in ("pending", "completed", "failed"):
+        with pytest.raises((psycopg.errors.CheckViolation, ValueError)):
+            update_enrollment(
+                database_connection,
+                workflow.id,
+                contact.id,
+                status=bad,
+            )
+        database_connection.rollback()
 
 
 def test_list_enrollments_detailed_limit(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1846,44 +1846,46 @@ def test_status_counts_includes_tags(
 # -- Note ---------------------------------------------------------------------
 
 
-def test_create_note(
+def test_create_contact_note_and_company_note(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
+    from mailpilot.database import create_note
+
     contact = make_test_contact(database_connection)
-    note = make_test_note(
-        database_connection, entity_type="contact", entity_id=contact.id
+    contact_note = create_note(
+        database_connection, contact_id=contact.id, body="Met at conf"
     )
-    assert note.entity_type == "contact"
-    assert note.entity_id == contact.id
-    assert note.body == "Test note body"
-    assert note.id
+    assert contact_note.contact_id == contact.id
+    assert contact_note.company_id is None
+
+    company = make_test_company(database_connection)
+    company_note = create_note(
+        database_connection, company_id=company.id, body="Tier 1 account"
+    )
+    assert company_note.company_id == company.id
+    assert company_note.contact_id is None
 
 
-def test_create_note_on_company(
+def test_create_note_requires_exactly_one_owner(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
-    company = make_test_company(database_connection)
-    note = make_test_note(
-        database_connection,
-        entity_type="company",
-        entity_id=company.id,
-        body="Company note",
-    )
-    assert note.entity_type == "company"
-    assert note.body == "Company note"
+    from mailpilot.database import create_note
+
+    with pytest.raises(ValueError, match="exactly one"):
+        create_note(database_connection, body="x")
+    with pytest.raises(ValueError, match="exactly one"):
+        create_note(
+            database_connection, contact_id="c1", company_id="co1", body="x"
+        )
 
 
 def test_list_notes(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
     contact = make_test_contact(database_connection)
-    make_test_note(
-        database_connection, entity_type="contact", entity_id=contact.id, body="first"
-    )
-    make_test_note(
-        database_connection, entity_type="contact", entity_id=contact.id, body="second"
-    )
-    notes = list_notes(database_connection, entity_type="contact", entity_id=contact.id)
+    make_test_note(database_connection, contact_id=contact.id, body="first")
+    make_test_note(database_connection, contact_id=contact.id, body="second")
+    notes = list_notes(database_connection, contact_id=contact.id)
     assert len(notes) == 2
     # Ordered by created_at DESC. Summary exposes body_preview, not body.
     assert notes[0].body_preview == "second"
@@ -1894,7 +1896,7 @@ def test_list_notes_empty(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
     contact = make_test_contact(database_connection)
-    notes = list_notes(database_connection, entity_type="contact", entity_id=contact.id)
+    notes = list_notes(database_connection, contact_id=contact.id)
     assert notes == []
 
 
@@ -1902,15 +1904,9 @@ def test_list_notes_with_limit(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
     contact = make_test_contact(database_connection)
-    make_test_note(
-        database_connection, entity_type="contact", entity_id=contact.id, body="first"
-    )
-    make_test_note(
-        database_connection, entity_type="contact", entity_id=contact.id, body="second"
-    )
-    notes = list_notes(
-        database_connection, entity_type="contact", entity_id=contact.id, limit=1
-    )
+    make_test_note(database_connection, contact_id=contact.id, body="first")
+    make_test_note(database_connection, contact_id=contact.id, body="second")
+    notes = list_notes(database_connection, contact_id=contact.id, limit=1)
     assert len(notes) == 1
 
 
@@ -1920,21 +1916,15 @@ def test_list_notes_since(
     from datetime import datetime, timedelta
 
     contact = make_test_contact(database_connection)
-    make_test_note(
-        database_connection, entity_type="contact", entity_id=contact.id, body="old"
-    )
+    make_test_note(database_connection, contact_id=contact.id, body="old")
     database_connection.execute(
         "UPDATE note SET created_at = CURRENT_TIMESTAMP - interval '2 days' "
         "WHERE body = 'old'"
     )
     database_connection.commit()
-    make_test_note(
-        database_connection, entity_type="contact", entity_id=contact.id, body="recent"
-    )
+    make_test_note(database_connection, contact_id=contact.id, body="recent")
     since = (datetime.now(UTC) - timedelta(days=1)).isoformat()
-    results = list_notes(
-        database_connection, entity_type="contact", entity_id=contact.id, since=since
-    )
+    results = list_notes(database_connection, contact_id=contact.id, since=since)
     assert len(results) == 1
     assert results[0].body_preview == "recent"
 
@@ -1943,9 +1933,7 @@ def test_get_note(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
     contact = make_test_contact(database_connection)
-    created = make_test_note(
-        database_connection, entity_type="contact", entity_id=contact.id
-    )
+    created = make_test_note(database_connection, contact_id=contact.id)
     found = get_note(database_connection, created.id)
     assert found is not None
     assert found.id == created.id
@@ -1963,7 +1951,7 @@ def test_status_counts_includes_notes(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):
     contact = make_test_contact(database_connection)
-    make_test_note(database_connection, entity_type="contact", entity_id=contact.id)
+    make_test_note(database_connection, contact_id=contact.id)
     counts = get_status_counts(database_connection)
     assert counts["notes"] == 1
 
@@ -2642,19 +2630,9 @@ def test_note_list_summary_with_body_preview(
     from mailpilot.models import NoteSummary
 
     contact = make_test_contact(database_connection)
-    make_test_note(
-        database_connection,
-        entity_type="contact",
-        entity_id=contact.id,
-        body="short",
-    )
-    make_test_note(
-        database_connection,
-        entity_type="contact",
-        entity_id=contact.id,
-        body="x" * 200,
-    )
-    notes = list_notes(database_connection, entity_type="contact", entity_id=contact.id)
+    make_test_note(database_connection, contact_id=contact.id, body="short")
+    make_test_note(database_connection, contact_id=contact.id, body="x" * 200)
+    notes = list_notes(database_connection, contact_id=contact.id)
     assert isinstance(notes[0], NoteSummary)
     assert not hasattr(notes[0], "body")
     # Long body truncated to 80 chars + "..." (ordered DESC, long one is first).

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1730,7 +1730,9 @@ def test_status_counts_includes_activities(
 
 def test_normalize_tag_name_accepts_valid_inputs() -> None:
     """Lowercase, hyphenated, alphanumeric tags pass through unchanged."""
-    from mailpilot.database import _normalize_tag_name
+    from mailpilot.database import (
+        _normalize_tag_name,  # pyright: ignore[reportPrivateUsage]
+    )
 
     assert _normalize_tag_name("prospect") == "prospect"
     assert _normalize_tag_name("hot-lead") == "hot-lead"
@@ -1739,7 +1741,9 @@ def test_normalize_tag_name_accepts_valid_inputs() -> None:
 
 def test_normalize_tag_name_collapses_separators_and_case() -> None:
     """Whitespace, underscores, and uppercase are normalized; hyphens collapse."""
-    from mailpilot.database import _normalize_tag_name
+    from mailpilot.database import (
+        _normalize_tag_name,  # pyright: ignore[reportPrivateUsage]
+    )
 
     assert _normalize_tag_name("Hot Lead") == "hot-lead"
     assert _normalize_tag_name("hot_lead") == "hot-lead"
@@ -1750,15 +1754,17 @@ def test_normalize_tag_name_collapses_separators_and_case() -> None:
 
 def test_normalize_tag_name_rejects_invalid() -> None:
     """Names that cannot be normalized to [a-z0-9][a-z0-9-]* raise ValueError."""
-    from mailpilot.database import _normalize_tag_name
+    from mailpilot.database import (
+        _normalize_tag_name,  # pyright: ignore[reportPrivateUsage]
+    )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="invalid tag name"):
         _normalize_tag_name("")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="invalid tag name"):
         _normalize_tag_name("---")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="invalid tag name"):
         _normalize_tag_name("hot/lead")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="invalid tag name"):
         _normalize_tag_name("hot.lead")
 
 
@@ -1769,13 +1775,17 @@ def test_create_contact_tag_and_company_tag(
     company = make_test_company(database_connection)
     contact = make_test_contact(database_connection)
 
-    contact_tag = create_tag(database_connection, contact_id=contact.id, name="prospect")
+    contact_tag = create_tag(
+        database_connection, contact_id=contact.id, name="prospect"
+    )
     assert contact_tag is not None
     assert contact_tag.contact_id == contact.id
     assert contact_tag.company_id is None
     assert contact_tag.name == "prospect"
 
-    company_tag = create_tag(database_connection, company_id=company.id, name="enterprise")
+    company_tag = create_tag(
+        database_connection, company_id=company.id, name="enterprise"
+    )
     assert company_tag is not None
     assert company_tag.company_id == company.id
     assert company_tag.contact_id is None
@@ -1976,7 +1986,9 @@ def test_remove_company_tag_emits_activity_atomically(
     company = make_test_company(database_connection)
     add_company_tag(database_connection, company_id=company.id, name="enterprise")
     assert (
-        remove_company_tag(database_connection, company_id=company.id, name="enterprise")
+        remove_company_tag(
+            database_connection, company_id=company.id, name="enterprise"
+        )
         is True
     )
     types = [
@@ -2045,9 +2057,7 @@ def test_create_note_requires_exactly_one_owner(
     with pytest.raises(ValueError, match="exactly one"):
         create_note(database_connection, body="x")
     with pytest.raises(ValueError, match="exactly one"):
-        create_note(
-            database_connection, contact_id="c1", company_id="co1", body="x"
-        )
+        create_note(database_connection, contact_id="c1", company_id="co1", body="x")
 
 
 def test_list_notes(
@@ -2918,9 +2928,7 @@ def test_list_tags_limit_and_since(
     contact = make_test_contact(database_connection)
     make_test_tag(database_connection, contact_id=contact.id, name="a")
     make_test_tag(database_connection, contact_id=contact.id, name="b")
-    assert (
-        len(list_tags(database_connection, contact_id=contact.id, limit=1)) == 1
-    )
+    assert len(list_tags(database_connection, contact_id=contact.id, limit=1)) == 1
     assert (
         len(
             list_tags(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1899,6 +1899,121 @@ def test_status_counts_includes_tags(
     assert counts["tags"] == 1
 
 
+# -- Atomic helpers ----------------------------------------------------------
+
+
+def test_add_contact_tag_emits_activity_atomically(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """add_contact_tag writes tag + tag_added activity in one transaction."""
+    from mailpilot.database import add_contact_tag
+
+    contact = make_test_contact(database_connection)
+    tag = add_contact_tag(database_connection, contact_id=contact.id, name="prospect")
+    assert tag is not None
+    assert tag.name == "prospect"
+    assert [t.name for t in list_tags(database_connection, contact_id=contact.id)] == [
+        "prospect"
+    ]
+    activities = list_activities(database_connection, contact_id=contact.id)
+    assert len(activities) == 1
+    assert activities[0].type == "tag_added"
+    assert activities[0].summary == "Tagged as prospect"
+
+
+def test_add_contact_tag_returns_none_on_duplicate_no_activity(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    """Duplicate tag insert returns None and emits no activity."""
+    from mailpilot.database import add_contact_tag
+
+    contact = make_test_contact(database_connection)
+    add_contact_tag(database_connection, contact_id=contact.id, name="prospect")
+    second = add_contact_tag(
+        database_connection, contact_id=contact.id, name="prospect"
+    )
+    assert second is None
+    activities = list_activities(database_connection, contact_id=contact.id)
+    assert len(activities) == 1
+
+
+def test_remove_contact_tag_emits_activity_atomically(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    from mailpilot.database import add_contact_tag, remove_contact_tag
+
+    contact = make_test_contact(database_connection)
+    add_contact_tag(database_connection, contact_id=contact.id, name="cold")
+    assert (
+        remove_contact_tag(database_connection, contact_id=contact.id, name="cold")
+        is True
+    )
+    types = [
+        a.type for a in list_activities(database_connection, contact_id=contact.id)
+    ]
+    assert "tag_removed" in types
+
+
+def test_add_company_tag_emits_company_activity(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    from mailpilot.database import add_company_tag
+
+    company = make_test_company(database_connection)
+    add_company_tag(database_connection, company_id=company.id, name="enterprise")
+    activities = list_activities(database_connection, company_id=company.id)
+    assert len(activities) == 1
+    assert activities[0].type == "tag_added"
+    assert activities[0].company_id == company.id
+    assert activities[0].contact_id is None
+
+
+def test_remove_company_tag_emits_activity_atomically(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    from mailpilot.database import add_company_tag, remove_company_tag
+
+    company = make_test_company(database_connection)
+    add_company_tag(database_connection, company_id=company.id, name="enterprise")
+    assert (
+        remove_company_tag(database_connection, company_id=company.id, name="enterprise")
+        is True
+    )
+    types = [
+        a.type for a in list_activities(database_connection, company_id=company.id)
+    ]
+    assert "tag_removed" in types
+
+
+def test_add_contact_note_emits_activity_atomically(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    from mailpilot.database import add_contact_note
+
+    contact = make_test_contact(database_connection)
+    note = add_contact_note(
+        database_connection, contact_id=contact.id, body="quick note"
+    )
+    notes = list_notes(database_connection, contact_id=contact.id)
+    assert [n.id for n in notes] == [note.id]
+    activities = list_activities(database_connection, contact_id=contact.id)
+    assert len(activities) == 1
+    assert activities[0].type == "note_added"
+
+
+def test_add_company_note_emits_company_activity(
+    database_connection: psycopg.Connection[dict[str, Any]],
+):
+    from mailpilot.database import add_company_note
+
+    company = make_test_company(database_connection)
+    add_company_note(database_connection, company_id=company.id, body="ent")
+    activities = list_activities(database_connection, company_id=company.id)
+    assert len(activities) == 1
+    assert activities[0].type == "note_added"
+    assert activities[0].company_id == company.id
+
+
 # -- Note ---------------------------------------------------------------------
 
 

--- a/tests/test_email_ops.py
+++ b/tests/test_email_ops.py
@@ -209,70 +209,6 @@ def test_send_email_raises_cooldown_when_recent_cold_send(
     gmail_client.send_message.assert_not_called()
 
 
-def test_send_email_activates_pending_enrollment(
-    database_connection: psycopg.Connection[dict[str, Any]],
-) -> None:
-    account = make_test_account(database_connection)
-    contact = make_test_contact(
-        database_connection, email="recipient@example.com", domain="example.com"
-    )
-    workflow = make_test_workflow(database_connection, account_id=account.id)
-    _activate(database_connection, workflow.id)
-    create_enrollment(database_connection, workflow.id, contact.id)
-    gmail_client = _make_gmail_client(account)
-
-    send_email(
-        connection=database_connection,
-        account=account,
-        gmail_client=gmail_client,
-        settings=make_test_settings(),
-        to="recipient@example.com",
-        subject="Hello",
-        body="Hi",
-        workflow_id=workflow.id,
-    )
-
-    enrollment = get_enrollment(database_connection, workflow.id, contact.id)
-    assert enrollment is not None
-    assert enrollment.status == "active"
-
-
-def test_send_email_pending_to_active_does_not_emit_workflow_activity(
-    database_connection: psycopg.Connection[dict[str, Any]],
-) -> None:
-    """The pending->active transition done inside email_ops must NOT emit
-    a workflow_completed/workflow_failed/workflow_assigned activity --
-    workflow_assigned and email_sent already cover the timeline."""
-    from mailpilot.database import list_activities
-
-    account = make_test_account(database_connection)
-    contact = make_test_contact(
-        database_connection, email="recipient@example.com", domain="example.com"
-    )
-    workflow = make_test_workflow(database_connection, account_id=account.id)
-    _activate(database_connection, workflow.id)
-    create_enrollment(database_connection, workflow.id, contact.id)
-    gmail_client = _make_gmail_client(account)
-
-    send_email(
-        connection=database_connection,
-        account=account,
-        gmail_client=gmail_client,
-        settings=make_test_settings(),
-        to="recipient@example.com",
-        subject="Hello",
-        body="Hi",
-        workflow_id=workflow.id,
-    )
-
-    workflow_activities = [
-        a
-        for a in list_activities(database_connection, contact_id=contact.id)
-        if a.type in ("workflow_assigned", "workflow_completed", "workflow_failed")
-    ]
-    assert workflow_activities == []
-
-
 def test_send_email_no_workflow_id_skips_enrollment(
     database_connection: psycopg.Connection[dict[str, Any]],
 ) -> None:
@@ -517,34 +453,6 @@ def test_reply_email_passes_in_reply_to_kwarg(
     )
 
 
-def test_reply_email_activates_pending_enrollment(
-    database_connection: psycopg.Connection[dict[str, Any]],
-) -> None:
-    account = make_test_account(database_connection)
-    contact = make_test_contact(
-        database_connection, email="sender@example.com", domain="example.com"
-    )
-    workflow = make_test_workflow(database_connection, account_id=account.id)
-    _activate(database_connection, workflow.id)
-    create_enrollment(database_connection, workflow.id, contact.id)
-    inbound = _make_inbound(database_connection, account.id, contact.id, workflow.id)
-    gmail_client = _make_gmail_client(account)
-
-    reply_email(
-        connection=database_connection,
-        account=account,
-        gmail_client=gmail_client,
-        settings=make_test_settings(),
-        email_id=inbound.id,
-        body="hi",
-        workflow_id=workflow.id,
-    )
-
-    enrollment = get_enrollment(database_connection, workflow.id, contact.id)
-    assert enrollment is not None
-    assert enrollment.status == "active"
-
-
 # -- Activity emission ---------------------------------------------------------
 
 
@@ -552,7 +460,7 @@ def test_send_email_emits_email_sent_activity(
     database_connection: psycopg.Connection[dict[str, Any]],
 ) -> None:
     """A successful send must produce one email_sent activity tied to the
-    resolved contact, with subject summary and workflow_id in the detail."""
+    resolved contact, with subject summary and email_id/workflow_id FKs."""
     from mailpilot.database import create_company, list_activities
 
     account = make_test_account(database_connection)
@@ -569,7 +477,7 @@ def test_send_email_emits_email_sent_activity(
     _activate(database_connection, workflow.id)
     gmail_client = _make_gmail_client(account)
 
-    send_email(
+    email = send_email(
         connection=database_connection,
         account=account,
         gmail_client=gmail_client,
@@ -586,6 +494,14 @@ def test_send_email_emits_email_sent_activity(
     assert len(activities) == 1
     assert activities[0].summary == "Outbound test"
     assert activities[0].company_id == company.id
+    row = database_connection.execute(
+        "SELECT email_id, workflow_id FROM activity "
+        "WHERE type = 'email_sent' AND contact_id = %s",
+        (contact.id,),
+    ).fetchone()
+    assert row is not None
+    assert row["email_id"] == email.id
+    assert row["workflow_id"] == workflow.id
 
 
 def test_send_email_skips_activity_when_contact_unknown(

--- a/tests/test_email_ops.py
+++ b/tests/test_email_ops.py
@@ -18,8 +18,6 @@ from conftest import (
 from mailpilot.database import (
     activate_workflow,
     create_email,
-    create_enrollment,
-    get_enrollment,
     update_workflow,
 )
 from mailpilot.database import disable_contact as db_disable_contact

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -77,8 +77,102 @@ def test_enrollment_defaults():
     enrollment = Enrollment(
         workflow_id="w1", contact_id="c1", created_at=NOW, updated_at=NOW
     )
-    assert enrollment.status == "pending"
+    assert enrollment.status == "active"
     assert enrollment.reason == ""
+
+
+def test_enrollment_status_literal_is_active_or_paused() -> None:
+    """EnrollmentStatus collapsed to operational state only (#102)."""
+    from typing import get_args
+
+    from mailpilot.models import EnrollmentStatus
+
+    assert set(get_args(EnrollmentStatus)) == {"active", "paused"}
+
+
+def test_activity_type_literal_uses_enrollment_vocabulary() -> None:
+    """workflow_* renamed to enrollment_*; pause/resume added (#102)."""
+    from typing import get_args
+
+    from mailpilot.models import ActivityType
+
+    assert set(get_args(ActivityType)) == {
+        "email_sent",
+        "email_received",
+        "note_added",
+        "tag_added",
+        "tag_removed",
+        "status_changed",
+        "enrollment_added",
+        "enrollment_completed",
+        "enrollment_failed",
+        "enrollment_paused",
+        "enrollment_resumed",
+    }
+
+
+def test_tag_uses_nullable_contact_company_fks() -> None:
+    """Polymorphic entity_type/entity_id replaced with typed FKs (#102 suggestion 1)."""
+    from mailpilot.models import Tag
+
+    contact_tag = Tag(
+        id="t1",
+        contact_id="c1",
+        company_id=None,
+        name="prospect",
+        created_at=NOW,
+    )
+    assert contact_tag.contact_id == "c1"
+    assert contact_tag.company_id is None
+    assert not hasattr(contact_tag, "entity_type")
+    assert not hasattr(contact_tag, "entity_id")
+
+
+def test_note_uses_nullable_contact_company_fks() -> None:
+    """Polymorphic entity_type/entity_id replaced with typed FKs (#102 suggestion 1)."""
+    from mailpilot.models import Note
+
+    note = Note(
+        id="n1",
+        company_id="co1",
+        contact_id=None,
+        body="Met at conf",
+        created_at=NOW,
+    )
+    assert note.company_id == "co1"
+    assert note.contact_id is None
+
+
+def test_activity_supports_company_only_and_structured_fks() -> None:
+    """contact_id is nullable; email_id/workflow_id/task_id added (#102 suggestions 2, 5)."""
+    from mailpilot.models import Activity
+
+    company_activity = Activity(
+        id="a1",
+        contact_id=None,
+        company_id="co1",
+        type="note_added",
+        summary="Company note",
+        detail={},
+        created_at=NOW,
+    )
+    assert company_activity.contact_id is None
+    assert company_activity.company_id == "co1"
+
+    email_activity = Activity(
+        id="a2",
+        contact_id="c1",
+        company_id=None,
+        email_id="e1",
+        workflow_id="wf1",
+        type="email_sent",
+        summary="Subject",
+        detail={},
+        created_at=NOW,
+    )
+    assert email_activity.email_id == "e1"
+    assert email_activity.workflow_id == "wf1"
+    assert email_activity.task_id is None
 
 
 def test_email_direction_literal():

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -569,7 +569,7 @@ def test_route_email_creates_enrollment_on_route(
 
     enrollment = get_enrollment(database_connection, workflow.id, contact.id)
     assert enrollment is not None
-    assert enrollment.status == "pending"
+    assert enrollment.status == "active"
 
 
 def test_route_email_enrollment_idempotent(
@@ -626,11 +626,11 @@ def test_route_email_enrollment_idempotent(
     assert routed.is_routed is True
 
 
-def test_route_email_emits_workflow_assigned_activity(
+def test_route_email_emits_enrollment_added_activity(
     database_connection: psycopg.Connection[dict[str, Any]],
 ) -> None:
-    """A first-time enrollment must emit a workflow_assigned activity tied
-    to the contact, with workflow id + name in the detail."""
+    """A first-time enrollment must emit an enrollment_added activity tied
+    to the contact, with workflow_id populated as a column."""
     from mailpilot.database import list_activities
 
     account = make_test_account(database_connection, email="wact@example.com")
@@ -669,17 +669,24 @@ def test_route_email_emits_workflow_assigned_activity(
     )
 
     activities = list_activities(
-        database_connection, contact_id=contact.id, activity_type="workflow_assigned"
+        database_connection, contact_id=contact.id, activity_type="enrollment_added"
     )
     assert len(activities) == 1
     assert workflow.name in activities[0].summary
+    row = database_connection.execute(
+        "SELECT workflow_id FROM activity WHERE type = 'enrollment_added' "
+        "AND contact_id = %s",
+        (contact.id,),
+    ).fetchone()
+    assert row is not None
+    assert row["workflow_id"] == workflow.id
 
 
-def test_route_email_workflow_assigned_only_once_on_duplicate_enrollment(
+def test_route_email_enrollment_added_only_once_on_duplicate_enrollment(
     database_connection: psycopg.Connection[dict[str, Any]],
 ) -> None:
     """When create_enrollment hits ON CONFLICT (returns None), no second
-    workflow_assigned activity should be emitted for the same pair."""
+    enrollment_added activity should be emitted for the same pair."""
     from mailpilot.database import list_activities
 
     account = make_test_account(database_connection, email="wactdup@example.com")
@@ -717,7 +724,7 @@ def test_route_email_workflow_assigned_only_once_on_duplicate_enrollment(
         )
 
     activities = list_activities(
-        database_connection, contact_id=contact.id, activity_type="workflow_assigned"
+        database_connection, contact_id=contact.id, activity_type="enrollment_added"
     )
     assert len(activities) == 1
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -11,6 +11,7 @@ import psycopg
 from mailpilot.models import (
     Contact,
     Email,
+    Enrollment,
     Task,
     Workflow,
 )
@@ -68,6 +69,18 @@ def _make_task(**overrides: Any) -> Task:
     return Task(**{**defaults, **overrides})
 
 
+def _make_enrollment(**overrides: Any) -> Enrollment:
+    defaults: dict[str, Any] = {
+        "workflow_id": _WORKFLOW_ID,
+        "contact_id": _CONTACT_ID,
+        "status": "active",
+        "reason": "",
+        "created_at": _NOW,
+        "updated_at": _NOW,
+    }
+    return Enrollment(**{**defaults, **overrides})
+
+
 def _make_email(**overrides: Any) -> Email:
     defaults: dict[str, Any] = {
         "id": _EMAIL_ID,
@@ -98,11 +111,13 @@ def test_execute_task_success(
     task = _make_task()
     workflow = _make_workflow()
     contact = _make_contact()
+    enrollment = _make_enrollment()
 
     agent_result = {"tool_calls": 2, "reasoning": "Sent follow-up."}
     with (
         patch("mailpilot.run.get_workflow", return_value=workflow),
         patch("mailpilot.run.get_contact", return_value=contact),
+        patch("mailpilot.run.get_enrollment", return_value=enrollment),
         patch(
             "mailpilot.run.invoke_workflow_agent",
             return_value=agent_result,
@@ -178,7 +193,37 @@ def test_execute_task_disabled_contact(
     )
 
 
-def test_execute_task_lock_held(
+def test_execute_task_paused_enrollment(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    from conftest import make_test_settings
+    from mailpilot.run import execute_task
+
+    settings = make_test_settings()
+    task = _make_task()
+    workflow = _make_workflow()
+    contact = _make_contact()
+    enrollment = _make_enrollment(status="paused", reason="operator hold")
+
+    with (
+        patch("mailpilot.run.get_workflow", return_value=workflow),
+        patch("mailpilot.run.get_contact", return_value=contact),
+        patch("mailpilot.run.get_enrollment", return_value=enrollment),
+        patch("mailpilot.run.invoke_workflow_agent") as mock_invoke,
+        patch("mailpilot.run.complete_task") as mock_complete,
+    ):
+        execute_task(database_connection, settings, task)
+
+    mock_invoke.assert_not_called()
+    mock_complete.assert_called_once_with(
+        database_connection,
+        _TASK_ID,
+        status="cancelled",
+        result={"reason": "enrollment paused"},
+    )
+
+
+def test_execute_task_missing_enrollment(
     database_connection: psycopg.Connection[dict[str, Any]],
 ) -> None:
     from conftest import make_test_settings
@@ -192,6 +237,37 @@ def test_execute_task_lock_held(
     with (
         patch("mailpilot.run.get_workflow", return_value=workflow),
         patch("mailpilot.run.get_contact", return_value=contact),
+        patch("mailpilot.run.get_enrollment", return_value=None),
+        patch("mailpilot.run.invoke_workflow_agent") as mock_invoke,
+        patch("mailpilot.run.complete_task") as mock_complete,
+    ):
+        execute_task(database_connection, settings, task)
+
+    mock_invoke.assert_not_called()
+    mock_complete.assert_called_once_with(
+        database_connection,
+        _TASK_ID,
+        status="cancelled",
+        result={"reason": "enrollment not found"},
+    )
+
+
+def test_execute_task_lock_held(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    from conftest import make_test_settings
+    from mailpilot.run import execute_task
+
+    settings = make_test_settings()
+    task = _make_task()
+    workflow = _make_workflow()
+    contact = _make_contact()
+    enrollment = _make_enrollment()
+
+    with (
+        patch("mailpilot.run.get_workflow", return_value=workflow),
+        patch("mailpilot.run.get_contact", return_value=contact),
+        patch("mailpilot.run.get_enrollment", return_value=enrollment),
         patch("mailpilot.run.invoke_workflow_agent", return_value=None),
         patch("mailpilot.run.complete_task") as mock_complete,
     ):
@@ -210,10 +286,12 @@ def test_execute_task_agent_error(
     task = _make_task()
     workflow = _make_workflow()
     contact = _make_contact()
+    enrollment = _make_enrollment()
 
     with (
         patch("mailpilot.run.get_workflow", return_value=workflow),
         patch("mailpilot.run.get_contact", return_value=contact),
+        patch("mailpilot.run.get_enrollment", return_value=enrollment),
         patch(
             "mailpilot.run.invoke_workflow_agent",
             side_effect=RuntimeError("LLM error"),
@@ -241,10 +319,12 @@ def test_execute_task_with_email(
     task = _make_task(email_id=_EMAIL_ID)
     workflow = _make_workflow()
     contact = _make_contact()
+    enrollment = _make_enrollment()
 
     with (
         patch("mailpilot.run.get_workflow", return_value=workflow),
         patch("mailpilot.run.get_contact", return_value=contact),
+        patch("mailpilot.run.get_enrollment", return_value=enrollment),
         patch("mailpilot.run.get_email", return_value=email),
         patch(
             "mailpilot.run.invoke_workflow_agent",

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1746,6 +1746,13 @@ def test_sync_inbound_emits_email_received_activity(
     activity = activities[0]
     assert activity.summary == "Activity wiring test"
     assert activity.company_id == company.id
+    row = database_connection.execute(
+        "SELECT email_id FROM activity "
+        "WHERE type = 'email_received' AND contact_id = %s",
+        (contact.id,),
+    ).fetchone()
+    assert row is not None
+    assert row["email_id"] == email.id
 
 
 def test_sync_inbound_skips_activity_when_create_email_returns_none(


### PR DESCRIPTION
Resolves #102.

## Summary

Applies all five design refinements from issue #102, plus the enrollment-status
collapse and paused-enrollment enforcement gate added during implementation.

## Changes

**Schema**
- `tag` and `note`: nullable typed FKs (`contact_id` / `company_id`) with CHECK
  constraints and partial unique indexes, replacing the polymorphic `entity_type`
  / `entity_id` design; enforces XOR at the DB level with full referential integrity
- `activity`: allow company-only rows (`contact_id` nullable, CHECK contact IS NOT
  NULL OR company IS NOT NULL); add structured FK columns `email_id`, `workflow_id`,
  `task_id`; composite timeline indexes
- `enrollment.status` collapsed to `(active, paused)` only -- `pending`, `completed`,
  `failed` removed; outcomes recorded exclusively in the activity timeline

**Activity vocabulary** (ADR-08 sect. 3)
- Renamed `workflow_assigned` -> `enrollment_added`
- Replaced `workflow_completed` / `workflow_failed` with `enrollment_completed` /
  `enrollment_failed` (emitted by new agent tool, not enrollment row mutation)

**Agent tool**
- Removed `update_enrollment_status` tool; replaced with `record_enrollment_outcome`
  which writes an activity row (with `enrollment_status_changed`-class types) and
  does not touch `enrollment.status`
- `list_enrollments` agent tool now returns `latest_outcome` / `latest_outcome_reason`
  / `latest_outcome_at` via LEFT JOIN LATERAL on activity timeline

**Runtime enforcement**
- `execute_task` cancels (not executes) tasks whose enrollment is paused or
  missing -- ADR-08 "paused = suspended" contract
- `enrollment run` CLI rejects paused enrollments with `invalid_state`

**Atomic DB helpers** (ADR-08 sect. 4)
- `add_contact_tag`, `add_company_tag`, `add_contact_note`, `add_company_note`,
  `remove_contact_tag`, `remove_company_tag`: each writes the CRM entity + activity
  row in one transaction

**Tag normalization**
- Strict regex `[a-z0-9][a-z0-9-]*`; invalid names raise at the DB boundary

**Structured activity FKs** (ADR-08 sect. 5)
- `email_received` activity carries `email_id` FK (emitted by sync)
- `email_sent` activity carries `email_id` + `workflow_id` FKs (emitted by email_ops)
- `enrollment_added` activity carries `workflow_id` FK (emitted by routing)

**Docs**
- Rewrote `docs/adr-08-crm-design.md` to match implemented design
- Updated CLAUDE.md project instructions
- Aligned `/smoke-test` skill with new enrollment vocabulary and tool names

## Issue triage

- Closes #102 (all suggestions implemented)
- #86 spec obsoleted: trigger condition (`enrollment.status == 'completed'`) and
  tool reference (`update_enrollment_status`) no longer exist; needs rewrite
- #83 partially helped: paused-gate is a manual circuit-breaker; structural
  self-thread guard still unimplemented