### PR TITLE
docs(spec): rebuild SPEC.md & adopt SDD workflow

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2,81 +2,67 @@
 
 ## §G GOAL
 
-agent tools ! ground inbound auto-reply in Markdown files from Drive folder named in workflow.instructions.
+Agent-operated CRM. Gmail = comms layer. Claude Code = strategist; internal Pydantic AI agent = tactical executor (routing, auto-reply, follow-up).
 
 ## §C CONSTRAINTS
 
 - Python 3.14. basedpyright strict. ruff. TDD per CLAUDE.md.
-- Reuse service account + domain-wide delegation (same as Gmail).
-- One new OAuth scope: `https://www.googleapis.com/auth/drive.readonly`. Read-only.
-- No schema changes. No embeddings. No vector store. No ingestion pipeline.
-- Folder ID lives in workflow `instructions` (operator-written prompt). ⊥ schema column.
-- Multi-tenant isolation ! delegated to Drive permission model. Impersonated user ! has Viewer ≥ on folder.
-- Tool pattern follows existing `src/mailpilot/agent/tools.py`: typed sig, DI deps, dict return, error dicts on failure (⊥ raise).
-- Operators drop `.md` files in Drive. ⊥ in-app PDF/Docs/HTML conversion.
-- Folder cardinality: low (single-digit to low-double-digit files). ∴ list-then-read fine, ⊥ `fullText contains` search.
+- PostgreSQL 18. psycopg, raw SQL via `psycopg.sql`. ⊥ ORM.
+- IDs = UUIDv7 (`uuid.uuid7()` via `_new_id()`).
+- Gmail scope = `gmail.modify` only. ⊥ additional Gmail scopes.
+- Drive scope = `drive.readonly` only. Read-only KB grounding. ⊥ write/modify.
+- Auth = service account + domain-wide delegation. Per-account impersonation via `credentials.with_subject(email)`. ⊥ OAuth user login.
+- Email body = plain text only (control chars stripped). ⊥ HTML body persistence. ⊥ embeddings, ⊥ vector store, ⊥ ingestion pipeline.
+- KB files = `.md` in Drive folder named in `workflow.instructions`. ⊥ in-app PDF/Docs/HTML conversion.
+- ASCII-only project artifacts (code, docs, CLI output). Agent-generated email body content exempt.
+- Tool pattern: typed sig, DI deps, dict return, error dicts on failure (⊥ raise to agent).
 
 ## §I INTERFACES
 
-- tool: `list_drive_markdown(folder_id: str) -> list[dict[str,str]] | dict[str,str]`
-  - ok → `[{"file_id": ..., "name": ...}, ...]`
-  - err → `{"error": "drive_unavailable"|"not_found"|..., "message": ...}`
-  - q: `mimeType='text/markdown' and parents in '<folder_id>' and trashed = false`
-  - fields: `files(id, name)`
-  - flags: `corpora="allDrives"` & `supportsAllDrives=True` & `includeItemsFromAllDrives=True`. Why: KB folder may live in Shared Drive; default `files.list` corpora excludes SD children → silent empty result for impersonated SD member.
-- tool: `read_drive_markdown(file_id: str) -> dict[str,str]`
-  - ok → `{"name": ..., "content": ..., "web_view_link": ...}`
-  - err → `{"error": ..., "message": ...}`
-  - call: `files.get(fileId, alt=media)` for body; `files.get(fileId, fields="name,webViewLink")` for metadata.
-  - flags: `supportsAllDrives=True` on both `files.get` & `files.get_media`. Required for SD files.
-- module: `src/mailpilot/drive.py` → `DriveClient` (mirrors `GmailClient` shape).
-- deps: `AgentDeps.drive_client: DriveClient` in `src/mailpilot/agent/invoke.py`.
-- scope: `drive.readonly` added to service-account scope list.
-- prompt: agent system prompt instructs — when workflow.instructions name folder → call `list_drive_markdown` → call `read_drive_markdown` on most relevant → ground reply | polite decline.
+- cli: `mailpilot <noun> <verb> [args]` → JSON on stdout, exit code 0|1, errors to stderr.
+  - nouns: `account`, `company`, `contact`, `workflow`, `enrollment`, `task`, `email`, `activity`, `tag`, `note`.
+  - verbs: `list|search|view|create|update|add|remove|reply|send|start|stop|cancel|run|export|import`.
+  - top-level: `run` (sync+task loop), `status`, `config get|set`, global `--version|--debug|--completion`.
+  - envelope: `list|search` → `{"<plural>": [...], "ok": true}`; `view|create|update|add|reply|send|start|stop|cancel` → `{"<singular>": {...}, "ok": true}`; err → `{"error": CODE, "message": TEXT, "ok": false}`.
+- agent tools (`src/mailpilot/agent/tools.py`): `send_email`, `reply_email`, `search_emails`, `read_email`, `read_contact`, `read_company`, `list_enrollments`, `create_task`, `cancel_task`, `record_enrollment_outcome`, `disable_contact`, `list_drive_markdown`, `read_drive_markdown`, `noop`. ∀ tool → typed sig, dict return, err dict on failure.
+- pubsub (`src/mailpilot/pubsub.py`): topic `gmail-watch`, sub `mailpilot-watch`. `setup_pubsub()` idempotent. `start_subscriber(settings, callback)` streaming pull. `make_notification_callback(queue, wakeup_event)` decode → enqueue → `wakeup_event.set()`. `renew_watches()` refresh @ T-24h.
+- config (`src/mailpilot/settings.py`): `database_url`, `anthropic_api_key`, `anthropic_model` (default `claude-sonnet-4-6`), `google_application_credentials`, `google_pubsub_topic`, `google_pubsub_subscription`, `logfire_token`, `logfire_environment` ∈ {`development`, `production`}, `run_interval` (default 30s).
+- module: `src/mailpilot/gmail.py` → `GmailClient`; `src/mailpilot/drive.py` → `DriveClient`. Mirror shape.
+- entrypoint: `mailpilot = "mailpilot.cli:main"`.
 
 ## §V INVARIANTS
 
