### PR TITLE
fix(sync): dedup account syncs when Pub/Sub event coincides with full sweep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 .claude/worktrees/
 .env
 .firecrawl/
-.pytest_cache
+.pytest_cache/
 .ruff_cache/
 .superpowers/
 .venv/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 .claude/worktrees/
 .env
 .firecrawl/
+.pytest_cache
+.ruff_cache/
 .superpowers/
 .venv/
 build/

--- a/src/mailpilot/sync.py
+++ b/src/mailpilot/sync.py
@@ -396,10 +396,10 @@ def _sync_all_accounts(
     """
     summaries = list_accounts(connection, limit=1000)
     for summary in summaries:
+        if summary.email in synced:
+            continue
         account = get_account(connection, summary.id)
         if account is None:
-            continue
-        if account.email in synced:
             continue
         try:
             client = GmailClient(account.email)

--- a/src/mailpilot/sync.py
+++ b/src/mailpilot/sync.py
@@ -334,12 +334,16 @@ def _run_periodic_iteration(
         wakeup_source=wakeup_source,
         did_full_sweep=do_full_sweep,
     ):
+        # Track accounts synced this tick so the full sweep doesn't re-run
+        # work the Pub/Sub drain just did.
+        synced: set[str] = set()
+
         # Sync accounts from Pub/Sub notifications.
-        _drain_sync_queue(connection, settings, sync_queue)
+        _drain_sync_queue(connection, settings, sync_queue, synced)
 
         # Periodic safety-net sync of all accounts.
         if do_full_sweep:
-            _sync_all_accounts(connection, settings)
+            _sync_all_accounts(connection, settings, synced)
 
         # Bridge routed emails to tasks and drain the queue.
         create_tasks_for_routed_emails(connection)
@@ -350,9 +354,9 @@ def _drain_sync_queue(
     connection: psycopg.Connection[dict[str, Any]],
     settings: Settings,
     sync_queue: queue.Queue[str],
+    synced: set[str],
 ) -> None:
     """Sync accounts that received Pub/Sub notifications."""
-    synced: set[str] = set()
     while not sync_queue.empty():
         try:
             email = sync_queue.get_nowait()
@@ -383,16 +387,24 @@ def _drain_sync_queue(
 def _sync_all_accounts(
     connection: psycopg.Connection[dict[str, Any]],
     settings: Settings,
+    synced: set[str],
 ) -> None:
-    """Sync all Gmail accounts. Errors per account are logged, not raised."""
+    """Sync all Gmail accounts. Errors per account are logged, not raised.
+
+    Accounts already present in ``synced`` (already handled this tick by
+    ``_drain_sync_queue``) are skipped to avoid duplicate Gmail round-trips.
+    """
     summaries = list_accounts(connection, limit=1000)
     for summary in summaries:
         account = get_account(connection, summary.id)
         if account is None:
             continue
+        if account.email in synced:
+            continue
         try:
             client = GmailClient(account.email)
             sync_account(connection, account, client, settings)
+            synced.add(account.email)
         except Exception as exc:
             logfire.exception(
                 "sync.account.sync_failed",

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -400,6 +400,45 @@ def test_run_periodic_iteration_skips_sync_all_when_do_full_sweep_false(
     assert spans[0]["attributes"]["did_full_sweep"] is False
 
 
+def test_run_periodic_iteration_full_sweep_skips_already_synced(
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """An account synced from the Pub/Sub queue is not synced again by the
+    full sweep in the same iteration.
+    """
+    import queue as _queue
+
+    from mailpilot.sync import (
+        _run_periodic_iteration,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    notified = make_test_account(
+        database_connection, email="notified@example.com", display_name="Notified"
+    )
+    other = make_test_account(
+        database_connection, email="other@example.com", display_name="Other"
+    )
+
+    settings = make_test_settings()
+    sync_queue: _queue.Queue[str] = _queue.Queue()
+    sync_queue.put(notified.email)
+
+    with (
+        patch("mailpilot.sync.GmailClient"),
+        patch("mailpilot.sync.sync_account") as mock_sync_account,
+    ):
+        _run_periodic_iteration(
+            database_connection,
+            settings,
+            sync_queue,
+            wakeup_source="event",
+            do_full_sweep=True,
+        )
+
+    synced_emails = [call.args[1].email for call in mock_sync_account.call_args_list]
+    assert sorted(synced_emails) == sorted([notified.email, other.email])
+
+
 def test_start_sync_loop_time_gates_full_sweep(
     database_connection: psycopg.Connection[dict[str, Any]],
 ):

--- a/tests/test_sync_loop_operator_log.py
+++ b/tests/test_sync_loop_operator_log.py
@@ -111,7 +111,7 @@ def test_drain_sync_queue_emits_pubsub_notify(
     sync_queue: queue.Queue[str] = queue.Queue()
     sync_queue.put(account.email)
 
-    _drain_sync_queue(database_connection, make_test_settings(), sync_queue)
+    _drain_sync_queue(database_connection, make_test_settings(), sync_queue, set())
 
     out = capsys.readouterr().out
     assert "event=pubsub.notify" in out
@@ -195,7 +195,7 @@ def test_drain_sync_queue_emits_error_on_sync_failure(
     sync_queue: queue.Queue[str] = queue.Queue()
     sync_queue.put(account.email)
 
-    _drain_sync_queue(database_connection, make_test_settings(), sync_queue)
+    _drain_sync_queue(database_connection, make_test_settings(), sync_queue, set())
 
     out = capsys.readouterr().out
     assert "event=error" in out


### PR DESCRIPTION
## Summary

- When a Pub/Sub notification wakes `start_sync_loop` on the same tick that the periodic full-sweep timer fires, both `_drain_sync_queue` and `_sync_all_accounts` ran -- and the synced-this-tick dedup set lived inside `_drain_sync_queue`, so the sweep re-synced any account the drain had just handled. Observed in trace `019dd8f4d2dcab5476bfa552d7d70859`: `outbound@lab5.ca` got two `sync.account.run` spans (678 ms + 700 ms) in a single iteration.
- Hoist the `synced: set[str]` tracker into `_run_periodic_iteration` and thread it through both helpers. `_sync_all_accounts` now skips accounts already in `synced` (checked against `summary.email` before the per-account `get_account` round-trip) and adds successful sweep syncs to it. The safety-net guarantee still holds -- any account *not* drained from the queue is still swept.
- Add `.pytest_cache/` and `.ruff_cache/` to `.gitignore`.

## Test plan

- [x] New unit test `test_run_periodic_iteration_full_sweep_skips_already_synced` -- queues one account, runs an iteration with `do_full_sweep=True`, asserts `sync_account` is called exactly once per unique account.
- [x] Updated two existing `_drain_sync_queue` direct callers in `tests/test_sync_loop_operator_log.py` for the new `synced` parameter.
- [x] `make check` -- ruff + basedpyright clean, full suite green.
- [ ] Confirm in production Logfire after merge that `sync.loop.iteration` spans with `wakeup_source=event` and `did_full_sweep=true` show only one `sync.account.run` per account.