### PR TITLE
fix(campaign-test): guard accounts with positional account view

### DIFF
--- a/.claude/skills/mailpilot-campaign-test/SKILL.md
+++ b/.claude/skills/mailpilot-campaign-test/SKILL.md
@@ -152,8 +152,8 @@ Preflight (step 1) fails when `outbound@lab5.ca` or `inbound@lab5.ca` is absent,
 which is the state right after `make clean` wipes them. Create each account only
 if it is missing:
 ```bash
-uv run mailpilot account view --email outbound@lab5.ca >/dev/null 2>&1 || uv run mailpilot account create --email outbound@lab5.ca --display-name "MailPilot Outbound"
-uv run mailpilot account view --email inbound@lab5.ca  >/dev/null 2>&1 || uv run mailpilot account create --email inbound@lab5.ca  --display-name "MailPilot Inbound"
+uv run mailpilot account view outbound@lab5.ca >/dev/null 2>&1 || uv run mailpilot account create --email outbound@lab5.ca --display-name "MailPilot Outbound"
+uv run mailpilot account view inbound@lab5.ca  >/dev/null 2>&1 || uv run mailpilot account create --email inbound@lab5.ca  --display-name "MailPilot Inbound"
 ```
 The `account view` guard makes this idempotent: `account create` errors with
 `duplicate_key` on an existing email, so the create runs only when `view` reports


### PR DESCRIPTION
## What

Step 0b of the mailpilot-campaign-test skill guarded account creation with `mailpilot account view --email <addr>`. The `account view` command has no `--email` option. It takes a positional `ACCOUNT_REF`.

The bad flag made the guard exit 2 on every run, so the `||` fallback always ran `account create`. Each run recorded two `duplicate_key` errors and two `account.create` exception spans in Logfire. The guard would not protect a future non-idempotent create path.

## Change

Both `account view` guards now use the positional form. `account view <addr>` exits 0 for an existing account, so the `||` skips `account create`. The `account create --email ... --display-name ...` half of each line is unchanged; `--email` is correct for `account create`.

## Verification

- `account view --help` lists only `--help`; the positional `ACCOUNT_REF` is confirmed.
- `account view outbound@lab5.ca` exits 0 for an existing account; `account view --email outbound@lab5.ca` exits 2. Confirmed by hand.
- Repo-wide search (hidden directories included) finds the pattern only at the two fixed lines.

Closes #147