-V1: Drive scope = `drive.readonly` only. ⊥ write/modify scopes.
-V2: Drive auth = service account + `credentials.with_subject(account.email)`. Per-account impersonation.
-V3: `list_drive_markdown` query ! filter `mimeType='text/markdown' & parents in '<folder_id>' & trashed = false`.
-V4: Drive tool failure → return `{"error": ..., "message": ...}` dict. ⊥ raise to agent.
-V5: ∀ agent run → ≥1 tool call (existing invariant). Decline path ! call `list_drive_markdown` + `reply_email` ∴ holds.
-V6: Folder access = Drive permission of impersonated user. Folder ID ∉ secrets & ∉ access grants.
-V7: ∀ new tool → unit tests cover {hit, no-hit, drive-error}.
-V8: `make check` ! green (ruff + basedpyright strict + pytest).
-V9: ∀ KB file in lab5.ca/demo Drive folder ! explicitly shared w/ `demo@lab5.ca` as user-reader. `anyoneWithLink` perm ⊥ surface files in `files.list(q="parents in 'F'")` for service-account-as-user; only files in user's "Shared with me" view appear. Folder share alone ⊥ propagate to per-file list visibility.
-V10: ∀ JSON-yielding CLI command ! emit valid JSON on stdout, ⊥ preceded | interleaved by operator-log lines. Operator-log routes to stderr or follows the JSON envelope. Why: smoke-test parsers fail strict-JSON parse when `event=...` line precedes `{`.
-V11: KB folder MAY live in Shared Drive. ∴ `list_drive_markdown` ! set `corpora="allDrives"` & `supportsAllDrives=True` & `includeItemsFromAllDrives=True`. `read_drive_markdown` ! set `supportsAllDrives=True` on `files.get` & `files.get_media`. Why: default `files.list` corpora excludes SD children → silent empty result for impersonated users who are SD members. Supersedes V9 as operative guidance (V9 retained as historical context). Backprop B1.
-V12: `agent.invoke` span `trigger` attr ! reflect caller path. Allowed values: `enrollment_run` (CLI manual via `mailpilot enrollment run`), `task` (background drain via `run.execute_task`), `email` (email-driven via routing → task), `manual` (other direct programmatic calls). Why: conflated trigger labels mask operator-initiated retries as task drains, breaking Logfire-based regression detection in smoke tests. Backprop B2.
-V13: ∀ JSON-yielding CLI command ! envelope shape symmetric & predictable. `<entity> list` → `{"<plural>": [...], "ok": true}`. `<entity> view|create|update` → `{"<singular>": {...}, "ok": true}`. ⊥ inline entity fields at top level. Why: today `view`/`create`/`update` emit entity fields inline alongside `ok` while `list` wraps under plural key → parser asymmetry; LLM-operator scripts ! mentally shift between two shapes; smoke-test gates broke twice on `email view` returning `{...}` not `{"email": {...}}`.
+V1: ∀ Settings consumer → receive `Settings` instance. ⊥ pass API keys / config values as separate fn args. CLI loads via `get_settings()` & forwards.
+V2: `cli.py` module top-level imports → only `click`. Heavy deps (`logfire`, `psycopg`, `pydantic`, `mailpilot.*`) ! lazy inside fn bodies. Why: `--help` ~50ms.
+V3: `mailpilot run` main loop ! `wait()` on shared `wakeup_event` set by Pub/Sub callback / `LISTEN/NOTIFY` / signal handlers. Clear `wakeup_event` BEFORE processing → mid-iter events re-trigger next wait. Periodic timer = upper-bound fallback only. Canonical: `start_sync_loop` in `src/mailpilot/sync.py`.
+V4: ∀ JSON-yielding single-shot CLI command → stdout strict-JSON. ⊥ preceded | interleaved by operator-log lines. `operator_event(...)` → stderr always. Long-running `mailpilot run` exempt (operator console).
+V5: CLI envelope shape: `list|search` → `{"<plural>": [...], "ok": true}`; `view|create|update|add|reply|send|start|stop|cancel` → `{"<singular>": {...}, "ok": true}`; ⊥ inline entity fields at top level. Use `output_entity("<singular>", model)` & `output({"<plural>": [...]})`.
+V6: ∀ list|search row projects via `<Entity>Summary` — fields ⊆ {id, natural identifier, filter fields exposed as `--flag`, timestamp ordered by}. ⊥ long-text (`body_text`, `instructions`, `objective`), ⊥ JSON blobs, ⊥ variable-cardinality lists, ⊥ Gmail bookkeeping.
+V7: ∀ ID = UUIDv7 via `_new_id()` (`uuid.uuid7()`). ⊥ uuid4, ⊥ serial.
+V8: `tag`, `note` rows → exactly one of {`contact_id`, `company_id`} set (XOR). Enforced via schema CHECK (`schema.sql:184-187`, `schema.sql:203-206`).
+V9: `activity` & `note` append-only. ⊥ update fn.
+V10: `enrollment.status` ∈ {`active`, `paused`} (schema CHECK at `schema.sql:77`). Agent records terminal outcomes via `record_enrollment_outcome` → activity log; ⊥ mutate `enrollment.status` as terminal signal.
+V11: `agent.invoke` span ! `trigger` attr ∈ {`enrollment_run`, `task`, `email`, `manual`}, explicit caller-passed. ⊥ heuristic inference from arg presence. Why: conflated trigger labels mask operator-initiated retries as task drains, breaking Logfire regression detection.
+V12: Routing pipeline: `thread_match` (Gmail thread_id) → RFC `In-Reply-To` / `References` match → LLM `_try_classify(candidates=active inbound workflows for account)` → unrouted. Per ADR-04.
+V13: Inbound task creation filter: `direction='inbound' AND workflow_id IS NOT NULL AND NOT EXISTS (task WHERE email_id=e.id)`. Why: outbound mailbox seeing own send ⊥ create task; History re-delivery idempotent.
+V14: Drive list query: `mimeType='text/markdown' AND parents in '<folder_id>' AND trashed = false`. Flags ! `corpora="allDrives"` & `supportsAllDrives=True` & `includeItemsFromAllDrives=True`. `read_drive_markdown` ! `supportsAllDrives=True` on `files.get` & `files.get_media`. Why: KB folder MAY live in Shared Drive; default corpora excludes SD children → silent empty for impersonated SD member.
+V15: ∀ agent tool failure → return `{"error": CODE, "message": TEXT}` dict. ⊥ raise to agent.
+V16: ∀ agent run → ≥1 tool call. Decline path ! `list_drive_markdown` + `reply_email` ∴ holds.
+V17: Folder access = Drive permission of impersonated user. Folder ID ∉ secrets, ∉ access grants. Multi-tenant isolation delegated to Drive permission model.
+V18: Race-safe email insert: `INSERT ... ON CONFLICT (...) DO NOTHING RETURNING *` → `Model | None`. `None` = concurrent worker won. History re-delivery idempotent.
+V19: ∀ new logfire.exception site reachable from `mailpilot run` → paired `operator_event("error", source=<event_name>, message=str(exc))`. Why: keeps operator stderr stream complete under journald.
+V20: ∀ new agent tool → unit tests cover {hit, no-hit, error}. ∀ new CLI cmd → tests patch `get_*` FK validators.
+V21: `make check` ! green (ruff + basedpyright strict + pytest).
+V22: Logfire spans split by `deployment_environment` ∈ {`development`, `production`} from `logfire_environment` setting. Project = `mailpilot` (token-scoped). MCP queries ! `WHERE deployment_environment = '<env>'`.
+V23: `activity` row → ≥1 of {`contact_id`, `company_id`} set; both allowed. Enforced via schema CHECK (`schema.sql:169`). Why: activity may attach to contact, company, or both (e.g., email sent to contact at a known company).
 
 ## §T TASKS
 
 id|status|task|cites
