### PR TITLE
fix(routing): align route_email span labels with smoke-test expectations

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -364,7 +364,7 @@ Match by `SUBJECT_B` (likely with a `Re:` prefix on Gmail's side).
 
 - Email present in outbound account's inbound emails.
 - `is_routed == true`.
-- `workflow_id == null` -- the outbound workflow exists and is active, but it does not own B's thread (no `thread_match`) and outbound workflows do not classify, so the reply correctly lands with `route_method=skipped_no_workflows`.
+- `workflow_id == null` -- the outbound workflow exists and is active, but it does not own B's thread (no `thread_match`) and outbound workflows do not classify, so the reply correctly lands with `route_method=skipped_no_inbound_workflows` (account has active workflows, but none are inbound, so the classifier never runs).
 - **No additional inbound replies.** Re-run `mailpilot email list --account-id <INBOUND_ACCOUNT_ID> --direction outbound --since <TEST_START_B>` and confirm only the single reply from B5 exists. More than one means the inbound agent kept replying despite the terminal `record_enrollment_outcome` call -- record as a defect.
 - **Outbound workflow stayed quiet (concurrent-workflow check).** Re-run `mailpilot email list --account-id <OUTBOUND_ACCOUNT_ID> --direction outbound --since <TEST_START_B>` and confirm zero new outbound sends. Any non-zero count means the still-active outbound workflow reacted to B's traffic -- record as a defect.
 
@@ -396,7 +396,7 @@ If the process does not exit within 10s, send SIGKILL and record this in the rep
 Time window `[TEST_START_B, now]`. Spans to verify:
 
 - `agent.invoke` -- exactly **1** invocation (B5). More than 1 means either the inbound agent re-fired or the outbound workflow reacted to B's traffic.
-- `routing.route_email` -- the inbound-side email (B4) should be `route_method=classified`. The outbound-side reply (B6) should be `route_method=skipped_no_workflows`.
+- `routing.route_email` -- the inbound-side email (B4) should be `route_method=classified`. The outbound-side reply (B6) should be `route_method=skipped_no_inbound_workflows` (the outbound workflow is active but not an inbound classification candidate).
 - `classify_email` -- 1 invocation (B4). Check `result` matches `INBOUND_WORKFLOW_ID`.
 - `running tool` (B5) -- expect `reply_email` and `record_enrollment_outcome`.
 - Any `is_exception=true` or `level=warn` spans -- record them.
@@ -450,7 +450,7 @@ Email summary (Scenario B):
   Operator trigger: <id>  subject: <SUBJECT_B>
   Inbound delivery: <id>  workflow_id: <INBOUND_WORKFLOW_ID> via classified
   Agent reply:      <id>  thread: <inbound thread>
-  Reply round-trip: <id>  skipped_no_workflows (outbound workflow active but does not own B's thread)
+  Reply round-trip: <id>  skipped_no_inbound_workflows (outbound workflow active but not an inbound classification candidate)
 
 Loop sentinels:
   Scenario A: agent.invoke count == 2 (expected 2)

--- a/docs/adr-04-email-routing.md
+++ b/docs/adr-04-email-routing.md
@@ -37,7 +37,9 @@ When an inbound email arrives for an account, route it through a four-step pipel
        v
   3. _try_classify (LLM, inbound active) -----> hit -----> route to workflow
        |
-       | miss
+       | miss (one of two no-match labels):
+       |   - unrouted                       (classifier ran, no candidate matched)
+       |   - skipped_no_inbound_workflows   (no active inbound workflows; LLM never ran)
        v
   4. store as unrouted
        |
@@ -51,9 +53,14 @@ When an inbound email arrives for an account, route it through a four-step pipel
 
 **Step 2 -- RFC 2822 message-id match (`_try_rfc_message_id_match`).** Gmail re-threads on the recipient side: a reply landing on the outbound mailbox can have a fresh `threadId` even though it cites our original send via `In-Reply-To` / `References`. When step 1 returns no match, walk the cited message-ids (parent first via `In-Reply-To`, then ancestors from the whitespace-separated `References`, deduped while preserving order) and look them up against `email.rfc2822_message_id` within the same `account_id`. Scope is intentionally restricted to the inbound email's own account so cross-account collisions on a shared `Message-ID` cannot leak workflow assignments.
 
-**Step 3 -- LLM classification (`_try_classify` -> `mailpilot.agent.classify.classify_email`).** Single-turn Pydantic AI structured-output call. Candidates are limited to **active inbound** workflows (`list_workflows(account_id, status="active")` filtered by `type == "inbound"`); paused, draft, and outbound workflows are excluded. This means a new email about a paused workflow's topic will go unrouted -- intentional, since paused workflows only handle existing threads, not new conversations. The classifier is also skipped when there are no candidates (returns None without calling the LLM) and when the model returns a `workflow_id` that is not in the candidate set (also coerced to None).
+**Step 3 -- LLM classification (`_try_classify` -> `mailpilot.agent.classify.classify_email`).** Single-turn Pydantic AI structured-output call. Candidates are limited to **active inbound** workflows (`list_workflows(account_id, status="active")` filtered by `type == "inbound"`); paused, draft, and outbound workflows are excluded. This means a new email about a paused workflow's topic will go unrouted -- intentional, since paused workflows only handle existing threads, not new conversations. When the model returns a `workflow_id` that is not in the candidate set, it is coerced to None.
 
-**Step 4 -- Unrouted.** If classification returns no match, store the email with `workflow_id = NULL` and `is_routed = TRUE`. The email is preserved and can be viewed via `mailpilot email list --account-id ID` and `mailpilot email view ID`.
+`_try_classify` returns `(workflow_id, route_method)` so the `routing.route_email` span can distinguish the two no-match cases:
+
+- `route_method=skipped_no_inbound_workflows` -- account has no active inbound workflows (or none survive hydration); the LLM is never called. Distinct from the sync-layer `skipped_no_workflows` short-circuit, which fires only when the account has zero active workflows of any type. The inbound-only label is what fires on the outbound mailbox when an inbound reply lands while only outbound workflows are active.
+- `route_method=unrouted` -- the LLM ran on real candidates and rejected all of them (returned `None` or returned a hallucinated workflow_id that was coerced to None). This is the genuine "classifier could not place this email" signal worth investigating in production.
+
+**Step 4 -- Unrouted.** If classification returns no match (either label above), store the email with `workflow_id = NULL` and `is_routed = TRUE`. The email is preserved and can be viewed via `mailpilot email list --account-id ID` and `mailpilot email view ID`.
 
 ### Pre-routing skips (sync layer)
 

--- a/docs/email-flow.md
+++ b/docs/email-flow.md
@@ -72,8 +72,8 @@ Determine which workflow handles this email. Idempotent: rows with `is_routed = 
 - **Bounce check first**: `_is_bounce` (sender local part `mailer-daemon`/`postmaster`, or any Gmail label containing `BOUNCE`). On hit, `_handle_bounce` marks the original outbound email `status = 'bounced'`, disables the original recipient (`contact.status = 'bounced'`), and stops here.
 - **Step 1 -- Thread match** (`_try_thread_match`): if a prior email in the same `gmail_thread_id` (same account, different row) has a non-null `workflow_id`, use the most recent such workflow. Status-agnostic (active or paused) for the no-ghosting guarantee.
 - **Step 2 -- RFC 2822 message-id match** (`_try_rfc_message_id_match`): if no thread match, walk the inbound email's `In-Reply-To` and `References` headers and look them up against `email.rfc2822_message_id` within the same account. Closes the recipient-side re-threading gap (Gmail can assign a fresh `threadId` even when the message cites our original `Message-ID`).
-- **Step 3 -- LLM classification** (`_try_classify` -> `agent.classify.classify_email`): single-turn structured-output call against active **inbound** workflows for the account (paused, draft, and outbound workflows are excluded).
-- **Step 4 -- Unrouted**: store with `workflow_id = NULL`, `is_routed = TRUE`.
+- **Step 3 -- LLM classification** (`_try_classify` -> `agent.classify.classify_email`): single-turn structured-output call against active **inbound** workflows for the account (paused, draft, and outbound workflows are excluded). Returns `(workflow_id, route_method)`; the route_method is `classified` on a hit, `unrouted` if the LLM rejected all candidates, or `skipped_no_inbound_workflows` if the account had no inbound candidates and the LLM was never called.
+- **Step 4 -- Unrouted**: store with `workflow_id = NULL`, `is_routed = TRUE` (covers both the `unrouted` and `skipped_no_inbound_workflows` route_methods).
 
 On a successful match, `_ensure_enrollment` creates the `(workflow_id, contact_id)` enrollment row if missing (`ON CONFLICT DO NOTHING`) and emits an `enrollment_added` activity once. See ADR-04 for the full pipeline contract.
 

--- a/src/mailpilot/routing.py
+++ b/src/mailpilot/routing.py
@@ -8,7 +8,15 @@ Pipeline that assigns inbound emails to the correct workflow:
    re-threading, where the same conversation has different ``threadId`` on
    each side)
 3. **LLM classification** -- single-turn call against active inbound workflows
-4. **Unrouted** -- store with is_routed=True, workflow_id=NULL
+4. **Unrouted** -- classifier ran on real candidates and rejected all of them
+5. **Skipped, no inbound workflows** -- account has zero active inbound
+   workflows; classifier never runs (distinct from the sync-layer
+   ``skipped_no_workflows`` short-circuit, which fires when the account has
+   zero active workflows of any type)
+
+Cases 4 and 5 both store with is_routed=True, workflow_id=NULL but emit
+distinct ``route_method`` values so operators can tell intentional structural
+gaps apart from genuine classifier misses.
 
 Also handles bounce detection (mailer-daemon/postmaster senders and
 bounce-related Gmail labels) and creates ``enrollment`` entries
@@ -93,16 +101,10 @@ def route_email(
                 if workflow_id is not None:
                     route_method = "rfc_message_id_match"
                 else:
-                    workflow_id = _try_classify(
+                    workflow_id, route_method = _try_classify(
                         connection, email, sender_email, settings
                     )
-                    route_method = (
-                        "classified" if workflow_id is not None else "unrouted"
-                    )
-            span.set_attribute(
-                "result",
-                route_method if workflow_id is not None else "unrouted",
-            )
+            span.set_attribute("result", route_method)
             span.set_attribute("route_method", route_method)
             if workflow_id is not None:
                 span.set_attribute("workflow_id", workflow_id)
@@ -289,12 +291,20 @@ def _try_classify(
     email: Email,
     sender_email: str,
     settings: Settings,
-) -> str | None:
-    """Step 2: LLM classification against active inbound workflows."""
+) -> tuple[str | None, str]:
+    """Step 3: LLM classification against active inbound workflows.
+
+    Returns ``(workflow_id, route_method)`` where ``route_method`` is:
+
+    - ``"classified"`` -- classifier ran and returned a workflow_id.
+    - ``"unrouted"`` -- classifier ran on real candidates and returned None.
+    - ``"skipped_no_inbound_workflows"`` -- account has no active inbound
+      workflows (or none survive hydration); classifier was not called.
+    """
     summaries = list_workflows(connection, account_id=email.account_id, status="active")
     inbound_summaries = [s for s in summaries if s.type == "inbound"]
     if not inbound_summaries:
-        return None
+        return (None, "skipped_no_inbound_workflows")
     # classify_email reads workflow.objective, which is not in WorkflowSummary;
     # hydrate via get_workflow so the LLM prompt has the full record.
     inbound_workflows = [
@@ -303,14 +313,15 @@ def _try_classify(
         if full is not None
     ]
     if not inbound_workflows:
-        return None
-    return classify_email(
+        return (None, "skipped_no_inbound_workflows")
+    workflow_id = classify_email(
         subject=email.subject,
         body=email.body_text,
         sender=sender_email,
         active_workflows=inbound_workflows,
         settings=settings,
     )
+    return (workflow_id, "classified" if workflow_id is not None else "unrouted")
 
 
 def _ensure_enrollment(

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -782,14 +782,65 @@ def test_route_email_span_has_route_method_unrouted(
     capfire: CaptureLogfire,
     database_connection: psycopg.Connection[dict[str, Any]],
 ) -> None:
-    """routing.route_email span must set route_method='unrouted'."""
+    """routing.route_email span must set route_method='unrouted' when the
+    classifier ran on real candidates and rejected them all."""
     account = make_test_account(database_connection, email="rmur@example.com")
+    workflow = make_test_workflow(
+        database_connection, account_id=account.id, workflow_type="inbound"
+    )
+    _activate_workflow(database_connection, workflow.id)
+
+    new_email = create_email(
+        database_connection,
+        account_id=account.id,
+        direction="inbound",
+        subject="Random spam",
+        body_text="You won a prize!",
+        gmail_thread_id="t-rmur",
+    )
+    assert new_email is not None
+
+    settings = make_test_settings(
+        anthropic_api_key="sk-test",
+        anthropic_model="claude-sonnet-4-6",
+    )
+    model = _function_model_returning(workflow_id=None, reasoning="no match")
+
+    with classify_module._AGENT.override(model=model):  # pyright: ignore[reportPrivateUsage]
+        route_email(database_connection, new_email, "nobody@example.com", settings)
+
+    spans = _routing_spans(capfire)
+    assert len(spans) == 1
+    assert spans[0]["attributes"]["route_method"] == "unrouted"
+
+
+def test_route_email_span_has_route_method_skipped_no_inbound_workflows(
+    capfire: CaptureLogfire,
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """routing.route_email span must set route_method='skipped_no_inbound_workflows'
+    when the account has only outbound workflows -- classifier never runs."""
+    account = make_test_account(database_connection, email="rmsni@example.com")
+    outbound_wf = make_test_workflow(
+        database_connection,
+        account_id=account.id,
+        name="Outbound only",
+        workflow_type="outbound",
+    )
+    update_workflow(
+        database_connection,
+        outbound_wf.id,
+        objective="Cold outreach",
+        instructions="Send cold emails",
+    )
+    activate_workflow(database_connection, outbound_wf.id)
+
     new_email = create_email(
         database_connection,
         account_id=account.id,
         direction="inbound",
         subject="orphan",
-        gmail_thread_id="t-rmur",
+        gmail_thread_id="t-rmsni",
     )
     assert new_email is not None
 
@@ -799,7 +850,8 @@ def test_route_email_span_has_route_method_unrouted(
 
     spans = _routing_spans(capfire)
     assert len(spans) == 1
-    assert spans[0]["attributes"]["route_method"] == "unrouted"
+    assert spans[0]["attributes"]["route_method"] == "skipped_no_inbound_workflows"
+    assert "workflow_id" not in spans[0]["attributes"]
 
 
 # -- RFC 2822 In-Reply-To fallback (Defect 2) ---------------------------------


### PR DESCRIPTION
Resolves #103.

## Summary

The `routing.route_email` span previously used `route_method=unrouted` for two structurally distinct cases:

1. **Account has active inbound workflows; classifier ran and rejected all candidates.** The case worth investigating in production.
2. **Account has no active inbound workflows; classifier never ran.** Structurally impossible to route (e.g. the smoke-test B6 round-trip on the outbound mailbox while only an outbound workflow is active).

This PR splits the overloaded label so each routing decision has its own value:

- `unrouted` -- case 1 only (genuine classifier miss).
- `skipped_no_inbound_workflows` -- case 2, slotting into the existing `skipped_*` family from `sync.py` (`skipped_outside_window`, `skipped_no_workflows`, `skipped_predates_workflows`).

## Implementation

- `src/mailpilot/routing.py`: `_try_classify` now returns `tuple[str | None, str]` so the route_method decision lives with the classifier that owns it. `route_email` destructures the tuple and the `result` span attribute is simplified to mirror `route_method`. Module docstring expanded to document the five-way outcome.
- `tests/test_routing.py`: existing `test_route_email_span_has_route_method_unrouted` rewritten to use a real inbound workflow with a mocked classifier returning `None` (genuine "rejected all candidates" path); new `test_route_email_span_has_route_method_skipped_no_inbound_workflows` covers the outbound-only scenario from smoke-test Gate B6.
- `docs/adr-04-email-routing.md`, `docs/email-flow.md`: pipeline diagram and step descriptions now document both no-match labels and contrast `skipped_no_inbound_workflows` (routing-layer, inbound classification structurally impossible) against `skipped_no_workflows` (sync-layer short-circuit, account has zero workflows of any type).
- `.claude/skills/smoke-test/SKILL.md`: Gate B6 expectation updated in three places (instruction text, Logfire review bullet, sample report email line).

`_VIA_BY_ROUTE_METHOD` did not need a new entry -- the new label is a no-match path and that map is only consulted on matched routes.

## Test plan

- [x] `make check` clean (ruff format, ruff lint, basedpyright, 669 tests pass)
- [x] Targeted span tests: `uv run pytest tests/test_routing.py -k route_method -v` (4 passed)
- [x] End-to-end via `/smoke-test`: Logfire `routing.route_email` query for B6 round-trip email returns `route_method=skipped_no_inbound_workflows`; smoke-test report has no label-drift footnote.