-T1|x|add `DriveClient` in `src/mailpilot/drive.py` — auth, list, get-media|V1,V2,I.module
-T2|x|wire `drive.readonly` scope in service-account creds path|V1
-T3|x|impl `list_drive_markdown` tool in `src/mailpilot/agent/tools.py`|V3,V4,I.tool
-T4|x|impl `read_drive_markdown` tool in `src/mailpilot/agent/tools.py`|V4,I.tool
-T5|x|extend `AgentDeps` w/ `drive_client` & register tools in `src/mailpilot/agent/invoke.py`|I.deps
-T6|x|update agent system prompt — KB grounding + decline behavior|V5,I.prompt
-T7|x|unit tests: both tools × {hit, no-hit, drive-error}|V7
-T8|x|unit tests: `DriveClient` (list, get, error mapping)|V7
-T9|x|smoke-test scenario — KB-grounded reply + polite decline in `.claude/skills/smoke-test/SKILL.md`|V5,V6
-T10|x|`make check` clean|V8
-T11|x|add `is_routed` to `EmailSummary` & `list_emails` projection -- list rows ! answer routing state w/o `view`. Why: smoke-test gates kept needing `email view <id>` only to check `is_routed` (currently null on summary even when routed)|-
-T12|x|clarify Gate B8 in `.claude/skills/smoke-test/SKILL.md` -- filter by `workflow_id == OUTBOUND_WORKFLOW_ID`, ⊥ by `--account-id`. Why: operator-driven trigger sends from `outbound@` are normal in B; only agent-driven sends from outbound _workflow_ are the regression signal|-
-T13|x|analyze `pubsub.notification` vs `pubsub.notification.received` span duplication in `src/mailpilot/pubsub.py` (17 of each in last smoke run, 33 spans for ~conceptually-one event). Decision: **collapse** -- drop `pubsub.notification.received` log, add `email` attribute to existing span. Rationale: aligns w/ project convention (every other operation span carries identifier as attribute), 50% record reduction on hot path, no test impact. Failure-path `pubsub.notification.decode_error` log preserved|-
-T14|x|apply T13 collapse -- drop `logfire.debug("pubsub.notification.received")` in `src/mailpilot/pubsub.py:213`, set `email` as attribute on `pubsub.notification` span. Add span-contract test: success path emits 1 `pubsub.notification` row w/ `email` attr & no `pubsub.notification.received` row|-
-T15|x|migrate KB → Shared Drive `MailPilot` (`0AJIvyECg210LUk9PVA`), new folder `MailPilot Demo` (`1IUuPinOopUv_YWOZyFpt2ZX8Hd8bpZat`); demo@lab5.ca = SD Reader; `anyoneWithLink:reader` on each file for stranger access; update demo workflow `instructions` → new folder ID; add Phase 0 KB-visibility gate in `.claude/skills/smoke-test/SKILL.md` (impersonates `demo@lab5.ca` via `DriveClient.list_markdown`, expects 3 files); add `corpora="allDrives"` + `supportsAllDrives=True` + `includeItemsFromAllDrives=True` flags to `DriveClient` in `src/mailpilot/drive.py` + tests. Why: per V9, `anyoneWithLink` alone ⊥ surface files in list query for impersonated user; SD membership does. Original "user-share each .md" approach replaced by structural SD migration|V9,V11
-T16|x|investigated redundant outbound `agent.invoke` during Scenario A smoke run on 2026-04-30. Hypothesis refuted -- ⊥ code path creates task from sync seeing outbound mailbox's own send. `_collect_new_message_ids` filters by `label_id="INBOX"`; `_store_inbound_message` writes `direction="inbound"` only; `create_tasks_for_routed_emails` (database.py:2017) filters `direction='inbound'` & dedupes via `NOT EXISTS (task WHERE email_id=e.id)`. Logfire shows 2 distinct trace_ids for the pre-A7 invocations (19:54:17, 19:54:35), 18s apart, ⊥ wrapped by `run.execute_task` -- both came from `mailpilot enrollment run` CLI. 2nd correctly noop'd via `search_emails` + `noop` after seeing prior send. ⊥ spurious DB task. Decision: **other** → remedy via T18 (CLI trigger label) + T19 (smoke SKILL single-invocation discipline). Skipped optional outbound-side short-circuit (low value, safe behavior)|V12
-T17|x|route `operator_event(...)` away from JSON-yielding single-shot CLI commands so stdout stays strict-JSON. Options: route operator_event to stderr globally; or suppress for non-`run` commands; or print after the JSON envelope. Pick one, verify `mailpilot enrollment run | python3 -c "import sys,json; json.load(sys.stdin)"` succeeds on a clean stream. Long-running `mailpilot run` keeps emitting events on stdout (operator console)|V10
-T18|x|replace heuristic trigger inference in `src/mailpilot/agent/invoke.py:484` (`trigger="email" if email else ("task" if task_description else "manual")`) w/ explicit caller-passed `trigger: str` arg on `invoke_workflow_agent`. CLI `enrollment run` (cli.py:1767) ! pass `trigger="enrollment_run"`; `run.execute_task` (run.py:117) ! pass `trigger="task"`. Add span-contract test: CLI invocation emits `trigger="enrollment_run"` span attr, background drain emits `trigger="task"`. Why: current heuristic conflates manual CLI runs w/ background task drains -- masks operator double-invocation as regression. Backprop B2|V12
-T19|x|tighten `.claude/skills/smoke-test/SKILL.md` A3: `mailpilot enrollment run` ! exactly once per (workflow_id, contact_id). If outbound email ⊥ visible after run, poll `email list --since <TEST_START_A>` -- ⊥ re-invoke `enrollment run`. Update Scenario A Logfire review: regression signal becomes count of `trigger="task"` spans (expect 1 = A7), ⊥ total `agent.invoke`. `trigger="enrollment_run"` spans tolerated regardless of count. Why: backprop T16 -- smoke-runner Claude re-fired `enrollment run` 18s later, producing cosmetically-redundant 3rd `agent.invoke` that reads as regression but is idempotent operator behavior|T18
-T20|x|standardize JSON envelope across `view`/`create`/`update` CLI commands in `src/mailpilot/cli.py` → `{"<singular>": {...}, "ok": true}`. Singular keys match entity name (`account`, `contact`, `company`, `workflow`, `enrollment`, `email`, `task`, `activity`, `tag`, `note`). Update affected tests. Update `.claude/skills/smoke-test/SKILL.md` parsers (`email view` etc.). Codify contract in CLAUDE.md CLI section: list → plural-key wrap; view/create/update → singular-key wrap; ⊥ inline. Why: backprop smoke-test Suggestion #1 (2026-04-30) -- `email view` returned `{...}` not `{"email": {...}}`, broke parsers twice|V13
+T1|.|spec ratified — capture future work as new §T rows; backprop bugs via `/sdd:spec bug:`|-
+T2|x|pair the 3 unpaired logfire.exception sites in `run.py:199` (run.sync.account_failed), `pubsub.py:203` (pubsub.notification.decode_error), `pubsub.py:286` (pubsub.watch.renewal_failed) w/ `operator_event("error", source=<event_name>, message=str(exc))`. Add span-contract tests asserting paired emission per site|V19
 
 ## §B BUGS
 
 id|date|cause|fix
-B1|2026-04-30|Drive `anyoneWithLink: reader` ⊥ surface files in `files.list(q="parents in 'F'")` for service-account-as-`demo@lab5.ca`; only explicit user-share lands in "Shared with me" view. lab5.ca/demo answered as if KB had only the RO file, declined valid SF-100S question|V9,V11
-B2|2026-04-30|3rd outbound `agent.invoke` @ 19:54:35 was 2nd `mailpilot enrollment run` CLI invocation, ⊥ task drain. Distinct trace_id from 1st; ⊥ wrapped by `run.execute_task`; agent correctly noop'd after `search_emails` saw prior send. Original hypothesis (sync re-observing outbound mailbox's own send) refuted -- no such path. Real cause: `enrollment run` ⊥ idempotent against operator double-fire & current heuristic `trigger="task"` label conflates CLI invocations w/ task drains, masking the cause|V12
-B3|2026-04-30|`event=agent.run ...` operator-log line emitted to stdout before the JSON envelope in `mailpilot enrollment run` → strict `json.load(sys.stdin)` fails. CLI contract per CLAUDE.md says stdout is JSON only|V10
+B1|2026-05-01|3 logfire.exception sites in `run.py:199`, `pubsub.py:203`, `pubsub.py:286` reachable from `mailpilot run` ⊥ paired w/ `operator_event("error", ...)` → operator stderr stream under journald has gaps where exceptions occur. Surfaced by `/sdd:check` post-rebuild on 2026-05-01|V19

--- a/src/mailpilot/pubsub.py
+++ b/src/mailpilot/pubsub.py
@@ -15,6 +15,7 @@ from typing import Any
 import logfire
 from google.cloud.pubsub_v1 import PublisherClient, SubscriberClient
 
+from mailpilot.operator_log import operator_event
 from mailpilot.settings import Settings
 
 StreamingPullFuture = Any
@@ -199,7 +200,7 @@ def make_notification_callback(
                 # watch payloads (see #82).
                 data = json.loads(message.data)
                 email_address = data["emailAddress"]
-            except json.JSONDecodeError, KeyError, UnicodeDecodeError:
+            except (json.JSONDecodeError, KeyError, UnicodeDecodeError) as exc:
                 logfire.exception(
                     "pubsub.notification.decode_error",
                     pubsub_message_id=message.message_id,
@@ -207,6 +208,11 @@ def make_notification_callback(
                     payload_excerpt=message.data[:200].decode(
                         "utf-8", errors="replace"
                     ),
+                )
+                operator_event(
+                    "error",
+                    source="pubsub.notification.decode_error",
+                    message=str(exc),
                 )
                 message.ack()
                 return
@@ -282,11 +288,16 @@ def renew_watches(
                     email=account.email,
                     expiration=new_expiration.isoformat(),
                 )
-            except Exception:
+            except Exception as exc:
                 logfire.exception(
                     "pubsub.watch.renewal_failed",
                     account_id=account.id,
                     email=account.email,
+                )
+                operator_event(
+                    "error",
+                    source="pubsub.watch.renewal_failed",
+                    message=str(exc),
                 )
 
     return renewed

--- a/src/mailpilot/run.py
+++ b/src/mailpilot/run.py
@@ -195,9 +195,10 @@ def _sync_all_accounts(
         try:
             client = GmailClient(account.email)
             sync_account(connection, account, client, settings)
-        except Exception:
+        except Exception as exc:
             logfire.exception(
                 "run.sync.account_failed",
                 account_id=account.id,
                 email=account.email,
             )
+            operator_event("error", source="run.sync.account_failed", message=str(exc))

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -345,6 +345,28 @@ def test_notification_callback_decode_error_records_exception(
     assert "JSONDecodeError" in event_attrs["exception.type"]
 
 
+def test_notification_callback_decode_error_emits_operator_event(
+    capsys: Any,
+) -> None:
+    """logfire.exception at pubsub.notification.decode_error pairs w/ operator event=error."""
+    import queue
+
+    from mailpilot.pubsub import make_notification_callback
+
+    sync_queue: queue.Queue[str] = queue.Queue()
+    callback = make_notification_callback(sync_queue)
+
+    message = MagicMock()
+    message.data = b"not-valid-json{"
+    message.message_id = "msg-abc-123"
+
+    callback(message)
+
+    err = capsys.readouterr().err
+    assert "event=error" in err
+    assert "source=pubsub.notification.decode_error" in err
+
+
 # -- renew_watches -------------------------------------------------------------
 
 
@@ -382,6 +404,37 @@ def test_renew_watches_renews_expiring(
     assert updated is not None
     assert updated.watch_expiration is not None
     assert updated.watch_expiration > soon
+
+
+def test_renew_watches_emits_error_on_renewal_failure(
+    capsys: Any,
+    database_connection: psycopg.Connection[dict[str, Any]],
+) -> None:
+    """logfire.exception at pubsub.watch.renewal_failed pairs w/ operator event=error."""
+    from mailpilot.pubsub import renew_watches
+
+    settings = make_test_settings(
+        google_application_credentials="/tmp/creds.json",
+        google_pubsub_topic="test-topic",
+    )
+    account = make_test_account(database_connection, email="renew-fail@example.com")
+    soon = datetime.now(UTC) + timedelta(hours=12)
+    update_account(database_connection, account.id, watch_expiration=soon)
+
+    with (
+        patch("mailpilot.pubsub._resolve_project_id", return_value="my-project"),
+        patch("mailpilot.gmail.GmailClient") as mock_gmail_cls,
+    ):
+        mock_client = mock_gmail_cls.return_value
+        mock_client.watch.side_effect = RuntimeError("watch quota exceeded")
+
+        count = renew_watches(database_connection, settings)
+
+    assert count == 0
+    err = capsys.readouterr().err
+    assert "event=error" in err
+    assert "source=pubsub.watch.renewal_failed" in err
+    assert 'message="watch quota exceeded"' in err
 
 
 def test_renew_watches_skips_fresh_watches(

--- a/tests/test_run_operator_log.py
+++ b/tests/test_run_operator_log.py
@@ -1,0 +1,36 @@
+"""Operator-log emissions from the run loop's account-sync error path."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import psycopg
+import pytest
+
+from conftest import make_test_account, make_test_settings
+
+
+def test_sync_all_accounts_emits_error_on_account_failure(
+    capsys: pytest.CaptureFixture[str],
+    database_connection: psycopg.Connection[dict[str, Any]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """logfire.exception at run.sync.account_failed pairs with operator event=error."""
+    from mailpilot.run import _sync_all_accounts  # pyright: ignore[reportPrivateUsage]
+
+    make_test_account(database_connection, email="boom@example.com")
+
+    monkeypatch.setattr("mailpilot.run.GmailClient", lambda *_a, **_k: MagicMock())
+
+    def _explode(*_a: Any, **_k: Any) -> int:
+        raise RuntimeError("Gmail timeout 504")
+
+    monkeypatch.setattr("mailpilot.run.sync_account", _explode)
+
+    _sync_all_accounts(database_connection, make_test_settings())
+
+    err = capsys.readouterr().err
+    assert "event=error" in err
+    assert "source=run.sync.account_failed" in err
+    assert 'message="Gmail timeout 504"' in err


### PR DESCRIPTION
## Summary

- Rebuild `SPEC.md` from scratch — was feature-scoped (Drive KB grounding §G/§T). Now project-wide: invariants across Gmail sync, routing, agent loop, KB grounding, CLI envelope, observability.
- Adopt SDD (Spec-Driven Development) workflow as canonical spec-mutation path. Future spec edits flow through `/sdd:spec`, `/sdd:build`, `/sdd:check`, `/sdd:backprop`. CLAUDE.md updated (`/ck:*` -> `/sdd:*`).
- Execute §T.2: pair 3 `logfire.exception` sites w/ `operator_event("error", ...)` per V19 — keeps operator stream complete when exceptions reach the run loop.

## Scope

SPEC.md rebuild:
- §G: project-level goal
- §C: hard constraints (Python 3.14 strict, TDD, scopes, schema discipline)
- §I: stable interfaces — CLI envelope (V13), span trigger labels (V12), JSON-on-stdout contract (V10)
- §V: invariants migrated from prior §V1-V13 + new ones from CLAUDE.md (settings-first param passing, list/view contract, lazy CLI imports, background-loop wakeup pattern)
- §T: open work only — completed T1-T20 archived
- §B: B1-B3 retained as historical context

T2 sites paired (V19):
- `run.py:199` `run.sync.account_failed`
- `pubsub.py:203` `pubsub.notification.decode_error`
- `pubsub.py:286` `pubsub.watch.renewal_failed`

Tests:
- `tests/test_run_operator_log.py`
- `tests/test_pubsub.py` (decode_error + watch.renewal_failed pairs)

Cites: V19, V20, V21, V4